### PR TITLE
#472 Deprecate `Attribute` and `AttributeHolder` for removal

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Enable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Enable.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface Enable {
     boolean enable() default true;
+    @Deprecated(since = "4.2.3", forRemoval = true)
     Class<? extends Attribute<?>>[] delegate() default {};
 }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/Bindings.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/Bindings.java
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.properties.Attribute;
 import org.dockbox.hartshorn.core.properties.AttributeHolder;
+import org.dockbox.hartshorn.core.properties.Enableable;
 import org.dockbox.hartshorn.core.services.ComponentContainer;
 import org.dockbox.hartshorn.core.HartshornUtils;
 
@@ -43,6 +44,9 @@ public final class Bindings {
         if (instance instanceof AttributeHolder injectable && injectable.canEnable()) {
             for (final Attribute<?> property : properties) injectable.apply(property);
             injectable.enable();
+        }
+        else if (instance instanceof Enableable enableable && enableable.canEnable()) {
+            enableable.enable();
         }
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/Attribute.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/Attribute.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.core.properties;
 
 @FunctionalInterface
+@Deprecated(since = "4.2.3", forRemoval = true)
 public interface Attribute<T> {
     T value();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/AttributeHolder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/AttributeHolder.java
@@ -19,16 +19,29 @@ package org.dockbox.hartshorn.core.properties;
 
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
+/**
+ * @deprecated Use {@link Enableable} instead.
+ */
+@Deprecated(since = "4.2.3", forRemoval = true)
 public interface AttributeHolder {
 
+    /**
+     * @deprecated Use {@link Enableable#enable()} instead.
+     */
+    @Deprecated(since = "4.2.3", forRemoval = false)
     default boolean canEnable() {
         return true;
     }
 
+    @Deprecated(since = "4.2.3", forRemoval = true)
     default void apply(final Attribute<?> property) throws ApplicationException {
         // Optional implementation provided by inheritor
     }
 
+    /**
+     * @deprecated Use {@link Enableable#enable()} instead.
+     */
+    @Deprecated(since = "4.2.3", forRemoval = false)
     default void enable() throws ApplicationException {
         // Optional implementation provided by inheritor
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/AttributeImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/AttributeImpl.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Deprecated(since = "4.2.3", forRemoval = true)
 public class AttributeImpl<T> implements Attribute<T> {
 
     private final T value;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/Enableable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/Enableable.java
@@ -1,0 +1,12 @@
+package org.dockbox.hartshorn.core.properties;
+
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+
+public interface Enableable {
+
+    default boolean canEnable() {
+        return true;
+    }
+
+    void enable() throws ApplicationException;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/UseFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/properties/UseFactory.java
@@ -17,6 +17,11 @@
 
 package org.dockbox.hartshorn.core.properties;
 
+/**
+ * @deprecated Will be replaced when <a href="https://github.com/GuusLieben/Hartshorn/issues/473">#473</a> is accepted.
+ * Also see <a href="https://github.com/GuusLieben/Hartshorn/issues/472">#472</a>
+ */
+@Deprecated(since = "4.2.3", forRemoval = true)
 public class UseFactory extends AttributeImpl<Object[]> {
     public UseFactory(final Object... use) {
         super(use);


### PR DESCRIPTION
Fixes #472

# Motivation and changes
`Attribute`s, and the associated `AttributeHolder` remain as a obscure part of Hartshorn. It allows for unchecked actions, and can fail hard if an implementation decides information is strictly required. As the current factory construction of types depends on attributes, I proposed #473 as a potential solution to its removal.
Do note that `AttributeHolder` also defines `enable()`, this method has been moved to `Enableable`. Deprecation descriptions link to the new interface and `Bindings.enable` has been updated accordingly.