### PR TITLE
#452 Add `scanPackages` to `@ServiceActivator`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/service/ServiceActivator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/service/ServiceActivator.java
@@ -27,5 +27,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
 public @interface ServiceActivator {
-    String scanPackages() default Hartshorn.PACKAGE_PREFIX;
+    String[] scanPackages() default { Hartshorn.PACKAGE_PREFIX };
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/service/ServiceActivator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/service/ServiceActivator.java
@@ -17,6 +17,8 @@
 
 package org.dockbox.hartshorn.core.annotations.service;
 
+import org.dockbox.hartshorn.core.boot.Hartshorn;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -25,4 +27,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
 public @interface ServiceActivator {
+    String scanPackages() default Hartshorn.PACKAGE_PREFIX;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -125,8 +125,10 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
 
     public void addActivator(final Annotation annotation) {
         if (this.activators.contains(annotation)) return;
-        if (TypeContext.of(annotation.annotationType()).annotation(ServiceActivator.class).present()) {
+        final Exceptional<ServiceActivator> activator = TypeContext.of(annotation.annotationType()).annotation(ServiceActivator.class);
+        if (activator.present()) {
             this.activators.add(annotation);
+            this.environment().prefix(activator.get().scanPackages());
             this.environment().annotationsWith(TypeContext.unproxy(this, annotation), ServiceActivator.class).forEach(this::addActivator);
         }
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -128,7 +128,9 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         final Exceptional<ServiceActivator> activator = TypeContext.of(annotation.annotationType()).annotation(ServiceActivator.class);
         if (activator.present()) {
             this.activators.add(annotation);
-            this.environment().prefix(activator.get().scanPackages());
+            for (final String scanPackage : activator.get().scanPackages()) {
+                this.environment().prefix(scanPackage);
+            }
             this.environment().annotationsWith(TypeContext.unproxy(this, annotation), ServiceActivator.class).forEach(this::addActivator);
         }
     }


### PR DESCRIPTION
Fixes #452 

# Motivation
By default two packages are scanned when an application is bootstrapped; `org.dockbox.hartshorn` and the package in which the application activator is located. This works fine while modules are only in Hartshorn itself, but lacks support for third-party modules.  
For example, if I create an application in `com.example.myapp`, and want to use services provided by a third party which are located in `net.thirdparty.services`, their package will not be scanned unless I manually define it.

# Changes
`@ServiceActivator` now has an optional attribute `scanPackages` which indicates the packages to be added to the environment context. As the environment already filters out duplicates this is a non-concern from the aspect of the application context.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: Corretto 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
