### PR TITLE
#514 Remove redundant inspection suppressions

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodModifier.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodModifier.java
@@ -47,7 +47,6 @@ public class CachedMethodModifier extends CacheServiceModifier<Cached> {
 
             final Exceptional<Object> content = cache.get();
 
-            //noinspection unchecked
             return (R) content.orElse(() -> {
                 context.log().debug("Cache " + cacheContext.name() + " has not been populated yet, or content has expired.");
                 try {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
@@ -154,7 +154,6 @@ public class CommandParserImpl implements CommandParser {
         }
         else {
             if (partial instanceof GroupCommandElement) {
-                //noinspection unchecked
                 final List<CommandElement<?>> elements = (List<CommandElement<?>>) value.get();
                 final List<String> tokens = HartshornUtils.asList(token.split(" "));
                 return this.parse(elements, tokens, source);

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
@@ -37,7 +37,6 @@ public abstract class SystemSubject implements CommandSource, Identifiable {
     @Getter
     private ApplicationContext applicationContext;
 
-    @SuppressWarnings("ConstantDeclaredInAbstractClass")
     public static final UUID UNIQUE_ID = new UUID(0, 0);
 
     public static SystemSubject instance(final ApplicationContext context) {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
@@ -32,7 +32,6 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
 
-@SuppressWarnings({ "unused", "ClassWithTooManyFields" })
 @Service
 public final class DefaultArgumentConverters {
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/ArgumentConverterContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/ArgumentConverterContext.java
@@ -85,7 +85,6 @@ public final class ArgumentConverterContext extends DefaultContext {
      * @return The converter if it exists, or {@link Exceptional#empty()}
      */
     public <T> Exceptional<ArgumentConverter<T>> converter(final TypeContext<T> type) {
-        //noinspection unchecked
         return Exceptional.of(this.converterMap.values().stream()
                 .filter(converter -> type.childOf(converter.type()))
                 .map(converter -> (ArgumentConverter<T>) converter)

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandDefinitionContextImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandDefinitionContextImpl.java
@@ -53,7 +53,6 @@ import java.util.regex.Pattern;
  * for this definition are explained at {@link CommandDefinitionContextImpl#ELEMENT_VALUE}. If no
  * explicit type is defined, {@link CommandDefinitionContextImpl#DEFAULT_TYPE} is used.
  */
-@SuppressWarnings("RegExpUnnecessaryNonCapturingGroup")
 public class CommandDefinitionContextImpl extends DefaultContext implements CommandDefinitionContext {
 
     /**
@@ -229,7 +228,6 @@ public class CommandDefinitionContextImpl extends DefaultContext implements Comm
 
             if (lookup.isEnum()) {
                 this.context.log().debug(type + " is an enum, creating explicit enum element.");
-                //noinspection unchecked
                 return CommandElements.enumElement(name, (TypeContext<E>) lookup, optional);
             }
             else {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServiceProcessor.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServiceProcessor.java
@@ -44,7 +44,6 @@ public class ArgumentServiceProcessor implements ServiceProcessor<UseCommands> {
         return !type.fieldsOf(ArgumentConverter.class).isEmpty();
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
     public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
         final List<FieldContext<ArgumentConverter>> fields = type.fieldsOf(ArgumentConverter.class);

--- a/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
+++ b/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
@@ -163,7 +163,6 @@ public class CommandDefinitionContextTests extends ApplicationAwareTest {
     }
 
     private Command createCommand() {
-        //noinspection OverlyComplexAnonymousInnerClass
         return new Command() {
 
             @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/GenericType.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/GenericType.java
@@ -48,7 +48,7 @@ public abstract class GenericType<T> implements Comparable<GenericType<T>> {
 
     public Exceptional<Class<T>> asClass() {
         final Type type = this.type();
-        if (type instanceof Class<?> clazz) //noinspection unchecked
+        if (type instanceof Class<?> clazz)
             return Exceptional.of((Class<T>) clazz);
         return Exceptional.empty();
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/HartshornUtils.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/HartshornUtils.java
@@ -71,7 +71,6 @@ import java.util.stream.StreamSupport;
  * Wraps all utility classes to a common accessor. This way all {@code final} utility classes can be
  * accessed at once and indexed more easily.
  */
-@SuppressWarnings({ "unused", "OverlyComplexClass", "ResultOfMethodCallIgnored" })
 public final class HartshornUtils {
 
     /**
@@ -118,7 +117,6 @@ public final class HartshornUtils {
      * @see HartshornUtils#entry(Object, Object)
      */
     @SafeVarargs
-    @SuppressWarnings("varargs")
     public static <K, V> Map<K, V> ofEntries(final Entry<? extends K, ? extends V>... entries) {
         if (0 == entries.length) { // implicit null check of entries array
             return HartshornUtils.emptyMap();
@@ -347,7 +345,6 @@ public final class HartshornUtils {
         return path.lastIndexOf(ch);
     }
 
-    @SuppressWarnings("MagicNumber")
     public static char convertDigit(final int value) {
         return _hex[value & 0x0f];
     }
@@ -460,7 +457,6 @@ public final class HartshornUtils {
         return current;
     }
 
-    @SuppressWarnings("OverlyComplexMethod")
     public static int damerauLevenshteinDistance(
             @NonNls final CharSequence source, @NonNls final CharSequence target) {
         final int length = verifyContentLength(source, target);
@@ -575,7 +571,6 @@ public final class HartshornUtils {
         return HartshornUtils.createString(bytes, "UTF-8");
     }
 
-    @SuppressWarnings("MagicNumber")
     public static int hashCodeIgnoreCase(final CharSequence s) {
         if (null == s) return 0;
         int hash = 0;
@@ -694,7 +689,7 @@ public final class HartshornUtils {
         }
         return file;
     }
-
+    
     public static String contentOrEmpty(@NotNull final Path file) {
         try {
             return Files.readString(file);
@@ -704,7 +699,6 @@ public final class HartshornUtils {
         }
     }
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static boolean unwrap(final Optional<Boolean> optional) {
         return optional.isPresent() && optional.get();
     }
@@ -766,7 +760,6 @@ public final class HartshornUtils {
      *
      * @return true if the defined vector is inside the 3D cuboid region
      */
-    @SuppressWarnings("OverlyComplexBooleanExpression")
     public static boolean inCuboidRegion(final int x_min, final int x_max, final int y_min, final int y_max, final int z_min, final int z_max, final int x, final int y, final int z) {
         return x_min <= x && x <= x_max
                 && y_min <= y && y <= y_max
@@ -794,7 +787,6 @@ public final class HartshornUtils {
         return Vector3N.of(centerX, centerY, centerZ);
     }
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static Exceptional<LocalDateTime> toLocalDateTime(final Optional<Instant> optionalInstant) {
         return Exceptional.of(optionalInstant).map(HartshornUtils::toLocalDateTime);
     }
@@ -876,7 +868,6 @@ public final class HartshornUtils {
 
     public static boolean equals(@NonNls final String str1, @NonNls final String str2) {
         if (null == str1 || null == str2) {
-            //noinspection StringEquality
             return str1 == str2;
         }
         return str1.equals(str2);
@@ -884,7 +875,6 @@ public final class HartshornUtils {
 
     public static boolean equalsIgnoreCase(@NonNls final String s1, @NonNls final String s2) {
         if (null == s1 || null == s2) {
-            //noinspection StringEquality
             return s1 == s2;
         }
         return s1.equalsIgnoreCase(s2);
@@ -892,7 +882,6 @@ public final class HartshornUtils {
 
     public static boolean equalsWithTrim(@NonNls final String s1, @NonNls final String s2) {
         if (null == s1 || null == s2) {
-            //noinspection StringEquality
             return s1 == s2;
         }
         return s1.trim().equals(s2.trim());
@@ -900,7 +889,6 @@ public final class HartshornUtils {
 
     public static boolean equalsIgnoreCaseWithTrim(@NonNls final String s1, @NonNls final String s2) {
         if (null == s1 || null == s2) {
-            //noinspection StringEquality
             return s1 == s2;
         }
         return s1.trim().equalsIgnoreCase(s2.trim());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MultiMap.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MultiMap.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-@SuppressWarnings("SuspiciousMethodCalls")
 public abstract class MultiMap<K, V> {
 
     private final Map<K, Collection<V>> map = HartshornUtils.emptyMap();
@@ -99,4 +98,3 @@ public abstract class MultiMap<K, V> {
         return false;
     }
 }
- 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/NamedImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/NamedImpl.java
@@ -23,7 +23,6 @@ import javax.inject.Named;
 
 import lombok.AllArgsConstructor;
 
-@SuppressWarnings("ClassExplicitlyAnnotation")
 @AllArgsConstructor
 public class NamedImpl implements Named {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -54,7 +54,6 @@ import javax.inject.Inject;
 import javassist.util.proxy.ProxyFactory;
 import lombok.Getter;
 
-@SuppressWarnings({ "unchecked", "rawtypes" })
 public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
 
     private static final Map<Class<?>, TypeContext<?>> CACHE = HartshornUtils.emptyConcurrentMap();
@@ -329,7 +328,6 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         final Class<T> from = this.type();
 
         if (null == to || null == from) return false;
-        //noinspection ConstantConditions
         if (to == from || to.equals(from)) return true;
 
         if (to.isAssignableFrom(from)) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Exceptional.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Exceptional.java
@@ -86,7 +86,6 @@ public final class Exceptional<T> {
      *
      * @return The {@link Exceptional}
      */
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static <T> Exceptional<T> of(final Optional<T> optional) {
         return optional.map(Exceptional::of).orElseGet(Exceptional::empty);
     }
@@ -117,8 +116,7 @@ public final class Exceptional<T> {
      * @return The none {@link Exceptional}
      */
     public static <T> Exceptional<T> empty() {
-        @SuppressWarnings("unchecked") final Exceptional<T> t = (Exceptional<T>) EMPTY;
-        return t;
+        return (Exceptional<T>) EMPTY;
     }
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/keys/KeyHolder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/keys/KeyHolder.java
@@ -29,7 +29,6 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
  * @param <T>
  *         The type which the {@link Key} can modify.
  */
-@SuppressWarnings("rawtypes")
 public interface KeyHolder<T extends KeyHolder> extends ContextCarrier {
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/keys/Keys.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/keys/Keys.java
@@ -96,7 +96,6 @@ public final class Keys {
         return new KeyBuilder<>();
     }
 
-    @SuppressWarnings("ClassReferencesSubclass")
     public static class KeyBuilder<K, A> {
 
         protected BiFunction<K, A, TransactionResult> setter;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/keys/RemovableKey.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/keys/RemovableKey.java
@@ -33,7 +33,6 @@ import java.util.function.Function;
  * @param <A>
  *         The type parameter indicating the constraint for the value to be applied/retrieved.
  */
-@SuppressWarnings("AbstractClassWithoutAbstractMethods")
 public abstract class RemovableKey<K, A> extends Key<K, A> {
 
     private final Consumer<K> remover;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ExceptionalTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ExceptionalTests.java
@@ -27,7 +27,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
-@SuppressWarnings("ResultOfMethodCallIgnored")
 public class ExceptionalTests {
 
     @Test

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -42,7 +42,6 @@ import java.util.stream.Stream;
 
 import javassist.util.proxy.ProxyFactory;
 
-@SuppressWarnings("ALL")
 public class ReflectTests extends ApplicationAwareTest {
 
     private static Stream<Arguments> fields() {
@@ -124,17 +123,17 @@ public class ReflectTests extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("fields")
-    void testFieldValueReturnsValue(String field) {
+    void testFieldValueReturnsValue(final String field) {
         final ReflectTestType instance = new ReflectTestType();
         final TypeContext<ReflectTestType> type = TypeContext.of(instance);
-        Exceptional<?> value = type.field(field).get().get(instance);
+        final Exceptional<?> value = type.field(field).get().get(instance);
         Assertions.assertTrue(value.present());
         Assertions.assertEquals(field, value.get());
     }
 
     @ParameterizedTest
     @MethodSource("methods")
-    void testRunMethodReturnsValue(String method) {
+    void testRunMethodReturnsValue(final String method) {
         final ReflectTestType instance = new ReflectTestType();
         final TypeContext<ReflectTestType> type = TypeContext.of(instance);
         final Exceptional<?> value = type.method(method, HartshornUtils.asList(TypeContext.of(String.class))).get().invoke(instance, "value");
@@ -144,7 +143,7 @@ public class ReflectTests extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("assignablePrimitives")
-    void testAssignableFromPrimitives(Class<?> primitive, Class<?> wrapper) {
+    void testAssignableFromPrimitives(final Class<?> primitive, final Class<?> wrapper) {
         final TypeContext<?> pt = TypeContext.of(primitive);
         final TypeContext<?> wt = TypeContext.of(wrapper);
         Assertions.assertTrue(pt.childOf(wt));
@@ -167,7 +166,7 @@ public class ReflectTests extends ApplicationAwareTest {
         final List<MethodContext<?, ReflectTestType>> methods = type.methods(Demo.class);
         Assertions.assertEquals(3, methods.size());
 
-        List<String> names = methods.stream().map(MethodContext::name).toList();
+        final List<String> names = methods.stream().map(MethodContext::name).toList();
         Assertions.assertTrue(names.contains("publicAnnotatedMethod"));
         Assertions.assertTrue(names.contains("privateAnnotatedMethod"));
     }
@@ -175,7 +174,7 @@ public class ReflectTests extends ApplicationAwareTest {
     @Test
     void testAnnotatedTypesReturnsAllInPrefix() {
         final PrefixContext context = new PrefixContext(HartshornUtils.asList("org.dockbox.hartshorn.core.types"), this.context().environment());
-        Collection<TypeContext<?>> types = context.types(Demo.class);
+        final Collection<TypeContext<?>> types = context.types(Demo.class);
         Assertions.assertEquals(1, types.size());
         Assertions.assertEquals(ReflectTestType.class, types.iterator().next().type());
     }
@@ -183,7 +182,7 @@ public class ReflectTests extends ApplicationAwareTest {
     @Test
     void testSubTypesReturnsAllSubTypes() {
         final PrefixContext context = new PrefixContext(HartshornUtils.asList("org.dockbox.hartshorn.core.types"), this.context().environment());
-        Collection<TypeContext<? extends ParentTestType>> types = context.children(ParentTestType.class);
+        final Collection<TypeContext<? extends ParentTestType>> types = context.children(ParentTestType.class);
         Assertions.assertEquals(1, types.size());
         Assertions.assertEquals(ReflectTestType.class, types.iterator().next().type());
     }
@@ -191,13 +190,13 @@ public class ReflectTests extends ApplicationAwareTest {
     @Test
     void testStaticFieldsReturnsAllModifiers() {
         final List<FieldContext<?>> fields = TypeContext.of(ReflectTestType.class).fields().stream()
-                .filter(field -> field.isStatic())
+                .filter(FieldContext::isStatic)
                 .collect(Collectors.toList());
         Assertions.assertEquals(2, fields.size());
     }
 
     @Test
-    void testHasAnnotationOnMethod() throws NoSuchMethodException {
+    void testHasAnnotationOnMethod() {
         final Exceptional<MethodContext<?, ReflectTestType>> method = TypeContext.of(ReflectTestType.class).method("publicAnnotatedMethod");
         Assertions.assertTrue(method.present());
         Assertions.assertTrue(method.get().annotation(Demo.class).present());
@@ -211,11 +210,11 @@ public class ReflectTests extends ApplicationAwareTest {
     }
 
     @Test
-    void testMethodsReturnsAllDeclaredAndParentMethods() throws NoSuchMethodException {
+    void testMethodsReturnsAllDeclaredAndParentMethods() {
         final TypeContext<ReflectTestType> type = TypeContext.of(ReflectTestType.class);
         final List<MethodContext<?, ReflectTestType>> methods = type.methods();
         boolean fail = true;
-        for (MethodContext<?, ReflectTestType> method : methods) {
+        for (final MethodContext<?, ReflectTestType> method : methods) {
             if (method.name().equals("parentMethod")) fail = false;
         }
         if (fail) Assertions.fail("Parent types were not included");
@@ -223,14 +222,14 @@ public class ReflectTests extends ApplicationAwareTest {
 
     @Test
     void testLookupReturnsClassIfPresent() {
-        TypeContext<?> lookup = TypeContext.lookup("org.dockbox.hartshorn.core.types.ReflectTestType");
+        final TypeContext<?> lookup = TypeContext.lookup("org.dockbox.hartshorn.core.types.ReflectTestType");
         Assertions.assertNotNull(lookup);
         Assertions.assertEquals(ReflectTestType.class, lookup.type());
     }
 
     @Test
     void testLookupReturnsNullIfAbsent() {
-        TypeContext<?> lookup = TypeContext.lookup("org.dockbox.hartshorn.util.AnotherClass");
+        final TypeContext<?> lookup = TypeContext.lookup("org.dockbox.hartshorn.util.AnotherClass");
         Assertions.assertEquals(TypeContext.VOID, lookup);
     }
 
@@ -256,7 +255,7 @@ public class ReflectTests extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("nonVoidTypes")
-    void testVoidIsFalseIfTypeIsNotVoid(Class<?> type) {
+    void testVoidIsFalseIfTypeIsNotVoid(final Class<?> type) {
         Assertions.assertFalse(TypeContext.of(type).isVoid());
     }
 
@@ -272,25 +271,25 @@ public class ReflectTests extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("fields")
-    void testHasFieldReturnsTrue(String field) {
+    void testHasFieldReturnsTrue(final String field) {
         Assertions.assertTrue(TypeContext.of(ReflectTestType.class).field(field).present());
     }
 
     @ParameterizedTest
     @MethodSource("fields")
-    void testFieldsConsumesAllFields(String field) {
+    void testFieldsConsumesAllFields(final String field) {
         boolean activated = false;
         final TypeContext<ReflectTestType> type = TypeContext.of(ReflectTestType.class);
-        for (FieldContext<?> fieldContext : type.fields()) {
+        for (final FieldContext<?> fieldContext : type.fields()) {
             if (fieldContext.name().equals(field)) activated = true;
         }
         Assertions.assertTrue(activated);
     }
 
     @Test
-    void testSetFieldUpdatesAccessorField() throws NoSuchFieldException, IllegalAccessException {
-        Field fieldRef = ReflectTestType.class.getDeclaredField("accessorField");
-        ReflectTestType instance = new ReflectTestType();
+    void testSetFieldUpdatesAccessorField() throws NoSuchFieldException {
+        final Field fieldRef = ReflectTestType.class.getDeclaredField("accessorField");
+        final ReflectTestType instance = new ReflectTestType();
         final FieldContext<?> field = FieldContext.of(fieldRef);
         field.set(instance, "newValue");
 
@@ -298,9 +297,9 @@ public class ReflectTests extends ApplicationAwareTest {
     }
 
     @Test
-    void testSetFieldUpdatesNormalField() throws NoSuchFieldException, IllegalAccessException {
-        Field fieldRef = ReflectTestType.class.getDeclaredField("publicField");
-        ReflectTestType instance = new ReflectTestType();
+    void testSetFieldUpdatesNormalField() throws NoSuchFieldException {
+        final Field fieldRef = ReflectTestType.class.getDeclaredField("publicField");
+        final ReflectTestType instance = new ReflectTestType();
         final FieldContext<?> field = FieldContext.of(fieldRef);
         field.set(instance, "newValue");
 
@@ -312,7 +311,7 @@ public class ReflectTests extends ApplicationAwareTest {
         final List<FieldContext<?>> fields = TypeContext.of(ReflectTestType.class).fields(Demo.class);
         Assertions.assertEquals(2, fields.size());
         int statics = 0;
-        for (FieldContext<?> field : fields) {
+        for (final FieldContext<?> field : fields) {
             if (field.isStatic()) statics++;
         }
         Assertions.assertEquals(1, statics);
@@ -326,8 +325,8 @@ public class ReflectTests extends ApplicationAwareTest {
     }
 
     @Test
-    void testIsProxyIsTrueIfTypeIsProxy() throws InstantiationException, IllegalAccessException {
-        Class<?> type = new ProxyFactory().createClass();
+    void testIsProxyIsTrueIfTypeIsProxy() {
+        final Class<?> type = new ProxyFactory().createClass();
         Assertions.assertTrue(TypeContext.of(type).isProxy());
     }
 
@@ -338,9 +337,9 @@ public class ReflectTests extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("primitiveValues")
-    void testStringToPrimitive(Class<?> type, String value, Object expected) throws TypeConversionException {
-        byte b = 0x0;
-        Object o = TypeContext.toPrimitive(TypeContext.of(type), value);
+    void testStringToPrimitive(final Class<?> type, final String value, final Object expected) throws TypeConversionException {
+        final byte b = 0x0;
+        final Object o = TypeContext.toPrimitive(TypeContext.of(type), value);
         Assertions.assertNotNull(o);
         Assertions.assertEquals(expected, o);
     }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ReflectTestType.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ReflectTestType.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 
 import lombok.Getter;
 
-@SuppressWarnings("FieldMayBeFinal")
 @Demo
 public class ReflectTestType extends ParentTestType {
 

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -40,7 +40,6 @@ import javax.inject.Singleton;
  * A simple default implementation of {@link EventBus}, used for internal event posting and
  * handling.
  */
-@SuppressWarnings("EqualsWithItself")
 @Binds(EventBus.class)
 @Singleton
 public class EventBusImpl implements EventBus {

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/properties/Remotes.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/properties/Remotes.java
@@ -56,7 +56,6 @@ public enum Remotes implements Remote {
     @Override
     public String url(final Object target) {
         if (this.target.isInstance(target)) {
-            //noinspection unchecked
             return ((Function<Object, String>) this.urlGen).apply(target);
         }
         throw new IllegalArgumentException("Provided target was expected to be of type " + this.target.getSimpleName() + " but was: " + target);

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/registry/Registry.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/registry/Registry.java
@@ -28,7 +28,6 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@SuppressWarnings({ "UnusedReturnValue", "unused" })
 public class Registry<V> extends HashMap<String, RegistryColumn<V>> {
 
     public Registry() {}

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/registry/RegistryColumn.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/registry/RegistryColumn.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-@SuppressWarnings({ "UnusedReturnValue", "unused" })
 public class RegistryColumn<T> extends ArrayList<T> {
 
     public RegistryColumn() {
@@ -108,7 +107,7 @@ public class RegistryColumn<T> extends ArrayList<T> {
 
         for (final T value : this) {
             if (clazz.isInstance(value)) {
-                @SuppressWarnings("unchecked") final K convertedValue = (K) value;
+                final K convertedValue = (K) value;
                 result.add(convertedValue);
             }
         }

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/registry/RegistryIdentifierImpl.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/registry/RegistryIdentifierImpl.java
@@ -34,7 +34,6 @@ public class RegistryIdentifierImpl implements RegistryIdentifier {
     }
 
     // Intended to support RegistryIdentifier implementations
-    @SuppressWarnings({ "EqualsWhichDoesntCheckParameterClass", "EqualsDoesntCheckParameterClass" })
     @Override
     public boolean equals(final Object o) {
         return RegistryIdentifier.super.same(o);

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/table/Table.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/table/Table.java
@@ -56,7 +56,6 @@ import lombok.Getter;
  * @author Simbolduc, GuusLieben
  * @since feature/S124
  */
-@SuppressWarnings({ "unchecked", "rawtypes" })
 public class Table {
 
     private static final Map<TypeContext<?>, List<ColumnIdentifier<?>>> DEFINITIONS = HartshornUtils.emptyMap();
@@ -140,6 +139,7 @@ public class Table {
         return new Table(DEFINITIONS.getOrDefault(type, HartshornUtils.emptyList()));
     }
 
+    @SafeVarargs
     public static <T> Table of(final TypeContext<T> type, final T... defaultEntries) {
         final Table table = Table.of(type);
         for (final T entry : defaultEntries) {

--- a/hartshorn-persistence/src/test/java/org/dockbox/hartshorn/persistence/SqlServiceTest.java
+++ b/hartshorn-persistence/src/test/java/org/dockbox/hartshorn/persistence/SqlServiceTest.java
@@ -78,18 +78,17 @@ class SqlServiceTest extends ApplicationAwareTest {
     }
 
     protected static PersistenceConnection connection(final Remote remote, final JdbcDatabaseContainer<?> container, final int defaultPort) {
-        SQLRemoteServer server = SQLRemoteServer.of("localhost", container.getMappedPort(defaultPort), DEFAULT_DATABASE);
+        final SQLRemoteServer server = SQLRemoteServer.of("localhost", container.getMappedPort(defaultPort), DEFAULT_DATABASE);
         return new PersistenceConnection(remote.url(server), container.getUsername(), container.getPassword(), remote);
     }
 
-    protected static PersistenceConnection directory(Remote remote, final String prefix) {
+    protected static PersistenceConnection directory(final Remote remote, final String prefix) {
         try {
-            Path dir = Files.createTempDirectory(prefix);
+            final Path dir = Files.createTempDirectory(prefix);
             return new PersistenceConnection(remote.url(dir), "", "", remote);
         }
         catch (final Exception e) {
             Assumptions.assumeTrue(false);
-            //noinspection ReturnOfNull
             return null;
         }
     }

--- a/hartshorn-persistence/src/test/java/org/junit/rules/TestRule.java
+++ b/hartshorn-persistence/src/test/java/org/junit/rules/TestRule.java
@@ -23,6 +23,5 @@ package org.junit.rules;
  * purely a placeholder to avoid runtime classloader issues.
  * @see <a href="https://github.com/testcontainers/testcontainers-java/issues/970">testcontainers/testcontainers-java #970</a>
  */
-@SuppressWarnings("unused")
 public interface TestRule {
 }

--- a/hartshorn-persistence/src/test/java/org/junit/runners/model/Statement.java
+++ b/hartshorn-persistence/src/test/java/org/junit/runners/model/Statement.java
@@ -23,6 +23,5 @@ package org.junit.runners.model;
  * purely a placeholder to avoid runtime classloader issues.
  * @see <a href="https://github.com/testcontainers/testcontainers-java/issues/970">testcontainers/testcontainers-java #970</a>
  */
-@SuppressWarnings("unused")
 public class Statement {
 }

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/PipelineTask.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/PipelineTask.java
@@ -20,7 +20,6 @@ package org.dockbox.hartshorn.core.task;
 import org.dockbox.hartshorn.core.task.pipeline.pipelines.Pipeline;
 import org.dockbox.hartshorn.core.task.pipeline.pipes.EqualPipe;
 
-@SuppressWarnings("AbstractClassNeverImplemented") // API type
 public abstract class PipelineTask extends AbstractTask {
 
     private final Pipeline<Void> pipeline;

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/CancellablePipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/CancellablePipe.java
@@ -35,7 +35,6 @@ public interface CancellablePipe<I, O> extends ComplexPipe<I, O> {
 
     O execute(Runnable cancelPipeline, I input, Throwable throwable) throws ApplicationException;
 
-    @SuppressWarnings("rawtypes")
     @Override
     default TypeContext<CancellablePipe> type() {
         return TypeContext.of(CancellablePipe.class);

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ComplexPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ComplexPipe.java
@@ -30,7 +30,6 @@ public interface ComplexPipe<I, O> extends IPipe<I, O> {
 
     O apply(AbstractPipeline<?, I> pipeline, I input, Throwable throwable) throws ApplicationException;
 
-    @SuppressWarnings("rawtypes")
     @Override
     default TypeContext<? extends IPipe> type() {
         return TypeContext.of(ComplexPipe.class);

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/IPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/IPipe.java
@@ -26,7 +26,6 @@ public interface IPipe<I, O> {
      *
      * @return The {@link Class} of the pipe.
      */
-    @SuppressWarnings("rawtypes")
     default TypeContext<? extends IPipe> type() {
         return TypeContext.of(IPipe.class);
     }

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ListenerPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ListenerPipe.java
@@ -20,7 +20,6 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
-@SuppressWarnings("InterfaceNeverImplemented") // API type
 @FunctionalInterface
 public interface ListenerPipe<I> extends StandardPipe<I, I> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/OutputPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/OutputPipe.java
@@ -20,7 +20,6 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
-@SuppressWarnings("InterfaceNeverImplemented") // API type
 @FunctionalInterface
 public interface OutputPipe<O> extends StandardPipe<O, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/StandardPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/StandardPipe.java
@@ -30,7 +30,6 @@ public interface StandardPipe<I, O> extends IPipe<I, O> {
 
     O apply(Exceptional<I> input) throws ApplicationException;
 
-    @SuppressWarnings("rawtypes")
     @Override
     default TypeContext<? extends IPipe> type() {
         return TypeContext.of(StandardPipe.class);

--- a/hartshorn-tasks/src/test/java/org/dockbox/hartshorn/core/task/PipelineTests.java
+++ b/hartshorn-tasks/src/test/java/org/dockbox/hartshorn/core/task/PipelineTests.java
@@ -161,7 +161,6 @@ public class PipelineTests {
         Assertions.assertEquals(11, output);
     }
 
-    @SuppressWarnings("ReturnOfNull")
     @Test
     public void processingCollectionInputsTest() {
         final List<Integer> output = new Pipeline<Integer>()

--- a/hartshorn-tasks/src/test/java/org/dockbox/hartshorn/core/task/TaskRunnerTests.java
+++ b/hartshorn-tasks/src/test/java/org/dockbox/hartshorn/core/task/TaskRunnerTests.java
@@ -38,7 +38,6 @@ public class TaskRunnerTests extends ApplicationAwareTest {
         Assertions.assertTrue(activated[0]);
     }
 
-    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void testTaskRunsDelayed() throws InterruptedException {
         final TaskRunner runner = this.context().get(TaskRunner.class);


### PR DESCRIPTION
Fixes #514

# Motivation
I've noticed several inspections are still suppressed even though the inspection was removed from the codestyle a longer time ago. Overall this lead me to consider the overall removal of suppressions, as warnings should be handled immediately instead of be ignored for another time.  

There are currently 13 `noinspection`, and 40 `@SuppressWarnings` suppressions across various modules. Most targeting `unused`, `unchecked`, and `rawtypes`. I've removed these suppressions and resolved any usages where relevant warnings were still given.