### PR TITLE
#394 Gradle dependency analysis and workflow

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -1,0 +1,18 @@
+name: Gradle dependency check
+
+on: pull_request
+
+jobs:
+  depCheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 16
+        uses: actions/setup-java@v1
+        with:
+          java-version: 16
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build all
+        run: ./gradlew dependencyCheckAnalyze

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -14,5 +14,5 @@ jobs:
           java-version: 16
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build all
+      - name: Analyze dependencies
         run: ./gradlew dependencyCheckAnalyze

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
     }
     dependencies {
         classpath "io.franzbecker:gradle-lombok:$gradleLombokVersion"
+        classpath 'org.owasp:dependency-check-gradle:6.2.2'
     }
 }
 
@@ -32,6 +33,8 @@ plugins {
     id 'org.cadixdev.licenser' version "$licenserVersion"
     id 'io.freefair.aggregate-javadoc' version "$aggregateJavadocVersion"
 }
+
+apply plugin: 'org.owasp.dependencycheck'
 
 static def getVersionName() {
     return 'git rev-parse --verify --short HEAD'.execute().text.trim()
@@ -46,6 +49,12 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(16)
     }
+}
+
+dependencyCheck {
+    // Strict rule, even small vulnerabilities should be handled unless they are supressed
+    failBuildOnCVSS = 1
+    failOnError = true
 }
 
 subprojects { Project subProject ->


### PR DESCRIPTION
Fixes #394

# Motivation
Recently it was noticed that dependencies like Guava have been outdated for a expanded amount of time. The used version was 21.0, while the latest was 30.1.1.

# Changes
A new Gradle plugin has been added, [dependency check Gradle](https://github.com/dependency-check/dependency-check-gradle). This task is added to a new GitHub Actions workflow, so dependencies are (strictly) checked before a PR can be merged.

## Type of change
- [x] New core feature