### PR TITLE
#521 Correctly pass exceptions in delegated methods

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -86,7 +86,7 @@ public class CommandGatewayImpl implements CommandGateway, Enableable {
                 this.execute(context.get(), commandContext.get());
             }
             else if (commandContext.caught()) {
-                commandContext.rethrow();
+                commandContext.rethrowUnchecked();
             }
             else {
                 this.context.log().warn("Could not parse command for input " + command + " but yielded no exceptions");

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServiceProcessor.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServiceProcessor.java
@@ -60,7 +60,7 @@ public class ArgumentServiceProcessor implements ServiceProcessor<UseCommands> {
                 }
             }
             return null;
-        }).rethrow();
+        }).rethrowUnchecked();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/AnnotationHelper.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/AnnotationHelper.java
@@ -83,7 +83,7 @@ public final class AnnotationHelper {
             ret = Exceptional.of(supplier::get);
             cache.put(keys, ret);
         }
-        ret.rethrow();
+        ret.rethrowUnchecked();
         return (T) ret.orNull();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -388,7 +388,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
                     final Exceptional<T> rawCandidate = instanceCandidate.orElse(() -> this.raw(type));
                     if (rawCandidate.absent()) {
                         final Throwable finalCause = cause;
-                        return this.environment().manager().proxy(type, typeInstance).rethrow().orThrow(() -> finalCause);
+                        return this.environment().manager().proxy(type, typeInstance).rethrowUnchecked().orThrow(() -> finalCause);
                     }
                     else {
                         return rawCandidate.get();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Exceptional.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Exceptional.java
@@ -562,11 +562,17 @@ public final class Exceptional<T> {
      * @throws RuntimeException
      *         If {@code throwable} is not null and is rethrown
      */
-    public Exceptional<T> rethrow() {
+    public Exceptional<T> rethrowUnchecked() {
         if (null != this.throwable) {
             if (this.throwable instanceof RuntimeException) throw (RuntimeException) this.throwable;
             else throw new RuntimeException(this.throwable);
         }
+        return this;
+    }
+
+    public Exceptional<T> rethrow() throws Throwable {
+        if (null != this.throwable)
+            throw this.throwable;
         return this;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/JavassistProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/JavassistProxyHandler.java
@@ -121,7 +121,7 @@ public class JavassistProxyHandler<T> extends DefaultContext implements ProxyHan
             final Method proceed,
             final Object self,
             Object returnValue
-    ) throws InvocationTargetException, IllegalAccessException, ApplicationException {
+    ) throws Throwable {
         // Used to ensure the target is performed if there is no OVERWRITE phase hook
         boolean target = true;
         for (final MethodProxyContext<T, ?> property : properties) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/MethodProxyContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/MethodProxyContext.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.core.proxy;
 
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
 import java.lang.reflect.Method;
 
@@ -55,7 +54,7 @@ public final class MethodProxyContext<T, R> {
         return this.target().getDeclaringClass();
     }
 
-    public R delegate(final T instance, final MethodContext<?, ?> proceed, final Object self, final Object... args) throws ApplicationException {
+    public R delegate(final T instance, final MethodContext<?, ?> proceed, final Object self, final Object... args) throws Throwable {
         this.holder.cancelled(false);
         return this.delegate.delegate(instance, args, new ProxyContextImpl(proceed, this.holder, self));
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyFunction.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyFunction.java
@@ -17,10 +17,8 @@
 
 package org.dockbox.hartshorn.core.proxy;
 
-import org.dockbox.hartshorn.core.exceptions.ApplicationException;
-
 @FunctionalInterface
 public interface ProxyFunction<T, R> {
 
-    R delegate(T instance, Object[] args, ProxyContext context) throws ApplicationException;
+    R delegate(T instance, Object[] args, ProxyContext context) throws Throwable;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServiceProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServiceProcessor.java
@@ -49,7 +49,7 @@ public final class ProviderServiceProcessor implements ServiceProcessor<UseServi
                     ? Key.of(method.returnType())
                     : Key.of(method.returnType(), Bindings.named(annotation.value()));
 
-            final ProviderContext<?> providerContext = new ProviderContext<>(((Key<Object>) key), singleton, annotation.priority(), () -> method.invoke(context).rethrow().orNull());
+            final ProviderContext<?> providerContext = new ProviderContext<>(((Key<Object>) key), singleton, annotation.priority(), () -> method.invoke(context).rethrowUnchecked().orNull());
             context.add(providerContext);
         }
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProxyDelegationModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProxyDelegationModifier.java
@@ -63,7 +63,7 @@ public abstract class ProxyDelegationModifier<P, A extends Annotation> extends S
             final MethodContext<?, P> parent = parentMethod.get();
             final R defaultValue = (R) parent.returnType().defaultOrNull();
             return (instance, args, proxyContext) -> {
-                R out = parent.invoke(concrete, args).map((r -> (R) r)).orElse(() -> defaultValue).orNull();
+                final R out = parent.invoke(concrete, args).rethrow().map((r -> (R) r)).orElse(() -> defaultValue).orNull();
                 if (out == concrete) return (R) handler.proxyInstance().orNull();
                 return out;
             };

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ExceptionalTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ExceptionalTests.java
@@ -421,7 +421,7 @@ public class ExceptionalTests {
         final Exceptional<String> exceptional = Exceptional.of(new Exception("error"));
 
         try {
-            exceptional.rethrow();
+            exceptional.rethrowUnchecked();
             Assertions.fail();
         }
         catch (final Throwable t) {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
@@ -34,7 +34,7 @@ public class ComponentProvisionTests extends ApplicationAwareTest {
 
     public static Stream<Arguments> components() {
         return HartshornRunner.createContext(ComponentProvisionTests.class)
-                .rethrow().get()
+                .rethrowUnchecked().get()
                 .locator()
                 .containers().stream()
                 .map(ComponentContainer::type)

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -188,7 +188,7 @@ public class EventBusImpl implements EventBus {
      */
     protected void checkListenerMethod(final MethodContext<?, ?> method) throws IllegalArgumentException {
         for (final Function<MethodContext<?, ?>, Exceptional<Boolean>> validator : this.validators) {
-            final boolean result = validator.apply(method).rethrow().get();
+            final boolean result = validator.apply(method).rethrowUnchecked().get();
             if (!result) throw new IllegalArgumentException("Unspecified validation error while validating: " + method.qualifiedName());
         }
     }

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/LanguageProviderServiceProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/LanguageProviderServiceProcessor.java
@@ -46,11 +46,11 @@ public class LanguageProviderServiceProcessor implements ServiceProcessor<UseTra
         final TranslationService translationService = context.get(TranslationService.class);
         for (final MethodContext<?, T> method : type.methods(TranslationProvider.class)) {
             if (method.returnType().childOf(TranslationBundle.class)) {
-                final TranslationBundle bundle = (TranslationBundle) method.invoke(context).rethrow().get();
+                final TranslationBundle bundle = (TranslationBundle) method.invoke(context).rethrowUnchecked().get();
                 translationService.add(bundle);
             }
             else if (method.returnType().childOf(Message.class)) {
-                final Message message = (Message) method.invoke(context).rethrow().get();
+                final Message message = (Message) method.invoke(context).rethrowUnchecked().get();
                 translationService.add(message);
             }
         }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/MvcController.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/MvcController.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.annotations;
 
 import org.dockbox.hartshorn.core.annotations.AliasFor;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/PathSpec.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/PathSpec.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.annotations;
 
 import org.dockbox.hartshorn.core.annotations.Extends;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.jetty;
 
 import org.dockbox.hartshorn.core.annotations.inject.Binds;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.jetty;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ClassPathViewTemplate.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ClassPathViewTemplate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import lombok.AllArgsConstructor;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/FileViewTemplate.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/FileViewTemplate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import java.nio.file.Path;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MVCInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MVCInitializer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MvcControllerProcessor.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MvcControllerProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/StringViewTemplate.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/StringViewTemplate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import lombok.AllArgsConstructor;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ViewModel.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ViewModel.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ViewModelImpl.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ViewModelImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 import org.dockbox.hartshorn.core.HartshornUtils;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ViewTemplate.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/ViewTemplate.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc;
 
 public interface ViewTemplate {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.mvc.freemarker;
 
 import org.dockbox.hartshorn.core.HartshornUtils;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoader.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.processing;
 
 import org.dockbox.hartshorn.core.annotations.inject.Binds;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoaderContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoaderContext.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.processing;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/ViewModelParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/ViewModelParameterRule.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.processing;
 
 import org.dockbox.hartshorn.core.context.element.ParameterContext;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/DirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/DirectoryServlet.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.servlet;
 
 import java.io.IOException;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletAction.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletAction.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.servlet;
 
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletFallback.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletFallback.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.servlet;
 
 import java.io.IOException;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.servlet;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/MvcServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/MvcServlet.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.servlet;
 
 import org.dockbox.hartshorn.core.annotations.inject.Binds;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServlet.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.servlet;
 
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;


### PR DESCRIPTION
Fixes #521
- [x] Breaking change

# Motivation
> When an exception is thrown inside a backing implementation of `ProxyDelegationModifier`, the exception is completely ignored.

# Changes
Any exceptions caused inside delegated methods will be rethrown through the proxy handler. Contrary to the original idea of checking the original method signature, this allows us to keep control of exceptions at the lowest level.

Renames `Exceptional#rethrow` to `Exceptional#rethrowUnchecked` as it causes a `RuntimeException`. The new `Exceptional#rethrow` will throw a checked `Throwable`.

## Type of change
- [x] Bug fix