### PR TITLE
#467 Common parameter loader for shared and extensible parameter processing logic

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandContextParameterRule.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandContextParameterRule.java
@@ -25,12 +25,12 @@ import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
 public class CommandContextParameterRule implements ParameterLoaderRule<CommandParameterLoaderContext> {
 
     @Override
-    public boolean accepts(ParameterContext<?> parameter, CommandParameterLoaderContext context, Object... args) {
+    public boolean accepts(final ParameterContext<?> parameter, final CommandParameterLoaderContext context, final Object... args) {
         return TypeContext.of(context.commandContext()).childOf(parameter.type());
     }
 
     @Override
-    public <T> Exceptional<T> load(ParameterContext<T> parameter, CommandParameterLoaderContext context, Object... args) {
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final CommandParameterLoaderContext context, final Object... args) {
         return Exceptional.of((T) context.commandContext());
     }
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandContextParameterRule.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandContextParameterRule.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.commands.arguments;
+
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+
+public class CommandContextParameterRule implements ParameterLoaderRule<CommandParameterLoaderContext> {
+
+    @Override
+    public boolean accepts(ParameterContext<?> parameter, CommandParameterLoaderContext context, Object... args) {
+        return TypeContext.of(context.commandContext()).childOf(parameter.type());
+    }
+
+    @Override
+    public <T> Exceptional<T> load(ParameterContext<T> parameter, CommandParameterLoaderContext context, Object... args) {
+        return Exceptional.of((T) context.commandContext());
+    }
+}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoader.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoader.java
@@ -17,7 +17,10 @@
 
 package org.dockbox.hartshorn.commands.arguments;
 
+import org.dockbox.hartshorn.commands.context.CommandParameterContext;
+import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 
@@ -29,5 +32,12 @@ public class CommandParameterLoader extends RuleBasedParameterLoader<CommandPara
     public CommandParameterLoader() {
         this.add(new CommandContextParameterRule());
         this.add(new CommandSubjectParameterRule());
+    }
+
+    @Override
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final int index, final CommandParameterLoaderContext context, final Object... args) {
+        final CommandParameterContext parameterContext = HartshornUtils.asList(context.executorContext().parameters().values()).get(index);
+        final Object out = context.commandContext().get(parameterContext.parameter().name());
+        return out == null ? super.loadDefault(parameter, index, context, args) : (T) out;
     }
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoader.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoader.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.commands.arguments;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
+
+import javax.inject.Named;
+
+@Binds(value = ParameterLoader.class, named = @Named("command_loader"))
+public class CommandParameterLoader extends RuleBasedParameterLoader<CommandParameterLoaderContext> {
+
+    public CommandParameterLoader() {
+        this.add(new CommandContextParameterRule());
+        this.add(new CommandSubjectParameterRule());
+    }
+}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoaderContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoaderContext.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.commands.arguments;
+
+import org.dockbox.hartshorn.commands.context.CommandContext;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+
+import lombok.Getter;
+
+public class CommandParameterLoaderContext extends ParameterLoaderContext {
+
+    @Getter
+    private final CommandContext commandContext;
+
+    public CommandParameterLoaderContext(MethodContext<?, ?> method, TypeContext<?> type, Object instance, ApplicationContext applicationContext, CommandContext commandContext) {
+        super(method, type, instance, applicationContext);
+        this.commandContext = commandContext;
+    }
+}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoaderContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoaderContext.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.commands.arguments;
 
 import org.dockbox.hartshorn.commands.context.CommandContext;
+import org.dockbox.hartshorn.commands.context.MethodCommandExecutorContext;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -29,9 +30,13 @@ public class CommandParameterLoaderContext extends ParameterLoaderContext {
 
     @Getter
     private final CommandContext commandContext;
+    @Getter
+    private final MethodCommandExecutorContext<?> executorContext;
 
-    public CommandParameterLoaderContext(MethodContext<?, ?> method, TypeContext<?> type, Object instance, ApplicationContext applicationContext, CommandContext commandContext) {
+    public CommandParameterLoaderContext(final MethodContext<?, ?> method, final TypeContext<?> type, final Object instance, final ApplicationContext applicationContext, final CommandContext commandContext,
+                                         final MethodCommandExecutorContext<?> executorContext) {
         super(method, type, instance, applicationContext);
         this.commandContext = commandContext;
+        this.executorContext = executorContext;
     }
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandSubjectParameterRule.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandSubjectParameterRule.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.commands.arguments;
+
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+
+public class CommandSubjectParameterRule implements ParameterLoaderRule<CommandParameterLoaderContext> {
+    @Override
+    public boolean accepts(ParameterContext<?> parameter, CommandParameterLoaderContext context, Object... args) {
+        return TypeContext.of(context.commandContext().source()).childOf(parameter.type());
+    }
+
+    @Override
+    public <T> Exceptional<T> load(ParameterContext<T> parameter, CommandParameterLoaderContext context, Object... args) {
+        return null;
+    }
+}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandSubjectParameterRule.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandSubjectParameterRule.java
@@ -24,12 +24,12 @@ import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
 
 public class CommandSubjectParameterRule implements ParameterLoaderRule<CommandParameterLoaderContext> {
     @Override
-    public boolean accepts(ParameterContext<?> parameter, CommandParameterLoaderContext context, Object... args) {
+    public boolean accepts(final ParameterContext<?> parameter, final CommandParameterLoaderContext context, final Object... args) {
         return TypeContext.of(context.commandContext().source()).childOf(parameter.type());
     }
 
     @Override
-    public <T> Exceptional<T> load(ParameterContext<T> parameter, CommandParameterLoaderContext context, Object... args) {
-        return null;
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final CommandParameterLoaderContext context, final Object... args) {
+        return Exceptional.of((T) context.commandContext());
     }
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
@@ -17,27 +17,30 @@
 
 package org.dockbox.hartshorn.commands.context;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.domain.Subject;
-import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.commands.CommandExecutor;
 import org.dockbox.hartshorn.commands.CommandParser;
 import org.dockbox.hartshorn.commands.CommandResources;
 import org.dockbox.hartshorn.commands.CommandSource;
 import org.dockbox.hartshorn.commands.annotations.Command;
+import org.dockbox.hartshorn.commands.arguments.CommandParameterLoaderContext;
 import org.dockbox.hartshorn.commands.definition.CommandElement;
 import org.dockbox.hartshorn.commands.events.CommandEvent;
 import org.dockbox.hartshorn.commands.events.CommandEvent.Before;
+import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.binding.Bindings;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.DefaultCarrierContext;
 import org.dockbox.hartshorn.core.context.element.AnnotatedElementContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.exceptions.Except;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.events.annotations.Posting;
 import org.dockbox.hartshorn.events.parents.Cancellable;
 import org.dockbox.hartshorn.i18n.Message;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
@@ -45,7 +48,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -68,6 +70,7 @@ public class MethodCommandExecutorContext<T> extends DefaultCarrierContext imple
 
     @Getter(AccessLevel.NONE)
     private Map<String, CommandParameterContext> parameters;
+    private final ParameterLoader<CommandParameterLoaderContext> parameterLoader;
 
     public MethodCommandExecutorContext(final ApplicationContext context, final MethodContext<?, T> method, final TypeContext<T> type) {
         super(context);
@@ -98,9 +101,10 @@ public class MethodCommandExecutorContext<T> extends DefaultCarrierContext imple
             this.parentAliases.addAll(HartshornUtils.asList(this.parent.value()));
         }
         this.parameters = this.parameters();
+        this.parameterLoader = context.get(Key.of(ParameterLoader.class, Bindings.named("command_loader")));
     }
 
-    private Map<String, CommandParameterContext> parameters() {
+    public Map<String, CommandParameterContext> parameters() {
         if (this.parameters == null) {
             this.parameters = HartshornUtils.emptyMap();
             final LinkedList<ParameterContext<?>> parameters = this.method().parameters();
@@ -125,7 +129,8 @@ public class MethodCommandExecutorContext<T> extends DefaultCarrierContext imple
             }
 
             final T instance = this.applicationContext().get(this.type());
-            final List<Object> arguments = this.arguments(ctx);
+            final CommandParameterLoaderContext loaderContext = new CommandParameterLoaderContext(this.method(), this.type(), null, this.applicationContext(), ctx, this);
+            final List<Object> arguments = this.parameterLoader().loadArguments(loaderContext);
             this.applicationContext().log().debug("Invoking command method %s with %d arguments".formatted(this.method().qualifiedName(), arguments.size()));
             this.method().invoke(instance, arguments.toArray()).caught(error -> Except.handle("Encountered unexpected error while performing command executor", error));
             new CommandEvent.After(ctx.source(), ctx).with(this.applicationContext()).post();
@@ -215,23 +220,5 @@ public class MethodCommandExecutorContext<T> extends DefaultCarrierContext imple
             else if (command.startsWith(alias + ' ')) command = command.substring(alias.length() + 1);
         }
         return command;
-    }
-
-    private List<Object> arguments(final CommandContext context) {
-        final List<Object> arguments = HartshornUtils.list(this.parameters().size());
-        final Map<String, CommandParameterContext> parameters = this.parameters();
-
-        for (final Entry<String, CommandParameterContext> entry : parameters.entrySet()) {
-            final CommandParameterContext commandParameterContext = entry.getValue();
-            final int index = commandParameterContext.index();
-            if (commandParameterContext.is(CommandContext.class)) arguments.set(index, context);
-            else {
-                @Nullable final Object object = context.get(entry.getKey());
-                // Target comparison is done last as this can target either the command source, or a parameter target
-                if (object == null && commandParameterContext.is(Subject.class)) arguments.set(index, context.source());
-                else arguments.set(index, object);
-            }
-        }
-        return arguments;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ParameterLoaderContext.java
@@ -1,0 +1,16 @@
+package org.dockbox.hartshorn.core.context;
+
+import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ParameterLoaderContext extends DefaultContext implements ContextCarrier {
+    private final MethodContext<?, ?> method;
+    private final TypeContext<?> type;
+    private final Object instance;
+    private final ApplicationContext applicationContext;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyInjectionService.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyInjectionService.java
@@ -32,7 +32,8 @@ public class ProxyInjectionService {
 
     @PostBootstrap
     public void prepareInjectionPoints(final ApplicationContext context) {
-        ProxyableBootstrap.boostrapDelegates(context);
+        final ProxyableBootstrap proxyableBootstrap = context.get(ProxyableBootstrap.class);
+        proxyableBootstrap.boostrapDelegates(context);
         context.add(InjectionPoint.of(TypeContext.of(Object.class), (instance, type, properties) -> {
             final ProxyHandler<Object> handler = context.environment().application().handler(type, instance);
             boolean proxy = false;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/AnnotatedParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/AnnotatedParameterLoaderRule.java
@@ -1,0 +1,16 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+
+import java.lang.annotation.Annotation;
+
+public abstract class AnnotatedParameterLoaderRule<A extends Annotation, C extends ParameterLoaderContext> implements ParameterLoaderRule<C>{
+
+    protected abstract Class<A> annotation();
+
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final C context, final Object... args) {
+        return parameter.annotation(this.annotation()).present();
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/GlobalProxyParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/GlobalProxyParameterLoader.java
@@ -1,0 +1,27 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.annotations.proxy.Instance;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.MethodContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Named;
+
+@Binds(value = ParameterLoader.class, named = @Named("global_proxy"))
+public class GlobalProxyParameterLoader extends ParameterLoader<ParameterLoaderContext> {
+
+    @Override
+    public List<Object> loadArguments(final ParameterLoaderContext context, final Object... args) {
+        final MethodContext<?, ?> method = context.method();
+        final List<Object> arguments = HartshornUtils.emptyList();
+        if (method.parameterCount() >= 1 && method.parameters().get(0).annotation(Instance.class).present()) {
+            arguments.add(context.instance());
+        }
+        arguments.addAll(Arrays.asList(args));
+        return arguments;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ParameterLoader.java
@@ -1,0 +1,12 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class ParameterLoader<C extends ParameterLoaderContext> {
+    public abstract List<Object> loadArguments(C context, Object... args);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ParameterLoaderRule.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+public interface ParameterLoaderRule<C extends ParameterLoaderContext> {
+    boolean accepts(ParameterContext<?> parameter, C context, Object... args);
+    <T> Exceptional<T> load(ParameterContext<T> parameter, C context, Object... args);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
@@ -5,6 +5,7 @@ import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -20,8 +21,10 @@ public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends 
     @Override
     public List<Object> loadArguments(final C context, final Object... args) {
         final List<Object> arguments = HartshornUtils.emptyList();
+        final LinkedList<ParameterContext<?>> parameters = context.method().parameters();
         parameters:
-        for (final ParameterContext<?> parameter : context.method().parameters()) {
+        for (int i = 0; i < parameters.size(); i++) {
+            final ParameterContext<?> parameter = parameters.get(i);
             for (final ParameterLoaderRule<C> rule : this.rules) {
                 if (rule.accepts(parameter, context, args)) {
                     final Exceptional<Object> argument = rule.load((ParameterContext<Object>) parameter, context, args);
@@ -29,12 +32,12 @@ public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends 
                     continue parameters;
                 }
             }
-            arguments.add(this.loadDefault(parameter, context, args));
+            arguments.add(this.loadDefault(parameter, i, context, args));
         }
         return arguments;
     }
 
-    protected <T> T loadDefault(final ParameterContext<T> parameter, final C context, final Object... args) {
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final int index, final C context, final Object... args) {
         return parameter.type().defaultOrNull();
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
@@ -29,8 +29,12 @@ public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends 
                     continue parameters;
                 }
             }
-            arguments.add(null);
+            arguments.add(this.loadDefault(parameter, context, args));
         }
         return arguments;
+    }
+
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final C context, final Object... args) {
+        return parameter.type().defaultOrNull();
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
@@ -1,0 +1,36 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+import java.util.List;
+import java.util.Set;
+
+public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends ParameterLoader<C>{
+
+    private final Set<ParameterLoaderRule<C>> rules = HartshornUtils.emptyConcurrentSet();
+
+    public RuleBasedParameterLoader add(final ParameterLoaderRule<C> rule) {
+        this.rules.add(rule);
+        return this;
+    }
+
+    @Override
+    public List<Object> loadArguments(final C context, final Object... args) {
+        final List<Object> arguments = HartshornUtils.emptyList();
+        parameters:
+        for (final ParameterContext<?> parameter : context.method().parameters()) {
+            for (final ParameterLoaderRule<C> rule : this.rules) {
+                if (rule.accepts(parameter, context, args)) {
+                    final Exceptional<Object> argument = rule.load((ParameterContext<Object>) parameter, context, args);
+                    arguments.add(argument.orNull());
+                    continue parameters;
+                }
+            }
+            arguments.add(null);
+        }
+        return arguments;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
@@ -9,8 +9,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+
 public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends ParameterLoader<C>{
 
+    @Getter(AccessLevel.PROTECTED)
     private final Set<ParameterLoaderRule<C>> rules = HartshornUtils.emptyConcurrentSet();
 
     public RuleBasedParameterLoader add(final ParameterLoaderRule<C> rule) {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ParameterLoaderRules.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ParameterLoaderRules.java
@@ -1,0 +1,53 @@
+package org.dockbox.hartshorn.core;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.parameterloaders.RuleBasedParameterLoaderImpl;
+import org.dockbox.hartshorn.core.parameterloaders.StringParameterRule;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ParameterLoaderRules {
+
+    @Test
+    void testRuleBasedParameterLoadersCannotHaveDuplicateRules() {
+        final RuleBasedParameterLoaderImpl parameterLoader = new RuleBasedParameterLoaderImpl();
+        final ParameterLoaderRule<ParameterLoaderContext> stringRule = new StringParameterRule();
+        parameterLoader.add(stringRule);
+        parameterLoader.add(stringRule);
+        Assertions.assertEquals(1, parameterLoader.rules().size());
+    }
+
+    @Test
+    void testRuleBasedParameterLoaderReturnsCorrectObjectsOrDefault() {
+        final RuleBasedParameterLoaderImpl parameterLoader = new RuleBasedParameterLoaderImpl();
+        parameterLoader.add(new StringParameterRule());
+        final MethodContext methodContext = Mockito.mock(MethodContext.class);
+        final ParameterContext stringParameter = Mockito.mock(ParameterContext.class);
+        Mockito.when(stringParameter.type()).thenReturn(TypeContext.of(String.class));
+
+        final ParameterContext intParameter = Mockito.mock(ParameterContext.class);
+        Mockito.when(intParameter.type()).thenReturn(TypeContext.of(int.class));
+
+        final LinkedList parameters = new LinkedList();
+        parameters.add(stringParameter);
+        parameters.add(intParameter);
+
+        Mockito.when(methodContext.parameters()).thenReturn(parameters);
+
+        final ParameterLoaderContext loaderContext = new ParameterLoaderContext(methodContext, null, null, null);
+        final List<Object> objects = parameterLoader.loadArguments(loaderContext);
+
+        Assertions.assertNotNull(objects);
+        Assertions.assertEquals(2, objects.size());
+        Assertions.assertEquals("JUnit", objects.get(0));
+        Assertions.assertEquals(0, objects.get(1)); // Default value for 'int', instead of the value being null
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/parameterloaders/RuleBasedParameterLoaderImpl.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/parameterloaders/RuleBasedParameterLoaderImpl.java
@@ -1,0 +1,14 @@
+package org.dockbox.hartshorn.core.parameterloaders;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
+
+import java.util.Set;
+
+public class RuleBasedParameterLoaderImpl extends RuleBasedParameterLoader<ParameterLoaderContext> {
+    @Override
+    public Set<ParameterLoaderRule<ParameterLoaderContext>> rules() {
+        return super.rules();
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/parameterloaders/StringParameterRule.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/parameterloaders/StringParameterRule.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.core.parameterloaders;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+
+public class StringParameterRule implements ParameterLoaderRule<ParameterLoaderContext> {
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final ParameterLoaderContext context, final Object... args) {
+        return parameter.type().is(String.class);
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final ParameterLoaderContext context, final Object... args) {
+        return Exceptional.of((T) "JUnit");
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -164,7 +164,7 @@ public class EventBusImpl implements EventBus {
             final Exceptional<Listener> annotation = method.annotation(Listener.class);
             if (annotation.present()) {
                 this.checkListenerMethod(method);
-                result.addAll(EventWrapperImpl.create(type, method, annotation.get().value().priority()));
+                result.addAll(EventWrapperImpl.create(this.context, type, method, annotation.get().value().priority()));
             }
         }
         return result;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoader.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoader.java
@@ -1,0 +1,14 @@
+package org.dockbox.hartshorn.events.handle;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
+
+import javax.inject.Named;
+
+@Binds(value = ParameterLoader.class, named = @Named("event_loader"))
+public class EventParameterLoader extends RuleBasedParameterLoader<EventParameterLoaderContext> {
+    public EventParameterLoader() {
+        this.add(new EventParameterRule());
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoaderContext.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoaderContext.java
@@ -1,0 +1,21 @@
+package org.dockbox.hartshorn.events.handle;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.events.parents.Event;
+
+import lombok.Getter;
+
+@Getter
+public class EventParameterLoaderContext extends ParameterLoaderContext {
+
+    private final Event event;
+
+    public EventParameterLoaderContext(final MethodContext<?, ?> method, final TypeContext<?> type, final Object instance,
+                                       final ApplicationContext applicationContext, final Event event) {
+        super(method, type, instance, applicationContext);
+        this.event = event;
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterRule.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterRule.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.events.handle;
+
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+
+public class EventParameterRule implements ParameterLoaderRule<EventParameterLoaderContext> {
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final EventParameterLoaderContext context, final Object... args) {
+        return TypeContext.of(context.event()).childOf(parameter.type());
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final EventParameterLoaderContext context, final Object... args) {
+        return Exceptional.of((T) context.event());
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventWrapperImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventWrapperImpl.java
@@ -18,10 +18,13 @@
 package org.dockbox.hartshorn.events.handle;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.binding.Bindings;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.Except;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.events.EventWrapper;
 import org.dockbox.hartshorn.events.parents.Event;
 import org.jetbrains.annotations.NotNull;
@@ -53,20 +56,30 @@ public final class EventWrapperImpl<T> implements Comparable<EventWrapperImpl<T>
         throw new AssertionError(); // ensures the comparator will never return 0 if the two wrapper
         // aren't equal
     };
-    @Getter private final TypeContext<T> listenerType;
+    @Getter private final ParameterLoader<EventParameterLoaderContext> parameterLoader;
     @Getter private final TypeContext<? extends Event> eventType;
     @Getter private final List<TypeContext<?>> eventParameters;
+    @Getter private final TypeContext<T> listenerType;
+    @Getter private final ApplicationContext context;
     @Getter private final MethodContext<?, T> method;
     @Getter private final int priority;
     @Getter private T listener;
 
-    private EventWrapperImpl(final TypeContext<T> type, final TypeContext<? extends Event> eventType, final MethodContext<?, T> method, final int priority) {
+    private EventWrapperImpl(
+            final ParameterLoader<EventParameterLoaderContext> parameterLoader,
+            final TypeContext<T> type,
+            final TypeContext<? extends Event> eventType,
+            final MethodContext<?, T> method,
+            final int priority,
+            final ApplicationContext context
+    ) {
+        this.context = context;
         this.listener = null; // Lazy loaded value
+        this.parameterLoader = parameterLoader;
         this.listenerType = type;
         this.eventType = eventType;
         this.method = method;
         this.priority = priority;
-
         this.eventParameters = method.parameters().get(0).typeParameters();
     }
 
@@ -83,11 +96,12 @@ public final class EventWrapperImpl<T> implements Comparable<EventWrapperImpl<T>
      *
      * @return The list of {@link EventWrapperImpl}s
      */
-    public static <T> List<EventWrapperImpl<T>> create(final TypeContext<T> type, final MethodContext<?, T> method, final int priority) {
+    public static <T> List<EventWrapperImpl<T>> create(final ApplicationContext context, final TypeContext<T> type, final MethodContext<?, T> method, final int priority) {
         final List<EventWrapperImpl<T>> invokeWrappers = HartshornUtils.emptyConcurrentList();
+        final ParameterLoader<EventParameterLoaderContext> parameterLoader = context.get(ParameterLoader.class, Bindings.named("event_loader"));
         for (final TypeContext<?> param : method.parameterTypes()) {
             if (param.childOf(Event.class)) {
-                invokeWrappers.add(new EventWrapperImpl<>(type, (TypeContext<? extends Event>) param, method, priority));
+                invokeWrappers.add(new EventWrapperImpl<>(parameterLoader, type, (TypeContext<? extends Event>) param, method, priority, context));
             }
         }
         return invokeWrappers;
@@ -100,7 +114,9 @@ public final class EventWrapperImpl<T> implements Comparable<EventWrapperImpl<T>
             event.applicationContext().log().debug("Invoking event " + eventName + " to method context of " + this.method.qualifiedName());
             // Lazy initialisation to allow processors to register first
             if (this.listener == null) this.listener = event.applicationContext().get(this.listenerType);
-            final Exceptional<?> result = this.method.invoke(this.listener, event);
+            final EventParameterLoaderContext loaderContext = new EventParameterLoaderContext(this.method, this.listenerType, this.listener, this.context, event);
+            final List<Object> arguments = this.parameterLoader().loadArguments(loaderContext);
+            final Exceptional<?> result = this.method.invoke(this.listener, arguments);
             if (result.caught()) {
                 Except.handle("Could not finish event runner for " + eventName, result.error());
             }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/DefaultHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/DefaultHttpWebServer.java
@@ -18,11 +18,14 @@
 package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.web.processing.BodyRequestArgumentProcessor;
-import org.dockbox.hartshorn.web.processing.HeaderRequestArgumentProcessor;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 import org.dockbox.hartshorn.web.processing.RequestArgumentProcessor;
 
 import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Named;
 
 import lombok.Getter;
 
@@ -31,13 +34,9 @@ public abstract class DefaultHttpWebServer implements HttpWebServer {
     @Getter
     private final Set<RequestArgumentProcessor<?>> processors = HartshornUtils.emptyConcurrentSet();
 
-    protected DefaultHttpWebServer() {
-        this.add(new BodyRequestArgumentProcessor());
-        this.add(new HeaderRequestArgumentProcessor());
-    }
+    @Inject
+    @Getter
+    @Named("http_webserver")
+    private ParameterLoader<HttpRequestParameterLoaderContext> loader;
 
-    @Override
-    public void add(final RequestArgumentProcessor<?> processor) {
-        this.processors().add(processor);
-    }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
@@ -18,13 +18,11 @@
 package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
-import org.dockbox.hartshorn.web.processing.RequestArgumentProcessor;
-
-import java.util.Set;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
 public interface HttpWebServer {
     void start(int port) throws ApplicationException;
     void register(RequestHandlerContext context);
-    void add(RequestArgumentProcessor<?> processor);
-    Set<RequestArgumentProcessor<?>> processors();
+    ParameterLoader<HttpRequestParameterLoaderContext> loader();
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpRequestParameterLoaderContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpRequestParameterLoaderContext.java
@@ -1,0 +1,24 @@
+package org.dockbox.hartshorn.web.processing;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.Getter;
+
+@Getter
+public class HttpRequestParameterLoaderContext extends ParameterLoaderContext {
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+
+    public HttpRequestParameterLoaderContext(final MethodContext<?, ?> method, final TypeContext<?> type, final Object instance, final ApplicationContext applicationContext, final HttpServletRequest request, final HttpServletResponse response) {
+        super(method, type, instance, applicationContext);
+        this.request = request;
+        this.response = response;
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
@@ -1,0 +1,22 @@
+package org.dockbox.hartshorn.web.processing;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
+import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
+import org.dockbox.hartshorn.web.processing.rules.HeaderRequestParameterRule;
+import org.dockbox.hartshorn.web.processing.rules.ServletRequestParameterRule;
+import org.dockbox.hartshorn.web.processing.rules.ServletResponseParameterRule;
+
+import javax.inject.Named;
+
+@Binds(value = ParameterLoader.class, named = @Named("http_webserver"))
+public class HttpServletParameterLoader extends RuleBasedParameterLoader<HttpRequestParameterLoaderContext> {
+
+    public HttpServletParameterLoader() {
+        this.add(new BodyRequestParameterRule());
+        this.add(new HeaderRequestParameterRule());
+        this.add(new ServletRequestParameterRule());
+        this.add(new ServletResponseParameterRule());
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
@@ -1,6 +1,7 @@
 package org.dockbox.hartshorn.web.processing;
 
 import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
@@ -18,5 +19,10 @@ public class HttpServletParameterLoader extends RuleBasedParameterLoader<HttpReq
         this.add(new HeaderRequestParameterRule());
         this.add(new ServletRequestParameterRule());
         this.add(new ServletResponseParameterRule());
+    }
+
+    @Override
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return context.applicationContext().get(parameter.type());
     }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
@@ -22,7 +22,7 @@ public class HttpServletParameterLoader extends RuleBasedParameterLoader<HttpReq
     }
 
     @Override
-    protected <T> T loadDefault(final ParameterContext<T> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final int index, final HttpRequestParameterLoaderContext context, final Object... args) {
         return context.applicationContext().get(parameter.type());
     }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/HeaderRequestParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/HeaderRequestParameterRule.java
@@ -15,37 +15,40 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.web.processing;
+package org.dockbox.hartshorn.web.processing.rules;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.AnnotatedParameterLoaderRule;
 import org.dockbox.hartshorn.web.annotations.RequestHeader;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-public class HeaderRequestArgumentProcessor implements RequestArgumentProcessor<RequestHeader> {
+public class HeaderRequestParameterRule extends AnnotatedParameterLoaderRule<RequestHeader, HttpRequestParameterLoaderContext> {
+
     @Override
     public Class<RequestHeader> annotation() {
         return RequestHeader.class;
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final ParameterContext<?> parameter, final HttpServletRequest request, final HttpServletResponse response) {
-        return RequestArgumentProcessor.super.preconditions(context, parameter, request, response)
-                && (parameter.type().childOf(String.class) || parameter.type().childOf(int.class) || parameter.type().childOf(long.class));
+    public boolean accepts(final ParameterContext<?> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return super.accepts(parameter, context, args) && (parameter.type().childOf(String.class) || parameter.type().childOf(int.class) || parameter.type().childOf(long.class));
     }
 
     @Override
-    public <T> Exceptional<T> process(final ApplicationContext context, final ParameterContext<T> parameter, final HttpServletRequest request, final HttpServletResponse response) {
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
         final RequestHeader requestHeader = parameter.annotation(RequestHeader.class).get();
+
+        final HttpServletRequest request = context.request();
 
         if (!request.getHeaders(requestHeader.value()).hasMoreElements()) return Exceptional.empty();
 
         if (parameter.type().is(String.class)) return Exceptional.of(() -> (T) request.getHeader(requestHeader.value()));
         else if (parameter.type().childOf(int.class)) return Exceptional.of(() -> request.getIntHeader(requestHeader.value())).map(v -> (T) v);
         else if (parameter.type().childOf(long.class)) return Exceptional.of(() -> request.getDateHeader(requestHeader.value())).map(v -> (T) v);
+
         return Exceptional.empty();
     }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/ServletRequestParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/ServletRequestParameterRule.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.web.processing.rules;
+
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
+
+public class ServletRequestParameterRule implements ParameterLoaderRule<HttpRequestParameterLoaderContext> {
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return TypeContext.of(context.request()).childOf(parameter.type());
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return Exceptional.of((T) context.request());
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/ServletResponseParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/ServletResponseParameterRule.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.web.processing.rules;
+
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
+
+public class ServletResponseParameterRule implements ParameterLoaderRule<HttpRequestParameterLoaderContext> {
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return TypeContext.of(context.response()).childOf(parameter.type());
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return Exceptional.of((T) context.response());
+    }
+}

--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
@@ -25,8 +25,9 @@ import org.dockbox.hartshorn.persistence.FileType;
 import org.dockbox.hartshorn.testsuite.ApplicationAwareTest;
 import org.dockbox.hartshorn.web.annotations.RequestHeader;
 import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
-import org.dockbox.hartshorn.web.processing.BodyRequestArgumentProcessor;
-import org.dockbox.hartshorn.web.processing.HeaderRequestArgumentProcessor;
+import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
+import org.dockbox.hartshorn.web.processing.rules.HeaderRequestParameterRule;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,7 +64,9 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
         final ParameterContext<String> context = Mockito.mock(ParameterContext.class);
         Mockito.when(context.type()).thenReturn(TypeContext.of(String.class));
 
-        final Exceptional<String> result = new BodyRequestArgumentProcessor().process(this.context(), context, request, null);
+        final HttpRequestParameterLoaderContext loaderContext = new HttpRequestParameterLoaderContext(null, null, null, this.context(), request, null);
+
+        final Exceptional<String> result = new BodyRequestParameterRule().load(context, loaderContext);
         Assertions.assertTrue(result.present());
         Assertions.assertEquals("Unparsed body", result.get());
     }
@@ -85,7 +88,9 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
         // Different order due to generic return type
         Mockito.doReturn(declaring).when(context).declaredBy();
 
-        final Exceptional<Message> result = new BodyRequestArgumentProcessor().process(this.context(), context, request, null);
+        final HttpRequestParameterLoaderContext loaderContext = new HttpRequestParameterLoaderContext(null, null, null, this.context(), request, null);
+
+        final Exceptional<Message> result = new BodyRequestParameterRule().load(context, loaderContext);
         Assertions.assertTrue(result.present());
         Assertions.assertEquals("Hello world!", result.get().message());
     }
@@ -101,7 +106,9 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
         Mockito.when(requestHeader.value()).thenReturn("string-header");
         Mockito.when(context.annotation(RequestHeader.class)).thenReturn(Exceptional.of(requestHeader));
 
-        final Exceptional<String> result = new HeaderRequestArgumentProcessor().process(this.context(), context, request, null);
+        final HttpRequestParameterLoaderContext loaderContext = new HttpRequestParameterLoaderContext(null, null, null, this.context(), request, null);
+
+        final Exceptional<String> result = new HeaderRequestParameterRule().load(context, loaderContext);
         Assertions.assertTrue(result.present());
         Assertions.assertEquals("Header!", result.get());
     }
@@ -117,7 +124,9 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
         Mockito.when(requestHeader.value()).thenReturn("int-header");
         Mockito.when(context.annotation(RequestHeader.class)).thenReturn(Exceptional.of(requestHeader));
 
-        final Exceptional<Integer> result = new HeaderRequestArgumentProcessor().process(this.context(), context, request, null);
+        final HttpRequestParameterLoaderContext loaderContext = new HttpRequestParameterLoaderContext(null, null, null, this.context(), request, null);
+
+        final Exceptional<Integer> result = new HeaderRequestParameterRule().load(context, loaderContext);
         Assertions.assertTrue(result.present());
         Assertions.assertEquals(1, result.get().intValue());
     }


### PR DESCRIPTION
Fixes #467
- [x] Breaking change

# Motivation
Currently there are four modules using four different ways of processing parameters for dynamic method invocation (excluding `MethodContext` invocation with a provided `ApplicationContext`):
- `hartshorn-commands` to invoke the command method
- `hartshorn-events` to invoke event methods
- `hartshorn-core` to invoke global proxy methods
- `hartshorn-web` to invoke servlet request handler methods

While this 'technically works', it is not optimal as it does not allow for proper extension and modification of how parameters are processed and injected.

# Changes
Adds a common `ParameterLoader` interface type, which defines one simple method: `loadArguments: List<Object>`. This interface can be used to implement different ways of processing parameters, shifting the responsibility to this interface rather than keeping it inside the module's invoker(s).  

There is one pre-existing partial implementation, a rule-based argument loader. In this loader each argument can be separately processed and added to a final list of arguments. Processing can then happen based on rules, for example whether a parameter is annotated or extends a certain type.  

To allow for full extensibility, the `ParameterLoader` accepts two things in the `loadArguments` method: 
1. An extensible context type, providing information about the method, the type it is in, the instance of the type if it exists, and the application context. This should be extensible so implementations can require additional information directly, e.g. Hartshorn Web can provide the `HttpServletRequest` and `HttpServletResponse`.
2. The raw arguments which may or may not exist beforehand.

The argument loaders for the following existing implementations have been migrated accordingly:
- Core: Global proxy method
- Web: Servlet request methods
- Events: Event wrapper methods
- Commands: Command methods

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
