### PR TITLE
#468 Resolve incorrect `application/json` content-type, will now resolve based on mapping format or write as `text/plain`

### DIFF
--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -93,12 +93,13 @@ public class ServletHandler implements AttributeHolder {
                     this.context.log().debug("Request %s processed for session %s, writing response body".formatted(request, sessionId));
                     try {
                         res.setStatus(HttpStatus.OK_200);
-                        res.setContentType("application/json");
                         if (String.class.equals(result.type())) {
+                            res.setContentType("text/plain");
                             this.context.log().debug("Returning plain body for request %s".formatted(request));
                             res.getWriter().print(result.get());
                         }
                         else {
+                            res.setContentType("application/" + this.mapper.fileType().extension());
                             this.context.log().debug("Writing body to string for request %s".formatted(request));
                             final Exceptional<String> write = this.mapper.write(result.get());
                             if (write.present()) {


### PR DESCRIPTION
Fixes #468

# Motivation
When returning a string value through a `RestController` service, the underlying `ServletHandler` correctly skips object mapping and directly writes the result to the response writer. However it always sets the content type to `application/json`.  

This leads to potential incorrect handling of the returned values. For example Rest clients like Insomnia assume spaces are invalid in visual previews, and thus the message `Hello world` becomes `Helloworld`.  

Additionally, when the object _is_ mapped, the content type is always `application/json`, even if the value is mapped to e.g. xml.

https://github.com/GuusLieben/Hartshorn/blob/c635bee574db25db465c1803f9608194186e4a83/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java#L96

# Changes
The content type is now determined based on the configured `FileType` in the requested `ObjectMapper`. If the return type is a `String` type, ensuring object mapping is skipped, the content type will be set to `text/plain`.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Integration testing

**Test Configuration**:
* Platform: Insomnia/HTTP client
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
