### PR TITLE
#450 Restructure `Language` definitions into separate contract

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.i18n.common.Language;
+import org.dockbox.hartshorn.i18n.common.Languages;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.text.Text;
 import org.jetbrains.annotations.NotNull;
@@ -46,7 +47,7 @@ public abstract class SystemSubject implements CommandSource, Identifiable {
 
     @Override
     public Language language() {
-        return Language.EN_US;
+        return Languages.EN_US;
     }
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.core.domain.tuple.Vector3N;
 import org.dockbox.hartshorn.core.services.ComponentContainer;
 import org.dockbox.hartshorn.i18n.ResourceService;
 import org.dockbox.hartshorn.i18n.common.Language;
+import org.dockbox.hartshorn.i18n.common.Languages;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.text.Text;
 import org.jetbrains.annotations.NonNls;
@@ -78,19 +79,19 @@ public final class DefaultArgumentConverters {
             .withConverter((@NonNls String in) -> {
                 Language lang;
                 try {
-                    lang = Language.valueOf(in);
+                    lang = Languages.valueOf(in);
                 }
                 catch (NullPointerException | IllegalArgumentException e) {
                     lang =
-                            Arrays.stream(Language.values())
+                            Arrays.stream(Languages.values())
                                     .filter(l -> l.nameEnglish().equals(in) || l.nameLocalized().equals(in))
                                     .findFirst()
-                                    .orElse(Language.EN_US);
+                                    .orElse(Languages.EN_US);
                 }
                 return Exceptional.of(lang);
             }).withSuggestionProvider(in -> {
                 List<String> suggestions = HartshornUtils.emptyList();
-                for (Language lang : Language.values()) {
+                for (Language lang : Languages.values()) {
                     suggestions.add(lang.code());
                     suggestions.add(lang.nameEnglish());
                     suggestions.add(lang.nameLocalized());

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/ResourceService.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/ResourceService.java
@@ -17,8 +17,8 @@
 
 package org.dockbox.hartshorn.i18n;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.context.ContextCarrier;
+import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.i18n.common.Language;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.message.MessageTemplate;

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/ResourceServiceImpl.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/ResourceServiceImpl.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.annotations.inject.Binds;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.i18n.common.Language;
+import org.dockbox.hartshorn.i18n.common.Languages;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.message.MessageTemplate;
 import org.dockbox.hartshorn.core.HartshornUtils;
@@ -50,7 +51,7 @@ public class ResourceServiceImpl implements ResourceService {
 
     public ResourceServiceImpl() {
         if (bundles.isEmpty()) {
-            for (final Language language : Language.values()) {
+            for (final Language language : Languages.values()) {
                 try {
                     final ResourceBundle bundle = ResourceBundle.getBundle("hartshorn.translations", language.locale());
                     ResourceServiceImpl.bundles.put(language, bundle);
@@ -119,7 +120,7 @@ public class ResourceServiceImpl implements ResourceService {
         @NonNls
         @NotNull final String finalKey = this.createValidKey(key);
         return Exceptional.of(() -> {
-            final Map<String, String> translations = this.translations(Language.EN_US);
+            final Map<String, String> translations = this.translations(Languages.EN_US);
             if (translations.containsKey(finalKey)) {
                 final String knownValue = translations.get(finalKey);
                 return new MessageTemplate(this.applicationContext(), knownValue, finalKey);

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/DefinedLanguage.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/DefinedLanguage.java
@@ -1,0 +1,15 @@
+package org.dockbox.hartshorn.i18n.common;
+
+import java.util.Locale;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DefinedLanguage implements Language {
+    private Locale locale;
+    private String code;
+    private String nameEnglish;
+    private String nameLocalized;
+}

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/Language.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/Language.java
@@ -1,77 +1,23 @@
-/*
- * Copyright (C) 2020 Guus Lieben
- *
- * This framework is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
- * the GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
- */
-
 package org.dockbox.hartshorn.i18n.common;
 
 import org.dockbox.hartshorn.persistence.PersistentCapable;
 
 import java.util.Locale;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+public interface Language extends PersistentCapable<PersistentLanguageModel> {
 
-@Getter
-@AllArgsConstructor
-public enum Language implements PersistentCapable<PersistentLanguageModel> {
-    CS_CZ(new Locale("cs"), "cs_CZ", "Czech", "Čeština"),
-    DE_CH(new Locale("de_ch"), "de_CH", "German (Switzerland)", "Deutsch (Schweiz)"),
-    ES_ES(new Locale("es"), "es_ES", "Spanish", "Español"),
-    FI(new Locale("fi"), "fi", "Finnish", "Suomi"),
-    NO_NO(new Locale("no"), "no_no", "Norwegian", "Norsk"),
-    PT_PT(new Locale("pt"), "pt_PT", "Portuguese", "Português"),
-    RU(new Locale("ru"), "ru", "Russian", "Pусский"),
-    SV_SE(new Locale("sv"), "sv_SE", "Swedish", "Svenska"),
-    TR(new Locale("tr"), "tr", "Turkish", "Türk"),
-    NL_NL(new Locale("nl"), "nl_NL", "Dutch", "Nederlands"),
-    EN_US(Locale.ENGLISH, "en_US", "English", "English"),
-    FR_FR(Locale.FRENCH, "fr_FR", "French", "Français"),
-    DE_DE(Locale.GERMANY, "de_DE", "German", "Deutsch");
-
-    private final Locale locale;
-    private final String code;
-    private final String nameEnglish;
-    private final String nameLocalized;
-
-    public static Language of(final String language) {
-        for (final Language value : Language.values()) {
-            if (value.code.equals(language)
-                    || value.nameEnglish.equals(language)
-                    || value.nameLocalized.equals(language)) {
-                return value;
-            }
-        }
-        return Language.EN_US;
-    }
-
-    public static Language of(final Locale locale) {
-        for (final Language value : Language.values()) {
-            // Compare based on language, as e.g. NL_NL will not match with Locale(nl, NL)
-            if (value.locale().getLanguage().equalsIgnoreCase(locale.getLanguage())) return value;
-        }
-        return Language.EN_US;
-    }
+    Locale locale();
+    String code();
+    String nameEnglish();
+    String nameLocalized();
 
     @Override
-    public Class<PersistentLanguageModel> type() {
+    default Class<PersistentLanguageModel> type() {
         return PersistentLanguageModel.class;
     }
 
     @Override
-    public PersistentLanguageModel model() {
-        return new PersistentLanguageModel(this.code);
+    default PersistentLanguageModel model() {
+        return new PersistentLanguageModel(this);
     }
 }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/Languages.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/Languages.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.i18n.common;
+
+import java.util.Locale;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Languages implements Language {
+    CS_CZ(new Locale("cs"), "cs_CZ", "Czech", "Čeština"),
+    DE_CH(new Locale("de_ch"), "de_CH", "German (Switzerland)", "Deutsch (Schweiz)"),
+    ES_ES(new Locale("es"), "es_ES", "Spanish", "Español"),
+    FI(new Locale("fi"), "fi", "Finnish", "Suomi"),
+    NO_NO(new Locale("no",""), "no_no", "Norwegian", "Norsk"),
+    PT_PT(new Locale("pt"), "pt_PT", "Portuguese", "Português"),
+    RU(new Locale("ru"), "ru", "Russian", "Pусский"),
+    SV_SE(new Locale("sv"), "sv_SE", "Swedish", "Svenska"),
+    TR(new Locale("tr"), "tr", "Turkish", "Türk"),
+    NL_NL(new Locale("nl"), "nl_NL", "Dutch", "Nederlands"),
+    EN_US(Locale.ENGLISH, "en_US", "English", "English"),
+    FR_FR(Locale.FRENCH, "fr_FR", "French", "Français"),
+    DE_DE(Locale.GERMANY, "de_DE", "German", "Deutsch");
+
+    private final Locale locale;
+    private final String code;
+    private final String nameEnglish;
+    private final String nameLocalized;
+
+    public static Language of(final String language) {
+        for (final Language value : Languages.values()) {
+            if (value.code().equals(language)
+                    || value.nameEnglish().equals(language)
+                    || value.nameLocalized().equals(language)) {
+                return value;
+            }
+        }
+        return Languages.EN_US;
+    }
+
+    public static Language of(final Locale locale) {
+        for (final Language value : Languages.values()) {
+            // Compare based on language, as e.g. NL_NL will not match with Locale(nl, NL)
+            if (value.locale().getLanguage().equalsIgnoreCase(locale.getLanguage())) return value;
+        }
+        return Languages.EN_US;
+    }
+}

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/PersistentLanguageModel.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/PersistentLanguageModel.java
@@ -17,20 +17,28 @@
 
 package org.dockbox.hartshorn.i18n.common;
 
-import org.dockbox.hartshorn.core.annotations.Property;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.persistence.PersistentModel;
 
-import lombok.Getter;
-import lombok.Setter;
+import java.util.Locale;
 
+import lombok.Data;
+
+@Data
 public class PersistentLanguageModel implements PersistentModel<Language> {
 
-    @Property(getter = "getCode", setter = "getCode")
-    @Getter @Setter private String code;
+    private String localeLang;
+    private String localeCountry;
+    private String code;
+    private String nameEnglish;
+    private String nameLocalized;
 
-    public PersistentLanguageModel(final String code) {
-        this.code = code;
+    public PersistentLanguageModel(final Language language) {
+        this.localeLang = language.locale().getLanguage();
+        this.localeCountry = language.locale().getCountry();
+        this.code = language.code();
+        this.nameEnglish = language.nameEnglish();
+        this.nameLocalized = language.nameLocalized();
     }
 
     @Override
@@ -40,6 +48,12 @@ public class PersistentLanguageModel implements PersistentModel<Language> {
 
     @Override
     public Language restore(final ApplicationContext context) {
-        return Language.of(this.code());
+        for (final Language value : Languages.values()) {
+            if (value.code().equals(this.code)) return value;
+        }
+        return new DefinedLanguage(
+                new Locale(this.localeLang, this.localeCountry),
+                this.code, this.nameEnglish, this.nameLocalized
+        );
     }
 }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/message/DetachedMessage.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/message/DetachedMessage.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.i18n.message;
 
 import org.dockbox.hartshorn.i18n.MessageReceiver;
 import org.dockbox.hartshorn.i18n.common.Language;
+import org.dockbox.hartshorn.i18n.common.Languages;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.text.Text;
 
@@ -72,6 +73,6 @@ public class DetachedMessage implements Message {
 
     @Override
     public Language language() {
-        return Language.EN_US;
+        return Languages.EN_US;
     }
 }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/message/MessageTemplate.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/message/MessageTemplate.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.i18n.MessageReceiver;
 import org.dockbox.hartshorn.i18n.ResourceService;
 import org.dockbox.hartshorn.i18n.common.Language;
+import org.dockbox.hartshorn.i18n.common.Languages;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.text.Text;
 import org.dockbox.hartshorn.core.HartshornUtils;
@@ -41,7 +42,7 @@ public class MessageTemplate implements Message, ContextCarrier {
     @Getter private final MessageFormatting formatting;
 
     public MessageTemplate(final ApplicationContext context, final String value, final String key) {
-        this(context, value, key, Language.EN_US);
+        this(context, value, key, Languages.EN_US);
     }
 
     public MessageTemplate(final ApplicationContext context, final String value, final String key, final Language language) {
@@ -87,7 +88,7 @@ public class MessageTemplate implements Message, ContextCarrier {
 
     @Override
     public Message translate() {
-        return this.translate(Language.EN_US);
+        return this.translate(Languages.EN_US);
     }
 
     @Override

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/MessageTemplateServiceTests.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/MessageTemplateServiceTests.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.i18n;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.i18n.common.Language;
+import org.dockbox.hartshorn.i18n.common.Languages;
 import org.dockbox.hartshorn.i18n.common.Message;
 import org.dockbox.hartshorn.i18n.message.MessageTemplate;
 import org.dockbox.hartshorn.testsuite.ApplicationAwareTest;
@@ -34,7 +35,7 @@ public class MessageTemplateServiceTests extends ApplicationAwareTest {
 
     private final ResourceService service = new ResourceServiceImpl() {
         static {
-            for (final Language value : Language.values()) bundles.put(value, createDemoBundle("Demo:" + value.code()));
+            for (final Language value : Languages.values()) bundles.put(value, createDemoBundle("Demo:" + value.code()));
         }
 
         @Override
@@ -86,7 +87,7 @@ public class MessageTemplateServiceTests extends ApplicationAwareTest {
         Assertions.assertTrue(demo.present());
 
         final Message entry = demo.get();
-        final Message formatted = entry.translate(Language.NL_NL);
+        final Message formatted = entry.translate(Languages.NL_NL);
 
         Assertions.assertNotSame(entry, formatted);
     }
@@ -97,7 +98,7 @@ public class MessageTemplateServiceTests extends ApplicationAwareTest {
         Assertions.assertTrue(demo.present());
 
         final MessageReceiver mock = Mockito.mock(MessageReceiver.class);
-        Mockito.when(mock.language()).thenReturn(Language.NL_NL);
+        Mockito.when(mock.language()).thenReturn(Languages.NL_NL);
 
         final Message entry = demo.get();
         final Message formatted = entry.translate(mock);
@@ -117,7 +118,7 @@ public class MessageTemplateServiceTests extends ApplicationAwareTest {
         final Exceptional<Message> demo = this.service.get("demo");
         Assertions.assertTrue(demo.present());
         final Message entry = demo.get();
-        for (final Language value : Language.values()) {
+        for (final Language value : Languages.values()) {
             Assertions.assertEquals("Demo:" + value.code(), entry.translate(value).plain());
         }
     }


### PR DESCRIPTION
Fixes #450
- [x] Breaking change

# Motivation
Currently the `Language` definition in the [Language](https://github.com/GuusLieben/Hartshorn/blob/566beff8656ddcb59967e2883a090465c4621453/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/common/Language.java) enum is entirely static, with no option for developers to extend this with their own languages or dialects.  

# Changes
Separates the `Language` enum into a reusable `Language` interface and renamed the enum to `Languages`. Usages have been updated accordingly.  

This PR is in preparation of #449.