### PR TITLE
#512 Allow serving static content through `HttpWebServer`

### DIFF
--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.persistence.properties.PersistenceModifier;
 import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
+import java.net.URI;
 
 import javax.inject.Singleton;
 
@@ -29,6 +30,7 @@ import javax.inject.Singleton;
 public interface HttpWebServer {
 
     public static String WEB_INF = "WEB-INF/";
+    public static String STATIC_CONTENT = WEB_INF + "static/";
 
     void start(int port) throws ApplicationException;
 
@@ -39,4 +41,8 @@ public interface HttpWebServer {
     ParameterLoader<HttpRequestParameterLoaderContext> loader();
 
     HttpWebServer skipBehavior(PersistenceModifier modifier);
+
+    HttpWebServer listStaticDirectories(boolean listDirectories);
+
+    HttpWebServer staticContent(URI location);
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
@@ -46,4 +46,6 @@ public interface HttpWebServer {
     HttpWebServer listStaticDirectories(boolean listDirectories);
 
     HttpWebServer staticContent(URI location);
+
+    void stop() throws ApplicationException;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
@@ -29,7 +29,7 @@ import javax.inject.Singleton;
 @Singleton
 public interface HttpWebServer {
 
-    public static String WEB_INF = "WEB-INF/";
+    public static String WEB_INF = "/WEB-INF/";
     public static String STATIC_CONTENT = WEB_INF + "static/";
 
     void start(int port) throws ApplicationException;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 import java.net.URI;
 
 import javax.inject.Singleton;
+import javax.servlet.Servlet;
 
 @Singleton
 public interface HttpWebServer {
@@ -34,13 +35,13 @@ public interface HttpWebServer {
 
     void start(int port) throws ApplicationException;
 
-    HttpWebServer register(RequestHandlerContext context);
-
-    HttpWebServer registerMvc(RequestHandlerContext context);
+    HttpWebServer register(Servlet servlet, String pathSpec);
 
     ParameterLoader<HttpRequestParameterLoaderContext> loader();
 
     HttpWebServer skipBehavior(PersistenceModifier modifier);
+
+    PersistenceModifier skipBehavior();
 
     HttpWebServer listStaticDirectories(boolean listDirectories);
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServerBootstrap.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServerBootstrap.java
@@ -18,12 +18,25 @@
 package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.config.annotations.Value;
+import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.UseBootstrap;
 import org.dockbox.hartshorn.core.annotations.service.Service;
 import org.dockbox.hartshorn.core.boot.LifecycleObserver;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.web.mvc.MVCInitializer;
+import org.dockbox.hartshorn.web.mvc.ViewTemplate;
+import org.dockbox.hartshorn.web.servlet.HttpWebServletAdapter;
+import org.dockbox.hartshorn.web.servlet.MvcServlet;
+import org.dockbox.hartshorn.web.servlet.WebServlet;
+import org.dockbox.hartshorn.web.servlet.WebServletFactory;
+import org.dockbox.hartshorn.web.servlet.WebServletImpl;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.servlet.Servlet;
 
 @Service(activators = UseBootstrap.class)
 public class ServerBootstrap implements LifecycleObserver {
@@ -32,6 +45,12 @@ public class ServerBootstrap implements LifecycleObserver {
 
     @Value(value = "hartshorn.web.port", or = "" + DEFAULT_PORT)
     private int port;
+
+    @Value(value = "hartshorn.web.servlet.directory", or = "true")
+    private boolean useDirectoryServlet;
+
+    @Inject
+    private WebServletFactory webServletFactory;
 
     @Override
     public void onCreated(final ApplicationContext applicationContext) {
@@ -42,13 +61,25 @@ public class ServerBootstrap implements LifecycleObserver {
     public void onStarted(final ApplicationContext applicationContext) {
         final HttpWebServer starter = applicationContext.get(HttpWebServer.class);
 
+        final Map<String, Servlet> servlets = HartshornUtils.emptyMap();
+
         final ControllerContext controllerContext = applicationContext.first(ControllerContext.class).get();
-        for (final RequestHandlerContext context : controllerContext.contexts())
-            starter.register(context);
+        for (final RequestHandlerContext context : controllerContext.contexts()) {
+            final WebServlet servlet = this.servlet(applicationContext, context, starter);
+            final Servlet adapter = new HttpWebServletAdapter(applicationContext, servlet);
+            servlets.put(context.pathSpec(), adapter);
+        }
 
         final MvcControllerContext mvcControllerContext = applicationContext.first(MvcControllerContext.class).get();
-        for (final RequestHandlerContext context : mvcControllerContext.contexts())
-            starter.registerMvc(context);
+        for (final RequestHandlerContext context : mvcControllerContext.contexts()) {
+            final MvcServlet servlet = this.webServletFactory.mvc((MethodContext<ViewTemplate, ?>) context.methodContext());
+            final Servlet adapter = new HttpWebServletAdapter(applicationContext, servlet);
+            servlets.put(context.pathSpec(), adapter);
+        }
+
+        servlets.forEach((path, servlet) -> starter.register(servlet, path));
+
+        starter.listStaticDirectories(this.useDirectoryServlet);
 
         try {
             final MVCInitializer initializer = applicationContext.get(MVCInitializer.class);
@@ -59,5 +90,11 @@ public class ServerBootstrap implements LifecycleObserver {
         catch (final ApplicationException e) {
             throw e.runtime();
         }
+    }
+
+    protected WebServlet servlet(final ApplicationContext applicationContext, final RequestHandlerContext context, final HttpWebServer webServer) {
+        final WebServletImpl adapter = this.webServletFactory.webServlet(webServer, context);
+        adapter.handler().mapper().skipBehavior(webServer.skipBehavior());
+        return adapter;
     }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
@@ -1,0 +1,46 @@
+package org.dockbox.hartshorn.web.jetty;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.web.HttpStatus;
+import org.dockbox.hartshorn.web.HttpWebServer;
+import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.resource.Resource;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Binds(DirectoryServlet.class)
+public class JettyDirectoryServlet implements DirectoryServlet {
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void handle(final HttpServletRequest request, final HttpServletResponse response, final URI uri, final String path) throws IOException {
+        String pathInfo = request.getPathInfo();
+        if (pathInfo == null) {
+            pathInfo = "/";
+        }
+        final Resource resource = Resource.newClassPathResource(HttpWebServer.STATIC_CONTENT + pathInfo);
+        if (resource.isDirectory()) {
+            response.setStatus(HttpStatus.OK.value());
+            response.setContentType("text/html;charset=utf-8");
+            response.getWriter().println("<html><head><title>Directory listing for " + pathInfo + "</title></head><body>");
+            response.getWriter().println("<h1>Directory listing for " + pathInfo + "</h1>");
+            response.getWriter().println("<ul>");
+            for (final String child : resource.list()) {
+                response.getWriter().println("<li><a href=\"" + URIUtil.encodePath(child) + "\">" + child + "</a></li>");
+            }
+            response.getWriter().println("</ul>");
+            response.getWriter().println("</body></html>");
+        } else {
+            response.setStatus(HttpStatus.NO_CONTENT.value());
+        }
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -120,6 +120,17 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
         return this;
     }
 
+    @Override
+    public void stop() throws ApplicationException {
+        if (this.server != null) {
+            try {
+                this.server.stop();
+            } catch (final Exception e) {
+                throw new ApplicationException(e);
+            }
+        }
+    }
+
     public HttpWebServer staticContent(final URL location) {
         if (this.servletHandler instanceof ResourceHandler resourceHandler) {
             resourceHandler.setResourceBase(location.toExternalForm());

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
@@ -1,5 +1,6 @@
 package org.dockbox.hartshorn.web.jetty;
 
+import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.web.HttpStatus;
 import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
@@ -24,17 +25,22 @@ public class JettyResourceService extends ResourceService {
     @Inject
     private DirectoryServlet servlet;
 
+    @Inject
+    private ApplicationContext applicationContext;
+
     @Override
-    protected void sendDirectory(final HttpServletRequest request,
-                                 final HttpServletResponse response,
+    protected void sendDirectory(final HttpServletRequest req,
+                                 final HttpServletResponse res,
                                  final Resource resource,
                                  final String pathInContext)
             throws IOException {
         if (!this.isDirAllowed()) {
-            response.sendError(HttpStatus.FORBIDDEN.value());
+            res.sendError(HttpStatus.FORBIDDEN.value());
             return;
         }
-        this.servlet.handle(request, response, resource.getURI(), pathInContext);
+        this.applicationContext.log().debug("Received " + req.getMethod() + " " + req.getRequestURI());
+        this.servlet.handle(req, res, resource.getURI(), pathInContext);
+        this.applicationContext.log().debug("Request " + req.getMethod() + " " + req.getRequestURI() + " completed");
     }
 
     @Override

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
@@ -1,0 +1,133 @@
+package org.dockbox.hartshorn.web.jetty;
+
+import org.dockbox.hartshorn.core.exceptions.Except;
+import org.dockbox.hartshorn.web.HttpStatus;
+import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
+import org.eclipse.jetty.http.HttpContent;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.ResourceService;
+import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.resource.Resource;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Enumeration;
+
+import javax.inject.Inject;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class JettyResourceService extends ResourceService {
+
+    @Inject
+    private DirectoryServlet servlet;
+
+    @Override
+    protected void sendDirectory(final HttpServletRequest request,
+                                 final HttpServletResponse response,
+                                 final Resource resource,
+                                 final String pathInContext)
+            throws IOException {
+        if (!this.isDirAllowed()) {
+            response.sendError(HttpStatus.FORBIDDEN.value());
+            return;
+        }
+        this.servlet.handle(request, response, resource.getURI(), pathInContext);
+    }
+
+    @Override
+    public boolean doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        String servletPath = null;
+        String pathInfo = null;
+        Enumeration<String> reqRanges = null;
+        final boolean included = request.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI) != null;
+        if (included)
+        {
+            servletPath = this.isPathInfoOnly() ? "/" : (String)request.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
+            pathInfo = (String)request.getAttribute(RequestDispatcher.INCLUDE_PATH_INFO);
+            if (servletPath == null)
+            {
+                servletPath = request.getServletPath();
+                pathInfo = request.getPathInfo();
+            }
+        }
+        else
+        {
+            servletPath = this.isPathInfoOnly() ? "/" : request.getServletPath();
+            pathInfo = request.getPathInfo();
+
+            // Is this a Range request?
+            reqRanges = request.getHeaders(HttpHeader.RANGE.asString());
+            if (!(reqRanges != null && reqRanges.hasMoreElements()))
+                reqRanges = null;
+        }
+
+        String pathInContext = URIUtil.addPaths(servletPath, pathInfo);
+
+        final boolean endsWithSlash = (pathInfo == null ? (this.isPathInfoOnly() ? "" : servletPath) : pathInfo).endsWith(URIUtil.SLASH);
+        final boolean checkPrecompressedVariants = this.getPrecompressedFormats().length > 0 && !endsWithSlash && !included && reqRanges == null;
+
+        HttpContent content = null;
+        boolean releaseContent = true;
+        try
+        {
+            // Find the content
+            content = this.getContentFactory().getContent(pathInContext, response.getBufferSize());
+
+            // Not found?
+            if (content == null || !content.getResource().exists())
+            {
+                if (included)
+                    throw new FileNotFoundException("!" + pathInContext);
+                // Allow secondary handler to handle this request
+                return false;
+            }
+
+            // Directory?
+            if (content.getResource().isDirectory())
+            {
+                this.sendWelcome(content, pathInContext, endsWithSlash, included, request, response);
+                return true;
+            }
+
+            // Strip slash?
+            if (!included && endsWithSlash && pathInContext.length() > 1)
+            {
+                final String q = request.getQueryString();
+                pathInContext = pathInContext.substring(0, pathInContext.length() - 1);
+                if (q != null && q.length() != 0)
+                    pathInContext += "?" + q;
+                response.sendRedirect(response.encodeRedirectURL(URIUtil.addPaths(request.getContextPath(), pathInContext)));
+                return true;
+            }
+
+            // Conditional response?
+            if (!included && !this.passConditionalHeaders(request, response, content))
+                return true;
+
+            if (this.isGzippedContent(pathInContext))
+                response.setHeader(HttpHeader.CONTENT_ENCODING.asString(), "gzip");
+
+            // Send the data
+            releaseContent = this.sendData(request, response, included, content, reqRanges);
+        }
+        catch (final IllegalArgumentException e)
+        {
+            Except.handle(e);
+            if (!response.isCommitted())
+                response.sendError(500, e.getMessage());
+        }
+        finally
+        {
+            if (releaseContent)
+            {
+                if (content != null)
+                    content.release();
+            }
+        }
+
+        return true;
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/DirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/DirectoryServlet.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.web.servlet;
+
+import java.io.IOException;
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public interface DirectoryServlet {
+    void handle(HttpServletRequest request, HttpServletResponse response, URI uri, String path) throws IOException;
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -1,5 +1,6 @@
 package org.dockbox.hartshorn.web.servlet;
 
+import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.web.HttpAction;
 
@@ -14,7 +15,8 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public class HttpWebServletAdapter extends HttpServlet {
-    
+
+    private final ApplicationContext applicationContext;
     private final WebServlet webServlet;
 
     @Override
@@ -54,7 +56,9 @@ public class HttpWebServletAdapter extends HttpServlet {
 
     private void perform(final HttpServletAction action, final HttpServletRequest req, final HttpServletResponse res, final HttpServletFallback fallback) throws ServletException, IOException {
         try {
+            this.applicationContext.log().debug("Received " + req.getMethod() + " " + req.getRequestURI());
             action.perform(req, res, this.wrap(fallback));
+            this.applicationContext.log().debug("Request " + req.getMethod() + " " + req.getRequestURI() + " completed");
         }
         catch (final ApplicationException e) {
             if (e.getCause() instanceof ServletException servletException) throw servletException;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -54,7 +54,7 @@ public class HttpWebServletAdapter extends HttpServlet {
         this.perform(this.webServlet::trace, req, res, super::doTrace);
     }
 
-    private void perform(final HttpServletAction action, final HttpServletRequest req, final HttpServletResponse res, final HttpServletFallback fallback) throws ServletException, IOException {
+    private synchronized void perform(final HttpServletAction action, final HttpServletRequest req, final HttpServletResponse res, final HttpServletFallback fallback) throws ServletException, IOException {
         try {
             this.applicationContext.log().debug("Received " + req.getMethod() + " " + req.getRequestURI());
             action.perform(req, res, this.wrap(fallback));

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -18,37 +18,37 @@ public class HttpWebServletAdapter extends HttpServlet {
     private final WebServlet webServlet;
 
     @Override
-    protected void doGet(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doGet(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::get, req, res, super::doGet);
     }
 
     @Override
-    protected void doHead(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doHead(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::head, req, res, super::doHead);
     }
 
     @Override
-    protected void doPost(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doPost(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::post, req, res, super::doPost);
     }
 
     @Override
-    protected void doPut(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doPut(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::put, req, res, super::doPut);
     }
 
     @Override
-    protected void doDelete(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doDelete(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::delete, req, res, super::doDelete);
     }
 
     @Override
-    protected void doOptions(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doOptions(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::options, req, res, super::doOptions);
     }
 
     @Override
-    protected void doTrace(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
+    protected synchronized void doTrace(final HttpServletRequest req, final HttpServletResponse res) throws ServletException, IOException {
         this.perform(this.webServlet::trace, req, res, super::doTrace);
     }
 


### PR DESCRIPTION
Fixes #512

# Motivation
Serving static content through the web module allows users of future MVC support ( #509 ) to use resources like CSS and JavaScript directly, rather than having to hardcode it or depending on a secondary DNS.  

This PR adds a configuration to the `HttpWebServer` which can then serve all content in `/WEB-INF/static/` according to the directory structure in that directory. If no content is found, the servlet will attempt to list the directory contents if it exists, this behavior can be customized through the implementation of `DirectoryServlet`.  

As this implementation, as well as the MVC implementation, has shown that there will be more generic `javax.servlet.Servlet`s I have modified the `#register` method in the `HttpWebServer` to support registering a generic `Servlet` with a provided path specification. The existing bootstrap has been updated accordingly, existing implementations do not break with this change.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Integration testing

**Test Configuration**:
* Java version: Corretto 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
