### PR TITLE
S413 Remove Guava dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,6 @@ allprojects {
         dependencies {
             // Typically included by platforms
             apiInclude "org.slf4j:slf4j-api:$slf4jVersion"
-            apiInclude "com.google.guava:guava:$guavaVersion"
             apiInclude "javax.persistence:javax.persistence-api:$javaxPersistenceVersion"
 
             // Compile/source dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,6 @@ pluginName=Hartshorn
 junitVersion=5.3.2
 mockitoVersion=3.10.0
 jetbrainsAnnotationsVersion=19.0.0
-guavaVersion=30.1.1-jre
 slf4jVersion=1.7.25
 jdaVersion=4.2.0_249
 reflectionsVersion=0.9.11

--- a/hartshorn-boot/src/main/java/org/dockbox/hartshorn/boot/HartshornApplication.java
+++ b/hartshorn-boot/src/main/java/org/dockbox/hartshorn/boot/HartshornApplication.java
@@ -17,15 +17,14 @@
 
 package org.dockbox.hartshorn.boot;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.exceptions.Except;
 import org.dockbox.hartshorn.boot.ServerState.Started;
 import org.dockbox.hartshorn.di.ApplicationBootstrap;
+import org.dockbox.hartshorn.di.ArrayListMultiMap;
 import org.dockbox.hartshorn.di.InjectConfiguration;
 import org.dockbox.hartshorn.di.Modifier;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.annotations.activate.Activator;
 import org.dockbox.hartshorn.di.annotations.inject.InjectConfig;
 import org.dockbox.hartshorn.di.annotations.inject.InjectPhase;
@@ -102,7 +101,7 @@ public class HartshornApplication {
 
             final String prefix = "".equals(annotation.prefix()) ? activator.getPackage().getName() : annotation.prefix();
 
-            final Multimap<InjectPhase, InjectConfiguration> configurations = ArrayListMultimap.create();
+            final MultiMap<InjectPhase, InjectConfiguration> configurations = new ArrayListMultiMap<>();
             for (final InjectConfig config : annotation.configs()) {
                 configurations.put(config.phase(), instance(config.value()));
             }

--- a/hartshorn-bootstrap/src/main/java/org/dockbox/hartshorn/boot/HartshornBootstrap.java
+++ b/hartshorn-bootstrap/src/main/java/org/dockbox/hartshorn/boot/HartshornBootstrap.java
@@ -17,8 +17,6 @@
 
 package org.dockbox.hartshorn.boot;
 
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.exceptions.Except;
 import org.dockbox.hartshorn.boot.annotations.UseBootstrap;
@@ -26,6 +24,7 @@ import org.dockbox.hartshorn.boot.config.GlobalConfig;
 import org.dockbox.hartshorn.di.InjectConfiguration;
 import org.dockbox.hartshorn.di.InjectableBootstrap;
 import org.dockbox.hartshorn.di.Modifier;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.annotations.context.LogExclude;
 import org.dockbox.hartshorn.di.annotations.inject.InjectPhase;
 import org.dockbox.hartshorn.di.annotations.inject.Required;
@@ -51,7 +50,7 @@ public abstract class HartshornBootstrap extends InjectableBootstrap {
     private final Set<MethodContext<?, ?>> postBootstrapActivations = HartshornUtils.emptyConcurrentSet();
 
     @Override
-    public void create(final Collection<String> prefixes, final Class<?> activationSource, final List<Annotation> activators, final Multimap<InjectPhase, InjectConfiguration> configs, final Modifier... modifiers) {
+    public void create(final Collection<String> prefixes, final Class<?> activationSource, final List<Annotation> activators, final MultiMap<InjectPhase, InjectConfiguration> configs, final Modifier... modifiers) {
         activators.add(new UseBootstrap() {
             @Override
             public Class<? extends Annotation> annotationType() {

--- a/hartshorn-bootstrap/src/test/java/org/dockbox/hartshorn/boot/SampleBootstrap.java
+++ b/hartshorn-bootstrap/src/test/java/org/dockbox/hartshorn/boot/SampleBootstrap.java
@@ -17,12 +17,10 @@
 
 package org.dockbox.hartshorn.boot;
 
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
-import org.dockbox.hartshorn.boot.HartshornBootstrap;
 import org.dockbox.hartshorn.di.InjectConfiguration;
 import org.dockbox.hartshorn.di.Modifier;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.annotations.inject.InjectPhase;
 import org.dockbox.hartshorn.di.context.element.TypeContext;
 
@@ -38,7 +36,7 @@ public class SampleBootstrap extends HartshornBootstrap {
     }
 
     @Override
-    public void create(final Collection<String> prefixes, final Class<?> activationSource, final List<Annotation> activators, final Multimap<InjectPhase, InjectConfiguration> configs, final Modifier... modifiers) {
+    public void create(final Collection<String> prefixes, final Class<?> activationSource, final List<Annotation> activators, final MultiMap<InjectPhase, InjectConfiguration> configs, final Modifier... modifiers) {
         // This is only used for Application testing, do not actually create bootstrap instance
     }
 

--- a/hartshorn-commands/src/impl/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/impl/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -17,9 +17,6 @@
 
 package org.dockbox.hartshorn.commands;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.commands.annotations.Command;
 import org.dockbox.hartshorn.commands.context.CommandContext;
@@ -29,6 +26,8 @@ import org.dockbox.hartshorn.commands.context.MethodCommandExecutorContext;
 import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.commands.extension.CommandExecutorExtension;
 import org.dockbox.hartshorn.commands.extension.ExtensionResult;
+import org.dockbox.hartshorn.di.ArrayListMultiMap;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.annotations.inject.Binds;
 import org.dockbox.hartshorn.di.context.ApplicationContext;
 import org.dockbox.hartshorn.di.context.element.MethodContext;
@@ -53,7 +52,7 @@ import lombok.Getter;
 @Binds(CommandGateway.class)
 public class CommandGatewayImpl implements CommandGateway, AttributeHolder {
 
-    private static final transient Multimap<String, CommandExecutorContext> contexts = ArrayListMultimap.create();
+    private static final transient MultiMap<String, CommandExecutorContext> contexts = new ArrayListMultiMap<>();
     @Getter(AccessLevel.PROTECTED)
     private final transient List<CommandExecutorExtension> extensions = HartshornUtils.emptyConcurrentList();
     @Inject
@@ -199,10 +198,8 @@ public class CommandGatewayImpl implements CommandGateway, AttributeHolder {
 
     /**
      * Gets all contexts stored by the gateway.
-     *
-     * @return
      */
-    public static Multimap<String, CommandExecutorContext> contexts() {
+    public static MultiMap<String, CommandExecutorContext> contexts() {
         return CommandGatewayImpl.contexts;
     }
 }

--- a/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/InjectableBootstrap.java
+++ b/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/InjectableBootstrap.java
@@ -17,8 +17,6 @@
 
 package org.dockbox.hartshorn.di;
 
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.di.annotations.inject.InjectPhase;
 import org.dockbox.hartshorn.di.context.ApplicationContext;
 import org.dockbox.hartshorn.di.context.HartshornApplicationContext;
@@ -36,7 +34,7 @@ import java.util.function.BiConsumer;
 public abstract class InjectableBootstrap extends ApplicationContextAware {
 
     @Override
-    public void create(final Collection<String> prefixes, final Class<?> activationSource, final List<Annotation> activators, final Multimap<InjectPhase, InjectConfiguration> configs, final Modifier... modifiers) {
+    public void create(final Collection<String> prefixes, final Class<?> activationSource, final List<Annotation> activators, final MultiMap<InjectPhase, InjectConfiguration> configs, final Modifier... modifiers) {
         super.create(new HartshornApplicationContext(this, activationSource, prefixes, modifiers));
         Reflections.log = null; // Don't output Reflections
 

--- a/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/context/ManagedHartshornContext.java
+++ b/hartshorn-di/src/impl/java/org/dockbox/hartshorn/di/context/ManagedHartshornContext.java
@@ -17,15 +17,14 @@
 
 package org.dockbox.hartshorn.di.context;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.exceptions.ApplicationException;
 import org.dockbox.hartshorn.di.ApplicationContextAware;
+import org.dockbox.hartshorn.di.ArrayListMultiMap;
 import org.dockbox.hartshorn.di.ComponentType;
 import org.dockbox.hartshorn.di.InjectionPoint;
 import org.dockbox.hartshorn.di.Key;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.ProvisionFailure;
 import org.dockbox.hartshorn.di.annotations.activate.Activator;
 import org.dockbox.hartshorn.di.annotations.inject.Enable;
@@ -62,8 +61,8 @@ public abstract class ManagedHartshornContext extends DefaultContext implements 
     protected static final Logger log = LoggerFactory.getLogger(ManagedHartshornContext.class);
     protected final transient Set<InjectionPoint<?>> injectionPoints = HartshornUtils.emptyConcurrentSet();
 
-    protected final transient Multimap<ServiceOrder, InjectionModifier<?>> injectionModifiers = ArrayListMultimap.create();
-    protected final transient Multimap<ServiceOrder, ComponentProcessor<?>> processors = ArrayListMultimap.create();
+    protected final transient MultiMap<ServiceOrder, InjectionModifier<?>> injectionModifiers = new ArrayListMultiMap<>();
+    protected final transient MultiMap<ServiceOrder, ComponentProcessor<?>> processors = new ArrayListMultiMap<>();
 
     protected final transient Map<String, Object> environmentValues = HartshornUtils.emptyConcurrentMap();
 

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/ApplicationBootstrap.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/ApplicationBootstrap.java
@@ -17,8 +17,6 @@
 
 package org.dockbox.hartshorn.di;
 
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.di.annotations.inject.InjectPhase;
 import org.dockbox.hartshorn.di.context.ApplicationContext;
 import org.dockbox.hartshorn.di.context.element.MethodContext;
@@ -35,7 +33,7 @@ public interface ApplicationBootstrap {
 
     ApplicationContext context();
 
-    void create(Collection<String> prefixes, Class<?> activationSource, List<Annotation> activators, Multimap<InjectPhase, InjectConfiguration> configs, Modifier... modifiers);
+    void create(Collection<String> prefixes, Class<?> activationSource, List<Annotation> activators, MultiMap<InjectPhase, InjectConfiguration> configs, Modifier... modifiers);
 
     void addActivation(MethodContext<?, ?> method);
 }

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/ArrayListMultiMap.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/ArrayListMultiMap.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.di;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ArrayListMultiMap<K, V> extends MultiMap<K, V> {
+    @Override
+    protected Collection<V> baseCollection() {
+        return new ArrayList<>();
+    }
+}

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/HashSetMultiMap.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/HashSetMultiMap.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.di;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class HashSetMultiMap<K, V> extends MultiMap<K, V> {
+    @Override
+    protected Collection<V> baseCollection() {
+        return new HashSet<>();
+    }
+}

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/MultiMap.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/MultiMap.java
@@ -1,0 +1,83 @@
+package org.dockbox.hartshorn.di;
+
+import org.dockbox.hartshorn.util.HartshornUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+@SuppressWarnings("SuspiciousMethodCalls")
+public abstract class MultiMap<K, V> {
+
+    private final Map<K, Collection<V>> map = HartshornUtils.emptyMap();
+
+    protected abstract Collection<V> baseCollection();
+
+    public void put(K key, V value) {
+        this.map.computeIfAbsent(key, k -> this.baseCollection()).add(value);
+    }
+
+    public void putIfAbsent(K key, V value) {
+        this.map.computeIfAbsent(key, k -> this.baseCollection());
+        if (!this.map.get(key).contains(value)) {
+            this.map.get(key).add(value);
+        }
+    }
+
+    public Collection<V> get(Object key) {
+        return this.map.getOrDefault(key, this.baseCollection());
+    }
+
+    public Set<K> keySet() {
+        return this.map.keySet();
+    }
+
+    public Set<Map.Entry<K, Collection<V>>> entrySet() {
+        return this.map.entrySet();
+    }
+
+    public Collection<Collection<V>> values() {
+        return this.map.values();
+    }
+
+    public boolean containsKey(Object key) {
+        return this.map.containsKey(key);
+    }
+
+    public Collection<V> remove(Object key) {
+        return this.map.remove(key);
+    }
+
+    public int size() {
+        int size = 0;
+        for (Collection<V> value : this.map.values()) {
+            size += value.size();
+        }
+        return size;
+    }
+
+    public boolean isEmpty() {
+        return this.map.isEmpty();
+    }
+
+    public void clear() {
+        this.map.clear();
+    }
+
+    public boolean remove(K key, V value) {
+        if (this.map.get(key) != null)
+            return this.map.get(key).remove(value);
+
+        return false;
+    }
+
+    public boolean replace(K key, V oldValue, V newValue) {
+        if (this.map.get(key) != null) {
+            if (this.map.get(key).remove(oldValue)) {
+                return this.map.get(key).add(newValue);
+            }
+        }
+        return false;
+    }
+}
+ 

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/DefaultContext.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/DefaultContext.java
@@ -17,10 +17,9 @@
 
 package org.dockbox.hartshorn.di.context;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
+import org.dockbox.hartshorn.di.HashSetMultiMap;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.annotations.context.AutoCreating;
 import org.dockbox.hartshorn.di.context.element.TypeContext;
 import org.dockbox.hartshorn.util.HartshornUtils;
@@ -31,7 +30,7 @@ import java.util.Set;
 public abstract class DefaultContext implements Context {
 
     protected final transient Set<Context> contexts = HartshornUtils.emptyConcurrentSet();
-    protected final transient Multimap<String, Context> namedContexts = HashMultimap.create();
+    protected final transient MultiMap<String, Context> namedContexts = new HashSetMultiMap<>();
 
     @Override
     public <C extends Context> void add(final C context) {

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/PrefixContext.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/PrefixContext.java
@@ -17,10 +17,9 @@
 
 package org.dockbox.hartshorn.di.context;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.di.AnnotationHelper;
+import org.dockbox.hartshorn.di.ArrayListMultiMap;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.context.element.TypeContext;
 import org.dockbox.hartshorn.util.HartshornUtils;
 import org.reflections.Reflections;
@@ -34,7 +33,7 @@ import java.util.stream.Collectors;
 public class PrefixContext extends DefaultContext {
 
     private final Map<String, Reflections> reflectedPrefixes = HartshornUtils.emptyConcurrentMap();
-    private final Multimap<Class<? extends Annotation>, Class<? extends Annotation>> annotationHierarchy = ArrayListMultimap.create();
+    private final MultiMap<Class<? extends Annotation>, Class<? extends Annotation>> annotationHierarchy = new ArrayListMultiMap<>();
 
     public PrefixContext(final Iterable<String> initialPrefixes) {
         for (final String initialPrefix : initialPrefixes) {

--- a/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/element/TypeContext.java
+++ b/hartshorn-di/src/main/java/org/dockbox/hartshorn/di/context/element/TypeContext.java
@@ -17,13 +17,12 @@
 
 package org.dockbox.hartshorn.di.context.element;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.domain.Exceptional;
 import org.dockbox.hartshorn.api.domain.tuple.Tristate;
 import org.dockbox.hartshorn.api.exceptions.ApplicationException;
+import org.dockbox.hartshorn.di.ArrayListMultiMap;
 import org.dockbox.hartshorn.di.GenericType;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.NotPrimitiveException;
 import org.dockbox.hartshorn.di.TypeConversionException;
 import org.dockbox.hartshorn.di.annotations.inject.Bound;
@@ -104,7 +103,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     private List<MethodContext<?, T>> flatMethods;
     private List<TypeContext<?>> typeParameters;
     private List<ConstructorContext<T>> constructors;
-    private Multimap<String, MethodContext<?, T>> methods;
+    private MultiMap<String, MethodContext<?, T>> methods;
     private Exceptional<ConstructorContext<T>> defaultConstructor;
     private Tristate isProxy = Tristate.UNDEFINED;
 
@@ -451,7 +450,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         if (this.methods == null) {
             // Organizing the methods by name and arguments isn't worth the additional overhead for list comparisons,
             // so instead we only link it by name and perform the list comparison on request.
-            this.methods = ArrayListMultimap.create();
+            this.methods = new ArrayListMultiMap<>();
             for (final MethodContext<?, T> method : this.flatMethods()) {
                 this.methods.put(method.name(), method);
             }

--- a/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/handle/ProxyHandler.java
+++ b/hartshorn-proxy/src/main/java/org/dockbox/hartshorn/proxy/handle/ProxyHandler.java
@@ -17,11 +17,10 @@
 
 package org.dockbox.hartshorn.proxy.handle;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import org.dockbox.hartshorn.api.exceptions.ApplicationException;
 import org.dockbox.hartshorn.boot.Hartshorn;
+import org.dockbox.hartshorn.di.ArrayListMultiMap;
+import org.dockbox.hartshorn.di.MultiMap;
 import org.dockbox.hartshorn.di.context.element.MethodContext;
 import org.dockbox.hartshorn.di.context.element.TypeContext;
 import org.dockbox.hartshorn.proxy.ProxyAttribute;
@@ -40,7 +39,7 @@ import lombok.Getter;
 
 public class ProxyHandler<T> implements MethodHandler {
 
-    private final Multimap<Method, ProxyAttribute<T, ?>> handlers = ArrayListMultimap.create();
+    private final MultiMap<Method, ProxyAttribute<T, ?>> handlers = new ArrayListMultiMap<>();
     private final T instance;
 
     @Getter

--- a/hartshorn-test/build.gradle
+++ b/hartshorn-test/build.gradle
@@ -35,8 +35,6 @@ dependencies {
         }
     }
 
-    testFixturesImplementation "com.google.guava:guava:$guavaVersion"
-
     testFixturesImplementation "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
 
     testFixturesImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"

--- a/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/HartshornUtils.java
+++ b/hartshorn-util/src/main/java/org/dockbox/hartshorn/util/HartshornUtils.java
@@ -17,9 +17,6 @@
 
 package org.dockbox.hartshorn.util;
 
-import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
-
 import org.dockbox.hartshorn.api.CheckedRunnable;
 import org.dockbox.hartshorn.api.domain.AbstractIdentifiable;
 import org.dockbox.hartshorn.api.domain.Exceptional;
@@ -63,6 +60,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -1152,9 +1150,11 @@ public final class HartshornUtils {
     }
 
     public static <T> Set<T> difference(final Collection<T> collectionOne, final Collection<T> collectionTwo) {
-        final Set<T> diff = emptySet();
-        final SetView<T> differenceInOne = Sets.difference(asSet(collectionOne), asSet(collectionTwo));
-        final SetView<T> differenceInTwo = Sets.difference(asSet(collectionTwo), asSet(collectionOne));
+        BiFunction<Collection<T>, Collection<T>, List<T>> filter = (c1, c2) -> c1.stream()
+                .filter(element -> !c2.contains(element))
+                .toList();
+        List<T> differenceInOne = filter.apply(collectionOne, collectionTwo);
+        List<T> differenceInTwo = filter.apply(collectionTwo, collectionOne);
         return asSet(merge(differenceInOne, differenceInTwo));
     }
 

--- a/hartshorn-util/src/test/java/org/dockbox/hartshorn/util/HartshornUtilTests.java
+++ b/hartshorn-util/src/test/java/org/dockbox/hartshorn/util/HartshornUtilTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class HartshornUtilTests {
@@ -285,6 +286,13 @@ public class HartshornUtilTests {
                 Arguments.of("2w3d", (2 * week) + (3 * day)),
                 Arguments.of("2w3d5h", (2 * week) + (3 * day) + (5 * hour)),
                 Arguments.of("17h21m13s", (17 * hour) + (21 * minute) + 13)
+        );
+    }
+
+    public static Stream<Arguments> differences() {
+        return Stream.of(
+                Arguments.of(HartshornUtils.asList("a", "b"), HartshornUtils.asList("a"), HartshornUtils.asList("b")),
+                Arguments.of(HartshornUtils.asList("a"), HartshornUtils.asList("a", "b"), HartshornUtils.asList("b"))
         );
     }
 
@@ -722,5 +730,14 @@ public class HartshornUtilTests {
                         v1  v2  v3 \s
                         """,
                 table);
+    }
+
+    @ParameterizedTest
+    @MethodSource("differences")
+    void testDifferenceInCollections(Collection<String> a, Collection<String> b, Collection<String> expected) {
+        Set<String> difference = HartshornUtils.difference(a, b);
+        Assertions.assertEquals(difference.size(), expected.size());
+        Assertions.assertTrue(difference.containsAll(expected));
+        Assertions.assertTrue(expected.containsAll(difference));
     }
 }


### PR DESCRIPTION
Fixes #413

# Motivation
Currently Guava is included purely for the use of the `Multimap` and `SetView` data structures.

# Changes
Replace usages of Guava's `Multimap` with a custom implementation and refactor the collection difference utility method to avoid depending on `SetView`.

## Type of change
- [x] Enhancement of existing functionality

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.1

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
