### PR TITLE
#497 Include default values when looking up annotation attribute hierarchy

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/AnnotationHelper.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/AnnotationHelper.java
@@ -206,6 +206,16 @@ public final class AnnotationHelper {
 
             // search in super annotation type
             for (final Class<? extends Annotation> klass : hierarchy) {
+                try {
+                    final Method klassMethod = klass.getMethod(name);
+                    if (klassMethod != null) {
+                        final Object defaultValue = klassMethod.getDefaultValue();
+                        if (defaultValue != null) return Exceptional.of(defaultValue);
+                    }
+                } catch (final NoSuchMethodException ignored) {
+                    // Do not break yet, we might find it in a super class
+                }
+
                 final Annotation[] annotationsOnCurrentAnnotationClass = klass.getAnnotations();
                 for (final Annotation annotationOnCurrentAnnotationClass : annotationsOnCurrentAnnotationClass) {
                     if (hierarchy.contains(annotationOnCurrentAnnotationClass.annotationType())) {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.core;
 
 import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.binding.Bindings;
+import org.dockbox.hartshorn.core.boot.EmptyService;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.proxy.ExtendedProxy;
 import org.dockbox.hartshorn.core.types.ContextInjectedType;
@@ -284,5 +285,14 @@ public class ApplicationContextTests extends ApplicationAwareTest {
         Assertions.assertNotNull(sample);
         Assertions.assertNotNull(sample.name());
         Assertions.assertEquals("Factory", sample.name());
+    }
+
+    @Test
+    void servicesAreSingletonsByDefault() {
+        Assertions.assertTrue(this.context().meta().singleton(TypeContext.of(EmptyService.class)));
+
+        final EmptyService emptyService = this.context().get(EmptyService.class);
+        final EmptyService emptyService2 = this.context().get(EmptyService.class);
+        Assertions.assertSame(emptyService, emptyService2);
     }
 }


### PR DESCRIPTION
Fixes #497 

# Motivation
> Concrete case; `@RestController` extends from `@Service`, which extends from `@Component`. `@Service` changes the default value for `singleton()` from false to true. When `@Service` itself is requested, the value of `singleton()` is true, however when `@RestControlelr` is requested, the value of `singleton()` is false.  

> I observed that annotating `@RestController` with a default `@Service` will fix this, as well as annotating `@Service` with `@Component(singleton=true)`. While both of these solutions technically work, they are simply bypassing the greater issue. `AnnotationHelper` does not check the potential default value of a attribute after checking `AliasFor`, and before checking the top annotations (`@Component` on `@Service`). This should thus be resolvable by adding a check for default values.

# Changes
Adds a rule to check the default value of an annotation attribute between `@AliasFor` and `superAnnotation` lookups. This prioritizes `@AliasFor`, while deferring super annotations.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
