### PR TITLE
#520 Validate `PersistenceConnection` before opening session in `HibernateJpaRepository`

### DIFF
--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateJpaRepository.java
@@ -222,7 +222,10 @@ public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enab
 
     public Session session() {
         if (this.session != null && this.session.isOpen()) return this.session;
-        this.applicationContext().log().debug("Opening remote session to %s".formatted(this.connection().url()));
+        final PersistenceConnection connection = this.connection();
+        if (connection == null) throw new IllegalStateException("Connection has not been configured!");
+
+        this.applicationContext().log().debug("Opening remote session to %s".formatted(connection.url()));
         return this.factory().openSession();
     }
 }


### PR DESCRIPTION
Fixes #520 

# Motivation
> When a session is requested in the `HibernateJpaRepository` while no active session exists, the session is created using the connection present in the repository. However the presence of the connection is not validated. This causes `HibernateJpaRepository#session` to throw an NPE when `connection().url()` is requested.

# Changes
The connection will now be validated beforehand, if the connection is absent an exception is thrown before a session can be created.

## Type of change
- [x] Bug fix