### PR TITLE
#496 Add `@RequestParam` rule support to read query parameters from `HttpServletRequest` when populating servlet handle arguments

### DIFF
--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/RequestParam.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/RequestParam.java
@@ -1,0 +1,13 @@
+package org.dockbox.hartshorn.web.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface RequestParam {
+    String value();
+    String or() default "";
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
@@ -6,6 +6,7 @@ import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.HeaderRequestParameterRule;
+import org.dockbox.hartshorn.web.processing.rules.RequestQueryParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.ServletRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.ServletResponseParameterRule;
 
@@ -17,6 +18,7 @@ public class HttpServletParameterLoader extends RuleBasedParameterLoader<HttpReq
     public HttpServletParameterLoader() {
         this.add(new BodyRequestParameterRule());
         this.add(new HeaderRequestParameterRule());
+        this.add(new RequestQueryParameterRule());
         this.add(new ServletRequestParameterRule());
         this.add(new ServletResponseParameterRule());
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/BodyRequestParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/BodyRequestParameterRule.java
@@ -42,6 +42,7 @@ public class BodyRequestParameterRule extends AnnotatedParameterLoaderRule<Reque
             return (Exceptional<T>) body;
         final FileType bodyFormat = parameter.declaredBy().annotation(HttpRequest.class).get().bodyFormat();
         final ObjectMapper objectMapper = context.applicationContext().get(ObjectMapper.class).fileType(bodyFormat);
+
         return body.flatMap(b -> objectMapper.read(b, parameter.type()));
     }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/RequestQueryParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/RequestQueryParameterRule.java
@@ -1,0 +1,31 @@
+package org.dockbox.hartshorn.web.processing.rules;
+
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.parameter.AnnotatedParameterLoaderRule;
+import org.dockbox.hartshorn.web.annotations.RequestParam;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
+
+public class RequestQueryParameterRule extends AnnotatedParameterLoaderRule<RequestParam, HttpRequestParameterLoaderContext> {
+
+    @Override
+    protected Class<RequestParam> annotation() {
+        return RequestParam.class;
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final int index, final HttpRequestParameterLoaderContext context, final Object... args) {
+        return Exceptional.of(() -> {
+            final RequestParam requestParam = parameter.annotation(RequestParam.class).get();
+            String value = context.request().getParameter(requestParam.value());
+            if (value == null) value = requestParam.or();
+
+            if (parameter.type().is(String.class)) return (T) value;
+            else if (parameter.type().isPrimitive()) {
+                return TypeContext.toPrimitive(parameter.type(), value);
+            }
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Fixes #496

# Motivation
Currently it is not possible to provide query parameters to request handles, e.g. the parameter `name` in `http://localhost:8080/greeting?name=Guus` cannot be obtained without accessing the `HttpServletRequest` directly.

# Changes
Adds a `@RequestParam` annotation which can be used to populate servlet handle arguments. When a parameter is annotated with `@RequestParam` the value will be looked up through `HttpServletRequest#getParameter`. If the parameter type is primitive it is automatically mapped to the correct primitive value.

## Type of change
- [x] New feature

# How Has This Been Tested?
- [x] Integration testing

**Test Configuration**:
* Platform: REST using Insomnia
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
