### PR TITLE
#355 Minor issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,12 +132,7 @@ allprojects {
             all*.exclude group: 'junit', module: 'junit'
         }
 
-        compileJava {
-            options.compilerArgs << '-parameters'
-            options.encoding = 'UTF-8'
-        }
-
-        compileTestJava {
+        tasks.withType(JavaCompile) {
             options.compilerArgs << '-parameters'
             options.encoding = 'UTF-8'
         }

--- a/hartshorn-commands/src/impl/java/org/dockbox/hartshorn/commands/service/CommandParameterValidator.java
+++ b/hartshorn-commands/src/impl/java/org/dockbox/hartshorn/commands/service/CommandParameterValidator.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.commands.service;
+
+import org.dockbox.hartshorn.boot.annotations.PostBootstrap;
+import org.dockbox.hartshorn.boot.annotations.UseBootstrap;
+import org.dockbox.hartshorn.di.annotations.service.Service;
+import org.dockbox.hartshorn.di.context.ApplicationContext;
+import org.dockbox.hartshorn.di.context.element.MethodContext;
+import org.dockbox.hartshorn.di.context.element.ParameterContext;
+import org.dockbox.hartshorn.di.context.element.TypeContext;
+
+@Service(activators = UseBootstrap.class)
+public class CommandParameterValidator {
+
+    @PostBootstrap
+    public void preload(final ApplicationContext context) {
+        final MethodContext<?, CommandParameterValidator> preload = TypeContext.of(this).method("preload", ApplicationContext.class).get();
+        final ParameterContext<?> parameter = preload.parameters().get(0);
+        if (!"context".equals(parameter.name())) {
+            context.log().warn("Parameter names are obfuscated, this will cause commands with @Parameter to be unable to inject arguments.");
+            context.log().warn("   Add -parameters to your compiler args to keep parameter names.");
+            context.log().warn("   See: https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html for more information.");
+        }
+    }
+
+}

--- a/hartshorn-commands/src/impl/java/org/dockbox/hartshorn/commands/service/CommandServiceScanner.java
+++ b/hartshorn-commands/src/impl/java/org/dockbox/hartshorn/commands/service/CommandServiceScanner.java
@@ -20,12 +20,10 @@ package org.dockbox.hartshorn.commands.service;
 import org.dockbox.hartshorn.commands.CommandGateway;
 import org.dockbox.hartshorn.commands.annotations.Command;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
-import org.dockbox.hartshorn.di.annotations.service.Service;
 import org.dockbox.hartshorn.di.context.ApplicationContext;
 import org.dockbox.hartshorn.di.context.element.TypeContext;
 import org.dockbox.hartshorn.di.services.ServiceProcessor;
 
-@Service(activators = UseCommands.class)
 public class CommandServiceScanner implements ServiceProcessor<UseCommands> {
 
     @Override

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/element/TypeContext.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/element/TypeContext.java
@@ -465,6 +465,14 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         return Exceptional.empty();
     }
 
+    public Exceptional<MethodContext<?, T>> method(final String name, final TypeContext<?>... arguments) {
+        return this.method(name, Arrays.asList(arguments));
+    }
+
+    public Exceptional<MethodContext<?, T>> method(final String name, final Class<?>... arguments) {
+        return this.method(name, Arrays.stream(arguments).map(TypeContext::of).collect(Collectors.toList()));
+    }
+
     private void verifyMetadataAvailable() {
         if (this.isProxy()) throw new ApplicationException("Cannot collect metadata of proxied type").runtime();
     }


### PR DESCRIPTION
Affects #355

# Changes
- Parameter names are now kept when compiling test sources
- A warning will be shown during early evaluation if parameter names are obfuscated

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.1

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
