### PR TITLE
#357 Rework Binder.manual into Binder.bind

### DIFF
--- a/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/TypeFactoryImpl.java
+++ b/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/TypeFactoryImpl.java
@@ -51,7 +51,7 @@ public class TypeFactoryImpl implements TypeFactory {
             if (property instanceof BindingMetaAttribute bindingMeta) named = bindingMeta.value();
         }
 
-        Exceptional<BoundContext<T, T>> binding = this.applicationContext.firstWire(type, named);
+        Exceptional<BoundContext<T, T>> binding = this.applicationContext.firstWire(Key.of(type, named));
         if (binding.absent()) {
             if (type.isAbstract()) throw new IllegalStateException("Could not autowire " + type.qualifiedName() + " as there is no active binding for it");
             else {

--- a/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/context/HartshornApplicationContext.java
+++ b/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/context/HartshornApplicationContext.java
@@ -377,9 +377,10 @@ public class HartshornApplicationContext extends ManagedHartshornContext {
     @Override
     public <C, T extends C> void bind(final Key<C> contract, final Class<? extends T> implementation) {
         final TypeContext<? extends T> context = TypeContext.of(implementation);
-        if (context.boundConstructors().isEmpty()) {
+        if (context.defaultConstructor().present() || !context.injectConstructors().isEmpty()) {
             this.inHierarchy(contract, hierarchy -> hierarchy.add(Providers.of(context)));
-        } else {
+        }
+        if (!context.boundConstructors().isEmpty()) {
             this.bindings.add(new ConstructorBoundContext<>(contract, context));
         }
     }

--- a/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/context/HartshornApplicationContext.java
+++ b/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/context/HartshornApplicationContext.java
@@ -269,11 +269,12 @@ public class HartshornApplicationContext extends ManagedHartshornContext {
     }
 
     @Override
-    public <T, I extends T> Exceptional<BoundContext<T, I>> firstWire(final TypeContext<T> contract, final Named property) {
+    public <T, I extends T> Exceptional<BoundContext<T, I>> firstWire(final Key<T> key) {
+        final Named named = key.named();
         for (final BoundContext<?, ?> binding : this.bindings) {
-            if (binding.contract().equals(contract)) {
+            if (binding.contract().equals(key.contract())) {
                 if (!"".equals(binding.name())) {
-                    if (property == null || !binding.name().equals(property.value())) continue;
+                    if (named == null || !binding.name().equals(named.value())) continue;
                 }
                 return Exceptional.of((BoundContext<T, I>) binding);
             }

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/ApplicationBinder.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/ApplicationBinder.java
@@ -22,12 +22,9 @@ import org.dockbox.hartshorn.di.InjectConfiguration;
 import org.dockbox.hartshorn.di.Key;
 import org.dockbox.hartshorn.di.binding.BindingHierarchy;
 import org.dockbox.hartshorn.di.context.element.MethodContext;
-import org.dockbox.hartshorn.di.context.element.TypeContext;
 import org.dockbox.hartshorn.di.inject.Binder;
 import org.dockbox.hartshorn.di.inject.ProviderContext;
 import org.dockbox.hartshorn.di.inject.wired.BoundContext;
-
-import javax.inject.Named;
 
 public interface ApplicationBinder extends Binder {
 
@@ -35,7 +32,7 @@ public interface ApplicationBinder extends Binder {
 
     void bind(String prefix);
 
-    <T, I extends T> Exceptional<BoundContext<T, I>> firstWire(TypeContext<T> contract, Named property);
+    <T, I extends T> Exceptional<BoundContext<T, I>> firstWire(Key<T> key);
 
     <T> T populate(T type);
 

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/element/WildcardTypeContext.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/element/WildcardTypeContext.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.di.context.element;
 
 public class WildcardTypeContext extends TypeContext<Void> {

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/inject/Binder.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/inject/Binder.java
@@ -23,12 +23,9 @@ import java.util.function.Supplier;
 
 public interface Binder {
 
-    <C> void provide(Key<C> contract, Supplier<C> supplier);
+    <C> void bind(Key<C> contract, Supplier<C> supplier);
 
     <C, T extends C> void bind(Key<C> key, Class<? extends T> implementation);
 
     <C, T extends C> void bind(Key<C> key, T instance);
-
-    <C, T extends C> void manual(Key<C> key, Class<? extends T> implementation);
-
 }

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/inject/DelegatedBinder.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/inject/DelegatedBinder.java
@@ -24,8 +24,8 @@ import java.util.function.Supplier;
 public interface DelegatedBinder extends Binder {
 
     @Override
-    default <C> void provide(final Key<C> contract, final Supplier<C> supplier) {
-        this.binder().provide(contract, supplier);
+    default <C> void bind(final Key<C> contract, final Supplier<C> supplier) {
+        this.binder().bind(contract, supplier);
     }
 
     Binder binder();
@@ -39,10 +39,4 @@ public interface DelegatedBinder extends Binder {
     default <C, T extends C> void bind(final Key<C> contract, final T instance) {
         this.binder().bind(contract, instance);
     }
-
-    @Override
-    default <C, T extends C> void manual(final Key<C> contract, final Class<? extends T> implementation) {
-        this.binder().manual(contract, implementation);
-    }
-
 }

--- a/hartshorn-di/src/test/java/org/dockbox/hartshorn/di/ApplicationContextTests.java
+++ b/hartshorn-di/src/test/java/org/dockbox/hartshorn/di/ApplicationContextTests.java
@@ -17,8 +17,13 @@
 
 package org.dockbox.hartshorn.di;
 
+import org.dockbox.hartshorn.api.domain.Exceptional;
+import org.dockbox.hartshorn.di.binding.BindingHierarchy;
 import org.dockbox.hartshorn.di.binding.Bindings;
+import org.dockbox.hartshorn.di.binding.ContextDrivenProvider;
+import org.dockbox.hartshorn.di.binding.Provider;
 import org.dockbox.hartshorn.di.context.element.TypeContext;
+import org.dockbox.hartshorn.di.inject.wired.BoundContext;
 import org.dockbox.hartshorn.di.properties.BindingMetaAttribute;
 import org.dockbox.hartshorn.test.ApplicationAwareTest;
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +43,7 @@ import test.types.SampleFieldImplementation;
 import test.types.SampleImplementation;
 import test.types.SampleInterface;
 import test.types.bound.SampleBoundAnnotatedImplementation;
+import test.types.dual.DualConstructableType;
 import test.types.meta.SampleMetaAnnotatedImplementation;
 import test.types.multi.SampleMultiAnnotatedImplementation;
 import test.types.provision.ProvidedInterface;
@@ -327,5 +333,22 @@ public class ApplicationContextTests extends ApplicationAwareTest {
         final ProvidedInterface provided = this.context().get(ProvidedInterface.class, BindingMetaAttribute.of("bound"), TypeFactory.use("BoundProvision"));
         Assertions.assertNotNull(provided);
         Assertions.assertEquals("BoundProvision", provided.name());
+    }
+
+    @Test
+    void testDualConstructableTypeCanBind() {
+        final Key<SampleInterface> key = Key.of(SampleInterface.class);
+        this.context().bind(key, DualConstructableType.class);
+        final BindingHierarchy<SampleInterface> hierarchy = this.context().hierarchy(key);
+
+        Assertions.assertEquals(1, hierarchy.size());
+
+        final Exceptional<Provider<SampleInterface>> provider = hierarchy.get(-1);
+        Assertions.assertTrue(provider.present());
+        Assertions.assertTrue(provider.get() instanceof ContextDrivenProvider);
+        Assertions.assertTrue(((ContextDrivenProvider<SampleInterface>) provider.get()).context().is(DualConstructableType.class));
+
+        final Exceptional<BoundContext<SampleInterface, SampleInterface>> boundContext = this.context().firstWire(key);
+        Assertions.assertTrue(boundContext.present());
     }
 }

--- a/hartshorn-di/src/test/java/org/dockbox/hartshorn/di/ApplicationContextTests.java
+++ b/hartshorn-di/src/test/java/org/dockbox/hartshorn/di/ApplicationContextTests.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import test.types.InvalidSampleBoundType;
 import test.types.PopulatedType;
 import test.types.SampleBoundPopulatedType;
 import test.types.SampleBoundType;
@@ -105,7 +105,7 @@ public class ApplicationContextTests extends ApplicationAwareTest {
 
     @Test
     public void testProviderBindingCanBeProvided() {
-        this.context().provide(Key.of(SampleInterface.class), SampleImplementation::new);
+        this.context().bind(Key.of(SampleInterface.class), (Supplier<SampleInterface>) SampleImplementation::new);
         final SampleInterface provided = this.context().get(SampleInterface.class);
         Assertions.assertNotNull(provided);
 
@@ -117,7 +117,7 @@ public class ApplicationContextTests extends ApplicationAwareTest {
 
     @Test
     public void testProviderBindingWithMetaCanBeProvided() {
-        this.context().provide(Key.of(SampleInterface.class, Bindings.named("demo")), SampleImplementation::new);
+        this.context().bind(Key.of(SampleInterface.class, Bindings.named("demo")), (Supplier<SampleInterface>) SampleImplementation::new);
         final SampleInterface provided = this.context().get(SampleInterface.class, Bindings.named("demo"));
         Assertions.assertNotNull(provided);
 
@@ -222,15 +222,8 @@ public class ApplicationContextTests extends ApplicationAwareTest {
     }
 
     @Test
-    public void invalidBoundTypesCannotBeBound() {
-        Assertions.assertThrows(IllegalArgumentException.class, () ->
-                this.context().manual(Key.of(SampleInterface.class), InvalidSampleBoundType.class)
-        );
-    }
-
-    @Test
     public void boundTypesCanBeProvided() {
-        this.context().manual(Key.of(SampleInterface.class), SampleBoundType.class);
+        this.context().bind(Key.of(SampleInterface.class), SampleBoundType.class);
 
         final SampleInterface wired = this.context().get(TypeFactory.class).create(SampleInterface.class, "BoundHartshorn");
         Assertions.assertNotNull(wired);
@@ -251,8 +244,8 @@ public class ApplicationContextTests extends ApplicationAwareTest {
 
     @Test
     public void boundTypesCanBeProvidedThroughFactoryProperty() {
-        this.context().manual(Key.of(SampleInterface.class), SampleBoundType.class);
-        this.context().manual(Key.of(SampleInterface.class), SampleBoundType.class);
+        this.context().bind(Key.of(SampleInterface.class), SampleBoundType.class);
+        this.context().bind(Key.of(SampleInterface.class), SampleBoundType.class);
 
         final SampleInterface provided = this.context().get(SampleInterface.class, TypeFactory.use("FactoryTyped"));
         Assertions.assertNotNull(provided);
@@ -265,7 +258,7 @@ public class ApplicationContextTests extends ApplicationAwareTest {
 
     @Test
     public void providerRedirectsVarargs() {
-        this.context().manual(Key.of(SampleInterface.class), SampleBoundType.class);
+        this.context().bind(Key.of(SampleInterface.class), SampleBoundType.class);
 
         final SampleInterface provided = this.context().get(SampleInterface.class, "FactoryTyped");
         Assertions.assertNotNull(provided);
@@ -278,7 +271,7 @@ public class ApplicationContextTests extends ApplicationAwareTest {
 
     @Test
     public void varargProvidedTypesArePopulated() {
-        this.context().manual(Key.of(SampleInterface.class), SampleBoundPopulatedType.class);
+        this.context().bind(Key.of(SampleInterface.class), SampleBoundPopulatedType.class);
         this.context().bind(Key.of(SampleField.class), SampleFieldImplementation.class);
 
         final SampleInterface provided = this.context().get(SampleInterface.class, "FactoryTyped");
@@ -290,7 +283,7 @@ public class ApplicationContextTests extends ApplicationAwareTest {
 
     @Test
     public void injectionPointsAreAppliedToVarargProviders() {
-        this.context().manual(Key.of(SampleInterface.class), SampleBoundType.class);
+        this.context().bind(Key.of(SampleInterface.class), SampleBoundType.class);
         this.context().bind(Key.of(SampleField.class), SampleFieldImplementation.class);
 
         final InjectionPoint<SampleInterface> point = InjectionPoint.of(TypeContext.of(SampleInterface.class), $ -> new SampleImplementation());

--- a/hartshorn-di/src/test/java/org/dockbox/hartshorn/di/BindingHierarchyTests.java
+++ b/hartshorn-di/src/test/java/org/dockbox/hartshorn/di/BindingHierarchyTests.java
@@ -101,11 +101,6 @@ public class BindingHierarchyTests extends ApplicationAwareTest {
 
     @Test
     void testContextCreatesHierarchy() {
-        interface LocalContract {
-        }
-        class LocalImpl implements LocalContract {
-        }
-
         this.context().bind(Key.of(LocalContract.class), LocalImpl.class);
 
         final BindingHierarchy<LocalContract> hierarchy = this.context().hierarchy(Key.of(LocalContract.class));
@@ -116,6 +111,11 @@ public class BindingHierarchyTests extends ApplicationAwareTest {
         Assertions.assertTrue(provider.present());
         Assertions.assertTrue(provider.get() instanceof ContextDrivenProvider);
         Assertions.assertEquals(((ContextDrivenProvider<LocalContract>) provider.get()).context().type(), LocalImpl.class);
+    }
+
+    interface LocalContract {
+    }
+    static class LocalImpl implements LocalContract {
     }
 
     private interface Contract {

--- a/hartshorn-di/src/test/java/test/types/dual/DualConstructableType.java
+++ b/hartshorn-di/src/test/java/test/types/dual/DualConstructableType.java
@@ -1,0 +1,24 @@
+package test.types.dual;
+
+import org.dockbox.hartshorn.di.annotations.inject.Bound;
+
+import test.types.SampleInterface;
+
+public class DualConstructableType implements SampleInterface {
+
+    private final String name;
+
+    @Bound
+    public DualConstructableType(final String name) {
+        this.name = name;
+    }
+
+    public DualConstructableType() {
+        this.name = "DefaultConstructor";
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+}

--- a/hartshorn-minecraft/hotbar/src/main/java/org/dockbox/hartshorn/hotbar/HotbarService.java
+++ b/hartshorn-minecraft/hotbar/src/main/java/org/dockbox/hartshorn/hotbar/HotbarService.java
@@ -91,6 +91,4 @@ public abstract class HotbarService implements AttributeHolder {
 
     @UpdateCache
     public abstract void save(Tuple<Long, InventoryRow> entry);
-
-
 }

--- a/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inject/SpongeInjector.java
+++ b/hartshorn-sponge-8/src/main/java/org/dockbox/hartshorn/sponge/inject/SpongeInjector.java
@@ -48,52 +48,26 @@ import org.dockbox.hartshorn.sponge.util.SpongeFileManager;
 import org.dockbox.hartshorn.sponge.util.SpongeTaskRunner;
 import org.slf4j.Logger;
 
+import java.util.function.Supplier;
+
 @LogExclude
 public class SpongeInjector extends InjectConfiguration {
 
     @Override
     public void collect(final ApplicationContext context) {
-        // Factory creation
         this.bind(Key.of(TypeFactory.class), TypeFactoryImpl.class);
-
-        // Tasks
         this.bind(Key.of(TaskRunner.class), SpongeTaskRunner.class);
-
-        // Persistence
         this.bind(Key.of(FileManager.class), SpongeFileManager.class);
-
-        // Services
         this.bind(Key.of(Players.class), SpongePlayers.class);
         this.bind(Key.of(Worlds.class), SpongeWorlds.class);
-//        this.bind(Key.of(WorldEditService.class), SpongeWorldEditService.class);
-//        this.bind(Key.of(CustomMapService.class), SpongeCustomMapService.class);
-//        this.bind(Key.of(PlotService.class), SpongePlotSquaredService.class);
         this.bind(Key.of(CacheManager.class), CacheManagerImpl.class);
-
-        // Builder types
         this.bind(Key.of(PaginationBuilder.class), PaginationBuilderImpl.class);
-//        this.bind(Key.of(LayoutBuilder.class), SpongeLayoutBuilder.class);
-//        this.bind(Key.of(PaginatedPaneBuilder.class), SpongePaginatedPaneBuilder.class);
-//        this.bind(Key.of(StaticPaneBuilder.class), SpongeStaticPaneBuilder.class);
-
-        // Wired types - do NOT call directly!
-        this.manual(Key.of(Item.class), SpongeItem.class);
-//        this.manual(Key.of(Bossbar.class), SpongeBossbar.class);
-        this.manual(Key.of(Profile.class), SpongeProfile.class);
-//        this.manual(Key.of(DiscordCommandSource.class), MagiBridgeCommandSource.class);
-        this.manual(Key.of(ConfigurationManager.class), ConfigurationManagerImpl.class);
-
-        // Log is created from LoggerFactory externally
-        this.provide(Key.of(Logger.class), context::log);
-
-        // Console is a constant singleton, to avoid recreation
+        this.bind(Key.of(Item.class), SpongeItem.class);
+        this.bind(Key.of(Profile.class), SpongeProfile.class);
+        this.bind(Key.of(ConfigurationManager.class), ConfigurationManagerImpl.class);
         this.bind(Key.of(SystemSubject.class), SpongeSystemSubject.class);
-
-        // Packets
-//        this.bind(Key.of(ChangeGameStatePacket.class), NMSChangeGameStatePacket.class);
-//        this.bind(Key.of(SpawnEntityPacket.class), NMSSpawnEntityPacket.class);
-
         this.bind(Key.of(GlobalConfig.class), TargetGlobalConfig.class);
         this.bind(Key.of(MinecraftVersion.class), MinecraftVersion.MC1_16);
+        this.bind(Key.of(Logger.class), (Supplier<Logger>) context::log);
     }
 }

--- a/hartshorn-test/src/testFixtures/java/org/dockbox/hartshorn/test/util/JUnitInjector.java
+++ b/hartshorn-test/src/testFixtures/java/org/dockbox/hartshorn/test/util/JUnitInjector.java
@@ -53,44 +53,31 @@ import org.dockbox.hartshorn.test.services.JUnitPlayers;
 import org.dockbox.hartshorn.test.services.JUnitWorlds;
 import org.slf4j.Logger;
 
+import java.util.function.Supplier;
+
 @LogExclude
 public class JUnitInjector extends InjectConfiguration {
 
     @Override
     public void collect(final ApplicationContext context) {
-        // Factory creation
         this.bind(Key.of(TypeFactory.class), TypeFactoryImpl.class);
-
-        // Tasks
         this.bind(Key.of(TaskRunner.class), JUnitTaskRunner.class);
-
-        // Persistence
         this.bind(Key.of(FileManager.class), JUnitFileManager.class);
-
-        // Services
         this.bind(Key.of(Players.class), JUnitPlayers.class);
         this.bind(Key.of(Worlds.class), JUnitWorlds.class);
         this.bind(Key.of(CustomMapService.class), JUnitCustomMapService.class);
         this.bind(Key.of(CacheManager.class), JUnitCacheManager.class);
-
-        // Wired types - do NOT call directly!
-        this.manual(Key.of(Item.class), JUnitItem.class);
-        this.manual(Key.of(Bossbar.class), JUnitBossbar.class);
-        this.manual(Key.of(Profile.class), JUnitProfile.class);
-        this.manual(Key.of(ItemFrame.class), JUnitItemFrame.class);
-        this.manual(Key.of(ArmorStand.class), JUnitArmorStand.class);
-        this.manual(Key.of(DiscordCommandSource.class), JUnitDiscordCommandSource.class);
-        this.manual(Key.of(ConfigurationManager.class), JUnitConfigurationManager.class);
-
-        // Log is created from LoggerFactory externally
-        this.provide(Key.of(Logger.class), context::log);
-
-        // Console is a constant singleton, to avoid recreation
+        this.bind(Key.of(Item.class), JUnitItem.class);
+        this.bind(Key.of(Bossbar.class), JUnitBossbar.class);
+        this.bind(Key.of(Profile.class), JUnitProfile.class);
+        this.bind(Key.of(ItemFrame.class), JUnitItemFrame.class);
+        this.bind(Key.of(ArmorStand.class), JUnitArmorStand.class);
+        this.bind(Key.of(DiscordCommandSource.class), JUnitDiscordCommandSource.class);
+        this.bind(Key.of(ConfigurationManager.class), JUnitConfigurationManager.class);
+        this.bind(Key.of(Logger.class), (Supplier<Logger>) context::log);
         this.bind(Key.of(SystemSubject.class), new JUnitSystemSubject());
-
         this.bind(Key.of(GlobalConfig.class), JUnitGlobalConfig.class);
         this.bind(Key.of(MinecraftVersion.class), MinecraftVersion.INDEV);
-
         this.bind(Key.of(DiscordUtils.class), JUnitDiscordUtils.class);
     }
 }


### PR DESCRIPTION
Fixes #357 
- [x] Breaking change

# Motivation
Currently it's not possible to use `Binder.bind` for both static bindings and bound bindings. This is a remnant of the Guice implementations, as there was a need to separate this functionality.

# Changes
Removes `Binder.manual` which was previously responsible for bound constructors. Types with constructors supporting bound injection are now automatically picked up by `Binder.bind`. `.bind` will create dual bindings if the type supports both bound and injected construction.

Additionally, `Binder.provide` was renamed to `Binder.bind` to make all binding related methods be consistent with each other.
`ApplicationBinder.firstWire` now accepts a `Key` rather than a separate `TypeContext` and `Named` instance.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.1

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
