### PR TITLE
#504 Add support for Java modules (since J9+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ module/src/test/resources/storage.db-journal
 *.log
 .jpb
 hartshorn-assembly/publications
+*/out

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,16 @@ allprojects {
             }
         }
 
+        compileJava {
+            inputs.property('moduleName', project.name)
+            doFirst {
+                options.compilerArgs = [
+                        '--module-path', classpath.asPath
+                ]
+                classpath = files()
+            }
+        }
+
         repositories {
             mavenCentral()
             maven {

--- a/examples/examples.gradle
+++ b/examples/examples.gradle
@@ -26,16 +26,19 @@ sourceSets {
     persistence
     commands
     caching
+    rest
 }
 
 configurations {
     persistenceImplementation.extendsFrom(implementation)
     commandsImplementation.extendsFrom(implementation)
     cachingImplementation.extendsFrom(implementation)
+    restImplementation.extendsFrom(implementation)
 
     persistenceAnnotationProcessor.extendsFrom(annotationProcessor)
     commandsAnnotationProcessor.extendsFrom(annotationProcessor)
     cachingAnnotationProcessor.extendsFrom(annotationProcessor)
+    restAnnotationProcessor.extendsFrom(annotationProcessor)
 }
 
 dependencies {

--- a/examples/src/caching/java/module-info.java
+++ b/examples/src/caching/java/module-info.java
@@ -15,25 +15,8 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
-
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+module Hartshorn.examples.caching {
+    requires Hartshorn.hartshorn.cache.main;
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.events.main;
 }

--- a/examples/src/commands/java/module-info.java
+++ b/examples/src/commands/java/module-info.java
@@ -15,25 +15,8 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
-
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+module Hartshorn.examples.commands {
+    requires Hartshorn.hartshorn.commands.main;
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.events.main;
 }

--- a/examples/src/persistence/java/module-info.java
+++ b/examples/src/persistence/java/module-info.java
@@ -15,25 +15,10 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
-
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+module Hartshorn.examples.persistence {
+    requires Hartshorn.hartshorn.commands.main;
+    requires Hartshorn.hartshorn.config.main;
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.events.main;
+    requires Hartshorn.hartshorn.persistence.main;
 }

--- a/examples/src/rest/java/module-info.java
+++ b/examples/src/rest/java/module-info.java
@@ -15,25 +15,7 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
-
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+module Hartshorn.examples.rest {
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.web.main;
 }

--- a/examples/src/rest/java/org/dockbox/hartshorn/demo/rest/Greeting.java
+++ b/examples/src/rest/java/org/dockbox/hartshorn/demo/rest/Greeting.java
@@ -17,23 +17,11 @@
 
 package org.dockbox.hartshorn.demo.rest;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+@Getter
+@RequiredArgsConstructor
+public class Greeting {
+    private final String content;
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ testContainersVersion=1.16.0
 mySqlConnectorVersion=8.0.26
 postgreSqlVersion=42.2.23
 mariaDbClientVersion=2.7.4
-log4jVersion=2.7
+log4jVersion=2.9.1
 javaxServletVersion=3.1.0
 jettyVersion=9.4.44.v20210927
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,8 +43,8 @@ testContainersVersion=1.16.0
 mySqlConnectorVersion=8.0.26
 postgreSqlVersion=42.2.23
 mariaDbClientVersion=2.7.4
-log4jVersion=2.9.1
-javaxServletVersion=3.1.0
+log4jVersion=2.14.1
+javaxServletVersion=4.0.1
 jettyVersion=9.4.44.v20210927
 
 # Gradle plugin versions

--- a/hartshorn-cache/src/main/java/module-info.java
+++ b/hartshorn-cache/src/main/java/module-info.java
@@ -15,25 +15,11 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.cache.main {
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.tasks.main;
+    requires lombok;
+    requires jakarta.inject;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.cache.annotations;
 }

--- a/hartshorn-commands/src/main/java/module-info.java
+++ b/hartshorn-commands/src/main/java/module-info.java
@@ -20,6 +20,9 @@ module Hartshorn.hartshorn.commands.main {
     requires Hartshorn.hartshorn.events.main;
     requires Hartshorn.hartshorn.i18n.main;
     requires Hartshorn.hartshorn.tasks.main;
+    requires jakarta.inject;
+    requires lombok;
+    requires org.jetbrains.annotations;
 
     exports org.dockbox.hartshorn.commands;
     exports org.dockbox.hartshorn.commands.annotations;

--- a/hartshorn-commands/src/main/java/module-info.java
+++ b/hartshorn-commands/src/main/java/module-info.java
@@ -15,25 +15,16 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.commands.main {
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.events.main;
+    requires Hartshorn.hartshorn.i18n.main;
+    requires Hartshorn.hartshorn.tasks.main;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.commands;
+    exports org.dockbox.hartshorn.commands.annotations;
+    exports org.dockbox.hartshorn.commands.arguments;
+    exports org.dockbox.hartshorn.commands.context;
+    exports org.dockbox.hartshorn.commands.definition;
+    exports org.dockbox.hartshorn.commands.service;
 }

--- a/hartshorn-config/src/main/java/module-info.java
+++ b/hartshorn-config/src/main/java/module-info.java
@@ -15,25 +15,9 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.config.main {
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.persistence.main;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.config.annotations;
 }

--- a/hartshorn-config/src/main/java/module-info.java
+++ b/hartshorn-config/src/main/java/module-info.java
@@ -18,6 +18,8 @@
 module Hartshorn.hartshorn.config.main {
     requires Hartshorn.hartshorn.core.main;
     requires Hartshorn.hartshorn.persistence.main;
+    requires lombok;
+    requires org.jetbrains.annotations;
 
     exports org.dockbox.hartshorn.config.annotations;
 }

--- a/hartshorn-core/hartshorn-core.gradle
+++ b/hartshorn-core/hartshorn-core.gradle
@@ -18,7 +18,8 @@
 apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
-    api "javax.inject:javax.inject:$javaxInjectVersion"
+    api group: 'jakarta.inject', name: 'jakarta.inject-api', version: '1.0.1'
+
     implementation "org.reflections:reflections:$reflectionsVersion"
     implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
     implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"

--- a/hartshorn-core/src/main/java/module-info.java
+++ b/hartshorn-core/src/main/java/module-info.java
@@ -20,8 +20,8 @@ module Hartshorn.hartshorn.core.main {
     requires org.slf4j;
     requires org.jetbrains.annotations;
     requires javassist;
-    requires log4j.api;
-    requires log4j.core;
+    requires org.apache.logging.log4j.core;
+    requires org.apache.logging.log4j;
 
     exports org.dockbox.hartshorn.core;
     exports org.dockbox.hartshorn.core.adapter;

--- a/hartshorn-core/src/main/java/module-info.java
+++ b/hartshorn-core/src/main/java/module-info.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+module Hartshorn.hartshorn.core.main {
+    requires lombok;
+    requires org.slf4j;
+    requires org.jetbrains.annotations;
+    requires javassist;
+    requires log4j.api;
+    requires log4j.core;
+
+    exports org.dockbox.hartshorn.core;
+    exports org.dockbox.hartshorn.core.adapter;
+    exports org.dockbox.hartshorn.core.annotations;
+    exports org.dockbox.hartshorn.core.annotations.activate;
+    exports org.dockbox.hartshorn.core.annotations.component;
+    exports org.dockbox.hartshorn.core.annotations.context;
+    exports org.dockbox.hartshorn.core.annotations.inject;
+    exports org.dockbox.hartshorn.core.annotations.service;
+    exports org.dockbox.hartshorn.core.binding;
+    exports org.dockbox.hartshorn.core.boot;
+    exports org.dockbox.hartshorn.core.context;
+    exports org.dockbox.hartshorn.core.context.element;
+    exports org.dockbox.hartshorn.core.domain;
+    exports org.dockbox.hartshorn.core.domain.tuple;
+    exports org.dockbox.hartshorn.core.exceptions;
+    exports org.dockbox.hartshorn.core.function;
+    exports org.dockbox.hartshorn.core.inject;
+    exports org.dockbox.hartshorn.core.keys;
+    exports org.dockbox.hartshorn.core.proxy;
+    exports org.dockbox.hartshorn.core.services;
+    exports org.dockbox.hartshorn.core.services.parameter;
+}

--- a/hartshorn-events/src/main/java/module-info.java
+++ b/hartshorn-events/src/main/java/module-info.java
@@ -15,25 +15,13 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.events.main {
+    requires Hartshorn.hartshorn.core.main;
+    requires lombok;
+    requires org.jetbrains.annotations;
+    requires jakarta.inject;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.events;
+    exports org.dockbox.hartshorn.events.annotations;
+    exports org.dockbox.hartshorn.events.parents;
 }

--- a/hartshorn-i18n/src/main/java/module-info.java
+++ b/hartshorn-i18n/src/main/java/module-info.java
@@ -19,6 +19,8 @@ module Hartshorn.hartshorn.i18n.main {
     requires Hartshorn.hartshorn.config.main;
     requires Hartshorn.hartshorn.core.main;
     requires Hartshorn.hartshorn.persistence.main;
+    requires jakarta.inject;
+    requires lombok;
 
     exports org.dockbox.hartshorn.i18n;
     exports org.dockbox.hartshorn.i18n.annotations;

--- a/hartshorn-i18n/src/main/java/module-info.java
+++ b/hartshorn-i18n/src/main/java/module-info.java
@@ -15,25 +15,11 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.i18n.main {
+    requires Hartshorn.hartshorn.config.main;
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.persistence.main;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.i18n;
+    exports org.dockbox.hartshorn.i18n.annotations;
 }

--- a/hartshorn-persistence/hartshorn-persistence.gradle
+++ b/hartshorn-persistence/hartshorn-persistence.gradle
@@ -18,17 +18,18 @@
 apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
-    implementation 'org.dockbox.hartshorn:hartshorn-core'
+    api 'org.dockbox.hartshorn:hartshorn-core'
     api 'jakarta.activation:jakarta.activation-api:2.0.1'
 
-    implementation "org.apache.derby:derby:$derbyVersion"
-    implementation "org.hibernate:hibernate-core:$hibernateVersion"
-    implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    implementation "org.codehaus.woodstox:woodstox-core-asl:$woodstoxVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-toml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-properties:$jacksonVersion"
+    api "org.hibernate:hibernate-core:$hibernateVersion"
+    api "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-toml:$jacksonVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-properties:$jacksonVersion"
+
+    compileOnly "org.apache.derby:derby:$derbyVersion"
+//    compileOnly "org.codehaus.woodstox:woodstox-core-asl:$woodstoxVersion"
 
     testImplementation "org.postgresql:postgresql:$postgreSqlVersion"
     testImplementation "org.testcontainers:mysql:$testContainersVersion"

--- a/hartshorn-persistence/hartshorn-persistence.gradle
+++ b/hartshorn-persistence/hartshorn-persistence.gradle
@@ -28,9 +28,8 @@ dependencies {
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-toml:$jacksonVersion"
     api "com.fasterxml.jackson.dataformat:jackson-dataformat-properties:$jacksonVersion"
 
-    compileOnly "org.apache.derby:derby:$derbyVersion"
-//    compileOnly "org.codehaus.woodstox:woodstox-core-asl:$woodstoxVersion"
-
+    testImplementation "org.codehaus.woodstox:woodstox-core-asl:$woodstoxVersion"
+    testImplementation "org.apache.derby:derby:$derbyVersion"
     testImplementation "org.postgresql:postgresql:$postgreSqlVersion"
     testImplementation "org.testcontainers:mysql:$testContainersVersion"
     testImplementation "org.testcontainers:mariadb:$testContainersVersion"

--- a/hartshorn-persistence/hartshorn-persistence.gradle
+++ b/hartshorn-persistence/hartshorn-persistence.gradle
@@ -19,6 +19,8 @@ apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
     implementation 'org.dockbox.hartshorn:hartshorn-core'
+    api 'jakarta.activation:jakarta.activation-api:2.0.1'
+
     implementation "org.apache.derby:derby:$derbyVersion"
     implementation "org.hibernate:hibernate-core:$hibernateVersion"
     implementation "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"

--- a/hartshorn-persistence/src/main/java/module-info.java
+++ b/hartshorn-persistence/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+module Hartshorn.hartshorn.persistence.main {
+    requires Hartshorn.hartshorn.core.main;
+    requires com.fasterxml.jackson.annotation;
+    requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.dataformat.toml;
+    requires com.fasterxml.jackson.dataformat.javaprop;
+    requires com.fasterxml.jackson.dataformat.xml;
+    requires com.fasterxml.jackson.dataformat.yaml;
+    requires org.jetbrains.annotations;
+    requires jakarta.inject;
+    requires lombok;
+
+    exports org.dockbox.hartshorn.persistence;
+    exports org.dockbox.hartshorn.persistence.annotations;
+    exports org.dockbox.hartshorn.persistence.jpa;
+    exports org.dockbox.hartshorn.persistence.mapping;
+    exports org.dockbox.hartshorn.persistence.properties;
+}

--- a/hartshorn-persistence/src/main/java/module-info.java
+++ b/hartshorn-persistence/src/main/java/module-info.java
@@ -26,6 +26,9 @@ module Hartshorn.hartshorn.persistence.main {
     requires org.jetbrains.annotations;
     requires jakarta.inject;
     requires lombok;
+    requires java.persistence;
+    requires org.hibernate.orm.core;
+    requires java.naming;
 
     exports org.dockbox.hartshorn.persistence;
     exports org.dockbox.hartshorn.persistence.annotations;

--- a/hartshorn-tasks/src/main/java/module-info.java
+++ b/hartshorn-tasks/src/main/java/module-info.java
@@ -15,25 +15,10 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.tasks.main {
+    requires Hartshorn.hartshorn.core.main;
+    requires org.jetbrains.annotations;
+    requires lombok;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.core.task;
 }

--- a/hartshorn-web/hartshorn-web.gradle
+++ b/hartshorn-web/hartshorn-web.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.dockbox.hartshorn:hartshorn-persistence'
     implementation "org.eclipse.jetty:jetty-servlet:$jettyVersion"
     implementation "org.eclipse.jetty:jetty-server:$jettyVersion"
-    api "javax.servlet:javax.servlet-api:$javaxServletVersion"
+    implementation 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/hartshorn-web/src/main/java/module-info.java
+++ b/hartshorn-web/src/main/java/module-info.java
@@ -15,25 +15,12 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.demo.rest;
+module Hartshorn.hartshorn.web.main {
+    requires Hartshorn.hartshorn.config.main;
+    requires Hartshorn.hartshorn.core.main;
+    requires Hartshorn.hartshorn.events.main;
+    requires Hartshorn.hartshorn.persistence.main;
 
-import org.dockbox.hartshorn.web.annotations.RequestHeader;
-import org.dockbox.hartshorn.web.annotations.RequestParam;
-import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpGet;
-
-@RestController
-public class DemoController {
-
-    @HttpGet("/hello")
-    public String hello(@RequestHeader("demo") final String name) {
-        return "Hello " + name;
-    }
-
-    private int id = 0;
-
-    @HttpGet("/greeting")
-    public Greeting greeting(@RequestParam(value = "name", or = "World") final String name) {
-        return new Greeting("Hello, " + name + "! (" + (++id) + ")");
-    }
+    exports org.dockbox.hartshorn.web.annotations;
+    exports org.dockbox.hartshorn.web.annotations.http;
 }

--- a/hartshorn-web/src/main/java/module-info.java
+++ b/hartshorn-web/src/main/java/module-info.java
@@ -20,6 +20,15 @@ module Hartshorn.hartshorn.web.main {
     requires Hartshorn.hartshorn.core.main;
     requires Hartshorn.hartshorn.events.main;
     requires Hartshorn.hartshorn.persistence.main;
+    requires org.eclipse.jetty.http;
+    requires org.eclipse.jetty.io;
+    requires org.eclipse.jetty.server;
+    requires org.eclipse.jetty.util;
+    requires jakarta.servlet;
+    requires jakarta.inject;
+    requires lombok;
+    requires org.eclipse.jetty.servlet;
+    requires javax.servlet.api;
 
     exports org.dockbox.hartshorn.web.annotations;
     exports org.dockbox.hartshorn.web.annotations.http;


### PR DESCRIPTION
Fixes #504 

# Motivation
Hartshorn aims to support modern language and JDK features, yet has not added support for Java modules which were introduced in Java 9.  

You can read more about Java modules here: https://www.oracle.com/corporate/features/understanding-java-9-modules.html

# Changes
Adds the required `module-info.java` files to all `main` sourcesets.  

_Additional changes will be documented before PR is ready for review._

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Integration testing (J9+ modules)

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
