### PR TITLE
#516 Add `onExit` state observable

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameterValidator.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameterValidator.java
@@ -29,12 +29,12 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 public class CommandParameterValidator implements LifecycleObserver {
 
     @Override
-    public void onCreated(ApplicationContext applicationContext) {
+    public void onCreated(final ApplicationContext applicationContext) {
         // Nothing happens
     }
 
     @Override
-    public void onStarted(ApplicationContext applicationContext) {
+    public void onStarted(final ApplicationContext applicationContext) {
         final MethodContext<?, CommandParameterValidator> preload = TypeContext.of(this).method("onStarted", ApplicationContext.class).get();
         final ParameterContext<?> parameter = preload.parameters().get(0);
         if (!"applicationContext".equals(parameter.name())) {
@@ -42,5 +42,10 @@ public class CommandParameterValidator implements LifecycleObserver {
             applicationContext.log().warn("   Add -parameters to your compiler args to keep parameter names.");
             applicationContext.log().warn("   See: https://docs.oracle.com/javase/tutorial/reflect/member/methodparameterreflection.html for more information.");
         }
+    }
+
+    @Override
+    public void onExit(final ApplicationContext applicationContext) {
+        // Nothing happens
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
@@ -215,6 +215,11 @@ public class HartshornApplicationFactory implements ApplicationFactory<Hartshorn
 
         final long startedTime = System.currentTimeMillis();
 
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            for (final LifecycleObserver observer : manager.observers())
+                observer.onExit(applicationContext);
+        }));
+
         applicationContext.log().info("Started " + Hartshorn.PROJECT_NAME + " in " + (startedTime - startTime) + "ms (" + (createdTime - startTime) + "ms creation, " + (startedTime - createdTime) + "ms init)");
 
         return applicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/LifecycleObserver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/LifecycleObserver.java
@@ -22,4 +22,5 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 public interface LifecycleObserver {
     void onCreated(ApplicationContext applicationContext);
     void onStarted(ApplicationContext applicationContext);
+    void onExit(ApplicationContext applicationContext);
 }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
@@ -37,12 +37,12 @@ import java.util.stream.Collectors;
 public class EventValidator implements LifecycleObserver {
 
     @Override
-    public void onCreated(ApplicationContext applicationContext) {
+    public void onCreated(final ApplicationContext applicationContext) {
         // Nothing happens
     }
 
     @Override
-    public void onStarted(ApplicationContext applicationContext) {
+    public void onStarted(final ApplicationContext applicationContext) {
         if (applicationContext.hasActivator(UseEvents.class)) {
             new EngineChangedState<Started>() {
             }.with(applicationContext).post();
@@ -75,5 +75,10 @@ public class EventValidator implements LifecycleObserver {
             }
             Hartshorn.log().warn(message.toString());
         }
+    }
+
+    @Override
+    public void onExit(final ApplicationContext applicationContext) {
+        // Nothing happens
     }
 }

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/PersistentTypeService.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/PersistentTypeService.java
@@ -32,13 +32,18 @@ import javax.persistence.Entity;
 public class PersistentTypeService implements LifecycleObserver {
 
     @Override
-    public void onCreated(ApplicationContext applicationContext) {
+    public void onCreated(final ApplicationContext applicationContext) {
         // Nothing happens
     }
 
     @Override
-    public void onStarted(ApplicationContext applicationContext) {
+    public void onStarted(final ApplicationContext applicationContext) {
         final Collection<TypeContext<?>> entities = applicationContext.environment().types(Entity.class);
         applicationContext.add(new EntityContext(entities));
+    }
+
+    @Override
+    public void onExit(final ApplicationContext applicationContext) {
+        // Nothing happens
     }
 }


### PR DESCRIPTION
Fixes #516

# Motivation
It's currently not possible to listen for application exits, besides manually registering shutdown hooks through `Runtime.getRuntime().addShutdownHook(Thread)`. To resolve this it is now possible for `LifecycleObserver`s to listen to application exits, to allow them to clean up before exiting.

## Type of change
- [x] New core feature