### PR TITLE
#519 Return persisted entity when updating or saving through `JpaRepository`

### DIFF
--- a/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/UserRepository.java
+++ b/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/UserRepository.java
@@ -66,8 +66,9 @@ public abstract class UserRepository implements JpaRepository<User, Long>, Deleg
      * logs the action.
      */
     @Override
-    public void save(final User object) {
+    public User save(final User object) {
         this.delegator(JpaRepository.class).get().save(object);
         this.eventBus.post(new UserCreatedEvent(object));
+        return object;
     }
 }

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/jpa/JpaRepository.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/jpa/JpaRepository.java
@@ -27,11 +27,11 @@ import javax.persistence.EntityManager;
 
 public interface JpaRepository<T, ID> extends ContextCarrier {
 
-    void save(final T object);
+    T save(final T object);
 
-    void update(T object);
+    T update(T object);
 
-    void updateOrSave(T object);
+    T updateOrSave(T object);
 
     void delete(T object);
 


### PR DESCRIPTION
Fixes #519

# Motivation
Convenience feature, directly returns the saved or updated entity through `JpaRepository` for all save/update actions. 

## Type of change
- [x] New QoL feature