### PR TITLE
#522 Correctly pass exceptions when handling servlets

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/ApplicationException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/ApplicationException.java
@@ -39,4 +39,12 @@ public class ApplicationException extends Exception {
     public RuntimeException runtime() {
         return new RuntimeException(this);
     }
+
+    public Throwable unwrap() {
+        Throwable root = this;
+        while (root.getCause() instanceof ApplicationException applicationException && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root;
+    }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -119,7 +119,15 @@ public class ServletHandler implements Enableable {
                         throw new ApplicationException(e);
                     }
                 }
+                else {
+                    if (result.caught()) throw new ApplicationException(result.error());
+                    else {
+                        res.setStatus(HttpStatus.NO_CONTENT.value());
+                    }
+                    return;
+                }
             }
+
             fallbackAction.fallback(req, res);
         }
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -92,7 +92,6 @@ public class ServletHandler implements Enableable {
                 if (result.present()) {
                     this.context.log().debug("Request %s processed for session %s, writing response body".formatted(request, sessionId));
                     try {
-                        res.setStatus(HttpStatus.OK.value());
                         if (String.class.equals(result.type())) {
                             res.setContentType("text/plain");
                             this.context.log().debug("Returning plain body for request %s".formatted(request));

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
@@ -17,6 +17,8 @@
 
 package org.dockbox.hartshorn.web.jetty;
 
+import org.dockbox.hartshorn.config.annotations.Value;
+import org.dockbox.hartshorn.core.annotations.component.Component;
 import org.dockbox.hartshorn.core.boot.Hartshorn;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
@@ -46,12 +48,16 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+@Component
 public class JettyErrorHandler extends ErrorHandler {
 
     @Inject
     private ApplicationContext context;
     @Inject
     private ErrorServlet errorServlet;
+
+    @Value(value = "hartshorn.web.headers.hartshorn", or = "true")
+    private boolean addHeader;
 
     @Override
     protected void generateAcceptableResponse(final Request baseRequest, final HttpServletRequest request, final HttpServletResponse response, final int code, String message, final String contentType)
@@ -65,7 +71,7 @@ public class JettyErrorHandler extends ErrorHandler {
             final PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, charset));
 
             response.setCharacterEncoding(charset.name());
-            response.addHeader("Hartshorn-Version", Hartshorn.VERSION);
+            if (this.addHeader) response.addHeader("Hartshorn-Version", Hartshorn.VERSION);
 
             final Throwable th = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
             final RequestError error = new RequestErrorImpl(this.context, request, response, code, writer, message, th);

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -81,11 +81,13 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
             if (this.server != null)
                 this.server.stop();
 
+            this.context.log().info("Starting service [JettyServer]");
             this.server = this.context.get(JettyServer.class);
             this.server.setConnectors(new Connector[]{ this.connector(this.server, port) });
             this.server.setHandler(this.servletHandler);
             this.server.setErrorHandler(this.errorHandler());
             this.server.start();
+            this.context.log().info("Service [JettyServer] started on port [{}]", port);
         } catch (final Exception e) {
             throw new ApplicationException(e);
         }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -35,7 +35,6 @@ import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -58,7 +57,7 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
     private final HandlerWrapper servletHandler;
     @Getter @Setter
     private PersistenceModifier skipBehavior = PersistenceModifier.SKIP_NONE;
-    private Server server;
+    private JettyServer server;
 
     @Inject
     public JettyHttpWebServer(final JettyResourceService resourceService) {
@@ -82,10 +81,7 @@ public class JettyHttpWebServer extends DefaultHttpWebServer {
             if (this.server != null)
                 this.server.stop();
 
-            final QueuedThreadPool threadPool = new QueuedThreadPool();
-            threadPool.setName(Hartshorn.PROJECT_NAME);
-
-            this.server = new Server(threadPool);
+            this.server = this.context.get(JettyServer.class);
             this.server.setConnectors(new Connector[]{ this.connector(this.server, port) });
             this.server.setHandler(this.servletHandler);
             this.server.setErrorHandler(this.errorHandler());

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
@@ -3,8 +3,8 @@ package org.dockbox.hartshorn.web.jetty;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.Except;
+import org.dockbox.hartshorn.web.HttpStatus;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -33,7 +33,7 @@ public class JettyServer extends Server {
         if (HttpMethod.OPTIONS.is(request.getMethod()) || "*".equals(target)) {
             if (!HttpMethod.OPTIONS.is(request.getMethod())) {
                 request.setHandled(true);
-                response.sendError(HttpStatus.BAD_REQUEST_400);
+                response.sendError(HttpStatus.BAD_REQUEST.value());
             }
             else {
                 this.handleOptions(request, response);
@@ -55,7 +55,8 @@ public class JettyServer extends Server {
                 if (cause instanceof ApplicationException) cause = cause.getCause();
 
                 request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, cause);
-                this.errorHandler.generateAcceptableResponse(request, request, response, org.dockbox.hartshorn.web.HttpStatus.INTERNAL_SERVER_ERROR.value(), cause.getMessage(), contentType);
+                response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                this.errorHandler.generateAcceptableResponse(request, request, response, HttpStatus.INTERNAL_SERVER_ERROR.value(), cause.getMessage(), contentType);
             }
         }
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
@@ -1,0 +1,62 @@
+package org.dockbox.hartshorn.web.jetty;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+
+public class JettyServer extends Server {
+
+    @Inject
+    private JettyErrorHandler errorHandler;
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void handle(final HttpChannel channel) throws IOException, ServletException {
+        final String target = channel.getRequest().getPathInfo();
+        final Request request = channel.getRequest();
+        final Response response = channel.getResponse();
+
+        if (HttpMethod.OPTIONS.is(request.getMethod()) || "*".equals(target)) {
+            if (!HttpMethod.OPTIONS.is(request.getMethod())) {
+                request.setHandled(true);
+                response.sendError(HttpStatus.BAD_REQUEST_400);
+            }
+            else {
+                this.handleOptions(request, response);
+                if (!request.isHandled())
+                    this.handle(target, request, request, response);
+            }
+        }
+        else {
+            try {
+                this.handle(target, request, request, response);
+            }
+            catch (final Throwable e) {
+                Except.handle("Encountered unexpected exception while handling request", e);
+                String contentType = response.getContentType();
+                if (contentType == null) contentType = "";
+                Throwable cause = e;
+                // Ensure we unwrap internal exceptions before proceeding
+                if (e instanceof ServletException) cause = e.getCause();
+                if (cause instanceof ApplicationException) cause = cause.getCause();
+
+                request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, cause);
+                this.errorHandler.generateAcceptableResponse(request, request, response, org.dockbox.hartshorn.web.HttpStatus.INTERNAL_SERVER_ERROR.value(), cause.getMessage(), contentType);
+            }
+        }
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -80,7 +80,7 @@ public class HttpWebServletAdapter extends HttpServlet {
         catch (final ApplicationException e) {
             if (e.getCause() instanceof ServletException servletException) throw servletException;
             else if (e.getCause() instanceof IOException ioException) throw ioException;
-            else throw new ServletException(e);
+            else throw new ServletException(e.unwrap());
         }
     }
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -80,7 +80,7 @@ public class HttpWebServletAdapter extends HttpServlet {
         catch (final ApplicationException e) {
             if (e.getCause() instanceof ServletException servletException) throw servletException;
             else if (e.getCause() instanceof IOException ioException) throw ioException;
-            else throw e.runtime();
+            else throw new ServletException(e);
         }
     }
 


### PR DESCRIPTION
Fixes #522

# Motivation
> When an exception is thrown inside a servlet handler, the exception is ignored. This causes the application to immediately fall back to default behavior, which typically is returning SC405 (method not supported).

# Changes
Will now correctly pass exceptions when handling servlets. If an exception is thrown it is rethrown so Jetty can handle it appropriately (this will pass it into the configured `ErrorServlet` so you keep control of everything). If no response was given, and no exception was thrown the status code `204` (No content) is returned instead of falling back to `405` (Method not supported)

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Integration testing