### PR TITLE
#490 Automatic activation of component- processors and modifiers

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodModifier.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.cache.modifiers;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.cache.annotations.EvictCache;
@@ -33,6 +34,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
  * decorated methods. This delegates functionality to the underlying {@link org.dockbox.hartshorn.cache.CacheManager}
  * to evict specific {@link org.dockbox.hartshorn.cache.Cache caches}.
  */
+@AutomaticActivation
 public class CacheEvictionMethodModifier extends CacheServiceModifier<EvictCache> {
 
     @Override

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServiceModifier.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServiceModifier.java
@@ -17,7 +17,6 @@
 
 package org.dockbox.hartshorn.cache.modifiers;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.cache.Cache;
 import org.dockbox.hartshorn.cache.CacheManager;
 import org.dockbox.hartshorn.cache.Expiration;
@@ -28,8 +27,9 @@ import org.dockbox.hartshorn.cache.context.CacheContextImpl;
 import org.dockbox.hartshorn.cache.context.CacheMethodContext;
 import org.dockbox.hartshorn.core.binding.Bindings;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodModifier;
 
 import java.lang.annotation.Annotation;

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodModifier.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.cache.modifiers;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.cache.annotations.UpdateCache;
@@ -33,6 +34,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
  * decorated methods. This delegates functionality to the underlying {@link org.dockbox.hartshorn.cache.CacheManager}
  * to update specific {@link org.dockbox.hartshorn.cache.Cache caches}.
  */
+@AutomaticActivation
 public class CacheUpdateMethodModifier extends CacheServiceModifier<UpdateCache> {
 
     @Override

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodModifier.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.cache.modifiers;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.Except;
@@ -36,6 +37,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
  * decorated methods. This delegates functionality to the underlying {@link org.dockbox.hartshorn.cache.CacheManager}
  * to store or obtain {@link Cache} entries.
  */
+@AutomaticActivation
 public class CachedMethodModifier extends CacheServiceModifier<Cached> {
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServiceProcessor.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServiceProcessor.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.commands.service;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
@@ -35,6 +36,7 @@ import java.util.List;
  * the {@link ArgumentConverterContext} contained in the {@link ApplicationContext}. Requires
  * the presence of {@link UseCommands}.
  */
+@AutomaticActivation
 public class ArgumentServiceProcessor implements ServiceProcessor<UseCommands> {
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameters.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.commands.service;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.boot.ApplicationManager;
 import org.dockbox.hartshorn.core.annotations.UseBootstrap;
 import org.dockbox.hartshorn.commands.annotations.Parameter;
@@ -35,6 +36,7 @@ import org.dockbox.hartshorn.core.services.ServiceOrder;
  * for each type found. Requires the use of a {@link ApplicationManager} and
  * presence of {@link UseBootstrap}.
  */
+@AutomaticActivation
 public class CommandParameters implements ComponentProcessor<UseCommands> {
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandServiceScanner.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandServiceScanner.java
@@ -20,10 +20,12 @@ package org.dockbox.hartshorn.commands.service;
 import org.dockbox.hartshorn.commands.CommandGateway;
 import org.dockbox.hartshorn.commands.annotations.Command;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServiceProcessor;
 
+@AutomaticActivation
 public class CommandServiceScanner implements ServiceProcessor<UseCommands> {
 
     @Override

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceModifier.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceModifier.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.config;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
 import org.dockbox.hartshorn.config.annotations.Value;
 import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.boot.Hartshorn;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.FieldContext;
@@ -38,6 +39,7 @@ import java.util.Set;
 /**
  * Looks up and populates fields annotated with {@link Value}.
  */
+@AutomaticActivation
 public class ConfigurationServiceModifier implements InjectionModifier<UseConfigurations> {
 
     @Override

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceProcessor.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.config;
 
 import org.dockbox.hartshorn.config.annotations.Configuration;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServiceOrder;
@@ -40,6 +41,7 @@ import java.util.regex.Pattern;
  * in the format {@code strategy_name:source_name}. If a strategy is not registered, or no name is defined, behavior
  * defaults to {@link FileSystemLookupStrategy}.
  */
+@AutomaticActivation
 public class ConfigurationServiceProcessor implements ServiceProcessor<UseConfigurations> {
 
     private static final Pattern STRATEGY_PATTERN = Pattern.compile("(.+):(.+)");

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/service/AutomaticActivation.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/service/AutomaticActivation.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.core.annotations.service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AutomaticActivation {
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationFactory.java
@@ -22,7 +22,9 @@ import org.dockbox.hartshorn.core.Modifier;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.inject.InjectionModifier;
 import org.dockbox.hartshorn.core.services.ComponentLocator;
+import org.dockbox.hartshorn.core.services.ComponentProcessor;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
@@ -53,6 +55,10 @@ public interface ApplicationFactory<Self extends ApplicationFactory<Self, C>, C 
     Self applicationEnvironment(Function<ApplicationManager, ApplicationEnvironment> applicationEnvironment);
 
     Self componentLocator(Function<ApplicationContext, ComponentLocator> componentLocator);
+
+    Self injectionModifier(InjectionModifier<?> modifier);
+
+    Self componentProcessor(ComponentProcessor<?> processor);
 
     Self prefix(String prefix);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -35,6 +35,7 @@ import org.dockbox.hartshorn.core.annotations.inject.Binds;
 import org.dockbox.hartshorn.core.annotations.inject.Combines;
 import org.dockbox.hartshorn.core.annotations.inject.Context;
 import org.dockbox.hartshorn.core.annotations.inject.Enable;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.service.ServiceActivator;
 import org.dockbox.hartshorn.core.binding.BindingHierarchy;
 import org.dockbox.hartshorn.core.binding.Bindings;
@@ -599,9 +600,11 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         for (final TypeContext<? extends T> child : children) {
             if (child.isAbstract()) continue;
 
-            final T raw = this.raw(child, false);
-            if (this.hasActivator(raw.activator()))
-                consumer.accept(this, raw);
+            if (child.annotation(AutomaticActivation.class).present()) {
+                final T raw = this.raw(child, false);
+                if (this.hasActivator(raw.activator()))
+                    consumer.accept(this, raw);
+            }
         }
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionProcessor.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core.services;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.annotations.inject.Context;
 import org.dockbox.hartshorn.core.annotations.service.Service;
@@ -32,6 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@AutomaticActivation
 public class ComponentContextInjectionProcessor extends ComponentValidator<Service>{
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextCarrierDelegationModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextCarrierDelegationModifier.java
@@ -17,9 +17,11 @@
 
 package org.dockbox.hartshorn.core.services;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.service.Service;
 import org.dockbox.hartshorn.core.context.ContextCarrier;
 
+@AutomaticActivation
 public class ContextCarrierDelegationModifier extends ProxyDelegationModifier<ContextCarrier, Service> {
     @Override
     public Class<Service> activator() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextMethodModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextMethodModifier.java
@@ -19,11 +19,13 @@ package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.annotations.proxy.Provided;
 import org.dockbox.hartshorn.core.annotations.proxy.UseProxying;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.binding.Bindings;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 
+@AutomaticActivation
 public class ContextMethodModifier extends ServiceAnnotatedMethodModifier<Provided, UseProxying> {
     @Override
     public Class<UseProxying> activator() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/DelegatorAccessorDelegationModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/DelegatorAccessorDelegationModifier.java
@@ -18,11 +18,13 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.annotations.proxy.UseProxying;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.proxy.DelegatorAccessor;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 
+@AutomaticActivation
 public class DelegatorAccessorDelegationModifier extends ProxyDelegationModifier<DelegatorAccessor, UseProxying> {
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServiceModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServiceModifier.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.annotations.Factory;
 import org.dockbox.hartshorn.core.annotations.inject.Enable;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.service.Service;
 import org.dockbox.hartshorn.core.binding.Bindings;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -29,6 +30,7 @@ import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 
+@AutomaticActivation
 public class FactoryServiceModifier extends ServiceAnnotatedMethodModifier<Factory, Service> {
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServiceProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServiceProcessor.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core.services;
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.Factory;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.service.Service;
 import org.dockbox.hartshorn.core.binding.Bindings;
 import org.dockbox.hartshorn.core.binding.ContextDrivenProvider;
@@ -33,6 +34,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import java.util.LinkedList;
 import java.util.Set;
 
+@AutomaticActivation
 public class FactoryServiceProcessor implements ServiceProcessor<Service> {
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/LifecycleObserverProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/LifecycleObserverProcessor.java
@@ -18,10 +18,12 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.annotations.UseBootstrap;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.boot.LifecycleObserver;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
+@AutomaticActivation
 public class LifecycleObserverProcessor implements ServiceProcessor<UseBootstrap> {
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServiceProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServiceProcessor.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core.services;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.binding.Bindings;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -28,6 +29,7 @@ import org.dockbox.hartshorn.core.inject.ProviderContext;
 
 import java.util.List;
 
+@AutomaticActivation
 public final class ProviderServiceProcessor implements ServiceProcessor<UseServiceProvision> {
 
     @Override

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/DemoProxyDelegationModifier.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/DemoProxyDelegationModifier.java
@@ -17,9 +17,11 @@
 
 package org.dockbox.hartshorn.core.proxy;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.service.Service;
 import org.dockbox.hartshorn.core.services.ProxyDelegationModifier;
 
+@AutomaticActivation
 public class DemoProxyDelegationModifier extends ProxyDelegationModifier<AbstractProxyParent, Service> {
     @Override
     public Class<Service> activator() {

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventServiceProcessor.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventServiceProcessor.java
@@ -17,12 +17,14 @@
 
 package org.dockbox.hartshorn.events;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServiceProcessor;
 import org.dockbox.hartshorn.events.annotations.Listener;
 import org.dockbox.hartshorn.events.annotations.UseEvents;
 
+@AutomaticActivation
 public class EventServiceProcessor implements ServiceProcessor<UseEvents> {
     @Override
     public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/LanguageProviderServiceProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/LanguageProviderServiceProcessor.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.i18n.services;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -27,6 +28,7 @@ import org.dockbox.hartshorn.i18n.TranslationService;
 import org.dockbox.hartshorn.i18n.annotations.TranslationProvider;
 import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
 
+@AutomaticActivation
 public class LanguageProviderServiceProcessor implements ServiceProcessor<UseTranslations> {
 
     @Override

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectModifier.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectModifier.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.i18n.services;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.MetaProvider;
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -32,6 +33,7 @@ import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodModifier;
 
+@AutomaticActivation
 public class TranslationInjectModifier extends ServiceAnnotatedMethodModifier<InjectTranslation, UseTranslations> {
 
     @Override

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/DeserialisationServiceModifier.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/DeserialisationServiceModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.persistence.service;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -31,6 +32,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import java.io.File;
 import java.nio.file.Path;
 
+@AutomaticActivation
 public class DeserialisationServiceModifier extends AbstractPersistenceServiceModifier<Deserialise, DeserialisationContext> {
 
     @Override

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/JpaRepositoryDelegationModifier.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/JpaRepositoryDelegationModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.persistence.service;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
@@ -24,6 +25,7 @@ import org.dockbox.hartshorn.core.services.ProxyDelegationModifier;
 import org.dockbox.hartshorn.persistence.JpaRepository;
 import org.dockbox.hartshorn.persistence.annotations.UsePersistence;
 
+@AutomaticActivation
 public class JpaRepositoryDelegationModifier extends ProxyDelegationModifier<JpaRepository, UsePersistence> {
     @Override
     public Class<UsePersistence> activator() {

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/QueryModifier.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/QueryModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.persistence.service;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -37,6 +38,7 @@ import org.dockbox.hartshorn.persistence.context.QueryContext;
 import java.util.Collection;
 import java.util.List;
 
+@AutomaticActivation
 public class QueryModifier extends ServiceAnnotatedMethodModifier<Query, UsePersistence> {
 
     @Override

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/SerialisationServiceModifier.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/SerialisationServiceModifier.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.persistence.service;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -33,6 +34,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import java.io.File;
 import java.nio.file.Path;
 
+@AutomaticActivation
 public class SerialisationServiceModifier extends AbstractPersistenceServiceModifier<Serialise, SerialisationContext> {
 
     @Override

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RestControllerProcessor.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RestControllerProcessor.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.web;
 
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -24,6 +25,7 @@ import org.dockbox.hartshorn.core.services.ServiceProcessor;
 import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
 import org.dockbox.hartshorn.web.annotations.UseHttpServer;
 
+@AutomaticActivation
 public class RestControllerProcessor implements ServiceProcessor<UseHttpServer> {
     @Override
     public Class<UseHttpServer> activator() {


### PR DESCRIPTION
Fixes #490
- [x] Breaking change (when using custom processors and/or modifiers only)

# Motivation
Currently all component- processors and modifiers are automatically activated when their activator is present. However in some cases it may be preferred to activate these handlers manually and/or programmatically.

# Changes
Adds a new way of marking automatically active processors and modifiers, annotating them with `@AutomaticActivation`. `HartshornApplicationContext#lookupActivatables()` will filter for this annotation on lookup, and will only register automatically active processors and modifiers.  
Additionally, it is now possible to register processors and modifiers through a `ApplicationFactory`, without the need of their official activator.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: Corretto 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
