### PR TITLE
#494 Resolve asynchronous access to thread-locked Scanner object in CommandCLI

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/cli/SimpleCommandCLI.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/cli/SimpleCommandCLI.java
@@ -39,61 +39,65 @@ import lombok.Setter;
 @Binds(CommandCLI.class)
 public class SimpleCommandCLI implements CommandCLI {
 
-    @Inject private ApplicationContext context;
-    @Inject private CommandGateway gateway;
-    @Inject private ThreadUtils threads;
+    @Inject
+    private ApplicationContext context;
+    @Inject
+    private CommandGateway gateway;
+    @Inject
+    private ThreadUtils threads;
 
-    @Getter @Setter
+    @Getter
+    @Setter
     private boolean async = false;
-    @Getter @Setter
+    @Getter
+    @Setter
     private InputStream input = System.in;
     @Setter
     private CommandSource source;
 
     @Override
     public void open() {
-        try (
-                final InputStream input = this.input();
-                final Scanner scanner = new Scanner(input)
-        ) {
-            final Runnable task = () -> {
+        final Runnable task = () -> {
+            try (
+                    final InputStream input = this.input();
+                    final Scanner scanner = new Scanner(input)
+            ) {
                 this.context.log().debug("Starting command CLI input listener");
                 while (this.running()) {
                     final String next = scanner.nextLine();
                     try {
                         this.gateway.accept(this.source(), next);
-                    }
-                    catch (final ParsingException e) {
+                    } catch (final ParsingException e) {
                         Except.handle(e);
                     }
                 }
-            };
+            } catch (final IOException e) {
+                Except.handle(e);
+            }
+        };
 
-            if (this.async()) {
-                this.context.log().debug("Performing startup task for command CLI asynchronously");
-                this.threads.performAsync(task);
-            }
-            else {
-                this.context.log().debug("Performing startup task for command CLI on current thread");
-                task.run();
-            }
-        }
-        catch (final IOException e) {
-            Except.handle(e);
+        if (this.async()) {
+            this.context.log().debug("Performing startup task for command CLI asynchronously");
+            this.threads.performAsync(task);
+        } else {
+            this.context.log().debug("Performing startup task for command CLI on current thread");
+            task.run();
         }
     }
 
     /**
-     * Indicates whether the command input is still active. If this method returns {@code false} the CLI closes.
-     * @return Whether to keep the CLI alive.
+     Indicates whether the command input is still active. If this method returns {@code false} the CLI closes.
+
+     @return Whether to keep the CLI alive.
      */
     protected boolean running() {
         return true;
     }
 
     /**
-     * Gets the {@link CommandSource} which is used to execute commands for the current CLI session.
-     * @return The source to execute commands.
+     Gets the {@link CommandSource} which is used to execute commands for the current CLI session.
+
+     @return The source to execute commands.
      */
     protected CommandSource source() {
         return SystemSubject.instance(this.context);


### PR DESCRIPTION
Fixes #494

# Changes
Moves the creation of the `Scanner` object into the (potentially) async runnable.

## Type of change
- [x] Bug fix