### PR TITLE
#529 QoL changes to `TypeContext` and associated contexts

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
@@ -36,7 +36,13 @@ public abstract class AnnotatedElementContext<A extends AnnotatedElement> extend
         return HartshornUtils.asUnmodifiableList(this.validate().values());
     }
 
+    public <T extends Annotation> Exceptional<T> annotation(final TypeContext<T> annotation) {
+        return this.annotation(annotation.type());
+    }
+
     public <T extends Annotation> Exceptional<T> annotation(final Class<T> annotation) {
+        if (!annotation.isAnnotation()) return Exceptional.empty();
+
         final Map<Class<?>, Annotation> annotations = this.validate();
         if (annotations.containsKey(annotation))
             return Exceptional.of(() -> (T) annotations.get(annotation));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ExecutableElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ExecutableElementContext.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core.context.element;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.annotations.inject.Context;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.domain.Named;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Executable;
@@ -28,7 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class ExecutableElementContext<A extends Executable> extends AnnotatedMemberContext<A> {
+public abstract class ExecutableElementContext<A extends Executable> extends AnnotatedMemberContext<A> implements Named {
 
     private LinkedList<ParameterContext<?>> parameters;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -95,6 +95,16 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             Tuple.of(long.class, 0L),
             Tuple.of(short.class, 0)
     );
+    private static final Map<Class<?>, Class<?>> WRAPPERS_TO_PRIMITIVE = HartshornUtils.ofEntries(
+            Tuple.of(Boolean.class, boolean.class),
+            Tuple.of(Byte.class, byte.class),
+            Tuple.of(Character.class, char.class),
+            Tuple.of(Double.class, double.class),
+            Tuple.of(Float.class, float.class),
+            Tuple.of(Integer.class, int.class),
+            Tuple.of(Long.class, long.class),
+            Tuple.of(Short.class, short.class)
+    );
 
     public static final TypeContext<Void> VOID = TypeContext.of(Void.class);
 
@@ -364,7 +374,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
 
     private static boolean isPrimitiveWrapper(final Class<?> targetClass, final Class<?> primitive) {
         if (!primitive.isPrimitive()) {
-            throw new IllegalArgumentException("First argument has to be isPrimitiveWrapper type");
+            throw new IllegalArgumentException("Second argument has to be primitive type");
         }
         return PRIMITIVE_WRAPPERS.get(primitive) == targetClass;
     }
@@ -567,8 +577,13 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     }
 
     public T defaultOrNull() {
-        if (!this.isPrimitive()) return null;
-        else return (T) PRIMITIVE_DEFAULTS.getOrDefault(this.type(), null);
+        if (this.isPrimitive()) {
+            return (T) PRIMITIVE_DEFAULTS.getOrDefault(this.type(), null);
+        } else {
+            final Class<?> primitive = WRAPPERS_TO_PRIMITIVE.get(this.type());
+            if (primitive == null) return null;
+            else return (T) TypeContext.of(primitive).defaultOrNull();
+        }
     }
 
     public boolean isFinal() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypedElementContext.java
@@ -17,7 +17,8 @@
 
 package org.dockbox.hartshorn.core.context.element;
 
-public interface TypedElementContext<T> extends QualifiedElement {
+import org.dockbox.hartshorn.core.domain.Named;
+
+public interface TypedElementContext<T> extends QualifiedElement, Named {
     TypeContext<T> type();
-    String name();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Named.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Named.java
@@ -1,0 +1,5 @@
+package org.dockbox.hartshorn.core.domain;
+
+public interface Named {
+    String name();
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ElementContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ElementContextTests.java
@@ -1,0 +1,300 @@
+package org.dockbox.hartshorn.core;
+
+import org.dockbox.hartshorn.core.annotations.service.ServiceActivator;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.exceptions.TypeConversionException;
+import org.dockbox.hartshorn.core.types.BoundUserImpl;
+import org.dockbox.hartshorn.core.types.TestEnumType;
+import org.dockbox.hartshorn.core.types.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+public class ElementContextTests {
+
+    public static Stream<Arguments> primitives() {
+        return Stream.of(
+                Arguments.of(boolean.class),
+                Arguments.of(byte.class),
+                Arguments.of(char.class),
+                Arguments.of(double.class),
+                Arguments.of(float.class),
+                Arguments.of(int.class),
+                Arguments.of(long.class),
+                Arguments.of(short.class)
+        );
+    }
+
+    public static Stream<Arguments> wrappers() {
+        return Stream.of(
+                Arguments.of(Boolean.class),
+                Arguments.of(Byte.class),
+                Arguments.of(Character.class),
+                Arguments.of(Double.class),
+                Arguments.of(Float.class),
+                Arguments.of(Integer.class),
+                Arguments.of(Long.class),
+                Arguments.of(Short.class)
+        );
+    }
+
+    public static Stream<Arguments> primitiveDefaults() {
+        return Stream.of(
+                Arguments.of(boolean.class, false),
+                Arguments.of(byte.class, 0),
+                Arguments.of(char.class, '\u0000'),
+                Arguments.of(double.class, 0.0d),
+                Arguments.of(float.class, 0.0f),
+                Arguments.of(int.class, 0),
+                Arguments.of(long.class, 0L),
+                Arguments.of(short.class, 0)
+        );
+    }
+
+    public static Stream<Arguments> wrapperDefaults() {
+        return Stream.of(
+                Arguments.of(Boolean.class, false),
+                Arguments.of(Byte.class, 0),
+                Arguments.of(Character.class, '\u0000'),
+                Arguments.of(Double.class, 0.0d),
+                Arguments.of(Float.class, 0.0f),
+                Arguments.of(Integer.class, 0),
+                Arguments.of(Long.class, 0L),
+                Arguments.of(Short.class, 0)
+        );
+    }
+
+    public static Stream<Arguments> primitiveStrings() {
+        return Stream.of(
+                Arguments.of(Boolean.class, "true", true),
+                Arguments.of(Byte.class, "0", (byte) 0),
+                Arguments.of(Character.class, "\u0000", '\u0000'),
+                Arguments.of(Double.class, "1.0d", 1.0d),
+                Arguments.of(Float.class, "1.0f", 1.0f),
+                Arguments.of(Integer.class, "1", 1),
+                Arguments.of(Long.class, "0", 0L),
+                Arguments.of(Short.class, "0", (short) 0)
+        );
+    }
+
+    @Test
+    void testTypeContextsAreReused() {
+        final TypeContext<ElementContextTests> tc1 = TypeContext.of(ElementContextTests.class);
+        final TypeContext<ElementContextTests> tc2 = TypeContext.of(ElementContextTests.class);
+        Assertions.assertSame(tc1, tc2);
+    }
+
+    @Test
+    void testTypeContextsAreNotReusedForDifferentTypes() {
+        final TypeContext<ElementContextTests> tc1 = TypeContext.of(ElementContextTests.class);
+        final TypeContext<Object> tc2 = TypeContext.of(Object.class);
+        Assertions.assertNotSame(tc1, tc2);
+    }
+
+    @ParameterizedTest
+    @MethodSource("primitives")
+    public void testIsPrimitiveAcceptsPrimitives(final Class<?> primitive) {
+        Assertions.assertTrue(TypeContext.of(primitive).isPrimitive());
+    }
+
+    @ParameterizedTest
+    @MethodSource("wrappers")
+    public void testIsPrimitiveRejectsPrimitiveWrappers(final Class<?> wrapper) {
+        Assertions.assertFalse(TypeContext.of(wrapper).isPrimitive());
+    }
+
+    @Test
+    public void testIsVoidAcceptsPrimitiveAndWrapper() {
+        Assertions.assertTrue(TypeContext.of(void.class).isVoid());
+        Assertions.assertTrue(TypeContext.of(Void.class).isVoid());
+        Assertions.assertTrue(TypeContext.VOID.isVoid());
+    }
+
+    @Test
+    public void testIsVoidRejectsNonPrimitiveAndNonWrapper() {
+        Assertions.assertFalse(TypeContext.of(String.class).isVoid());
+        Assertions.assertFalse(TypeContext.of(Object.class).isVoid());
+    }
+
+    @Test
+    public void testIsPrimitiveRejectsNonPrimitiveAndNonWrapper() {
+        Assertions.assertFalse(TypeContext.of(String.class).isPrimitive());
+        Assertions.assertFalse(TypeContext.of(Object.class).isPrimitive());
+    }
+
+    @Test
+    public void testIsPrimitiveRejectsVoid() {
+        Assertions.assertFalse(TypeContext.VOID.isPrimitive());
+    }
+
+    @Test
+    public void testIsPrimitiveRejectsVoidWrapper() {
+        Assertions.assertFalse(TypeContext.of(Void.class).isPrimitive());
+    }
+
+    @Test
+    public void testIsPrimitiveAcceptsVoidPrimitive() {
+        Assertions.assertTrue(TypeContext.of(void.class).isPrimitive());
+    }
+
+    @Test
+    public void testAnonymousTypesAreAnonymous() {
+        final TypeContext<Object> anonymous = TypeContext.of(new Object() {
+        });
+        Assertions.assertTrue(anonymous.isAnonymous());
+    }
+
+    @Test
+    public void testNonAnonymousTypesAreNotAnonymous() {
+        final TypeContext<Object> anonymous = TypeContext.of(Object.class);
+        Assertions.assertFalse(anonymous.isAnonymous());
+    }
+
+    @Test
+    void testAnonymousWrappersReturnCorrectType() {
+        final TypeContext<Object> anonymous = TypeContext.of(new Object() {
+        });
+        Assertions.assertNotEquals(Object.class, anonymous.type());
+    }
+
+    @Test
+    public void testEnumsAreEnum() {
+        Assertions.assertTrue(TypeContext.of(TestEnumType.class).isEnum());
+    }
+
+    @Test
+    public void testNonEnumsAreNotEnum() {
+        Assertions.assertFalse(TypeContext.of(Object.class).isEnum());
+    }
+
+    @Test
+    public void testEnumsAreNotAnonymous() {
+        Assertions.assertFalse(TypeContext.of(TestEnumType.class).isAnonymous());
+    }
+
+    @Test
+    public void enumConstantsCanBeObtained() {
+        final TypeContext<TestEnumType> enumContext = TypeContext.of(TestEnumType.class);
+        Assertions.assertEquals(TestEnumType.values().length, enumContext.enumConstants().size());
+    }
+
+    @Test
+    public void testAnnotationsAreAnnotations() {
+        Assertions.assertTrue(TypeContext.of(ServiceActivator.class).isAnnotation());
+    }
+
+    @Test
+    public void testNonAnnotationsAreNotAnnotations() {
+        Assertions.assertFalse(TypeContext.of(Object.class).isAnnotation());
+    }
+
+    @Test
+    public void testAnnotationsAreNotAnonymous() {
+        Assertions.assertFalse(TypeContext.of(Annotation.class).isAnonymous());
+    }
+
+    @Test
+    public void testAnnotationsAreNotEnum() {
+        Assertions.assertFalse(TypeContext.of(Annotation.class).isEnum());
+    }
+
+    @Test
+    public void testAnnotationsAreNotPrimitive() {
+        Assertions.assertFalse(TypeContext.of(Annotation.class).isPrimitive());
+    }
+
+    @Test
+    public void testAnnotationsAreNotVoid() {
+        Assertions.assertFalse(TypeContext.of(Annotation.class).isVoid());
+    }
+
+    @Test
+    public void testAnnotationsAreNotArray() {
+        Assertions.assertFalse(TypeContext.of(Annotation.class).isArray());
+    }
+
+    @Test
+    void testArraysAreArrays() {
+        Assertions.assertTrue(TypeContext.of(Object[].class).isArray());
+    }
+
+    @Test
+    void testArraysAreNotAnonymous() {
+        Assertions.assertFalse(TypeContext.of(Object[].class).isAnonymous());
+    }
+
+    @Test
+    void testArraysAreNotEnum() {
+        Assertions.assertFalse(TypeContext.of(Object[].class).isEnum());
+    }
+
+    @Test
+    void testArraysAreNotPrimitive() {
+        Assertions.assertFalse(TypeContext.of(Object[].class).isPrimitive());
+    }
+
+    @Test
+    void testArraysAreNotVoid() {
+        Assertions.assertFalse(TypeContext.of(Object[].class).isVoid());
+    }
+
+    @Test
+    void testArraysAreNotAnnotation() {
+        Assertions.assertFalse(TypeContext.of(Object[].class).isAnnotation());
+    }
+
+    @ParameterizedTest
+    @MethodSource("primitiveDefaults")
+    void testPrimitiveDefaults(final Class<?> primitive, final Object defaultValue) {
+        Assertions.assertEquals(defaultValue, TypeContext.of(primitive).defaultOrNull());
+    }
+
+    @Test
+    void testVoidDefaultsToNull() {
+        Assertions.assertNull(TypeContext.VOID.defaultOrNull());
+    }
+
+    @Test
+    void testObjectDefaultsToNull() {
+        Assertions.assertNull(TypeContext.of(Object.class).defaultOrNull());
+    }
+
+    @Test
+    void testAnnotationDefaultsToNull() {
+        Assertions.assertNull(TypeContext.of(ServiceActivator.class).defaultOrNull());
+    }
+
+    @Test
+    void testEnumDefaultsToNull() {
+        Assertions.assertNull(TypeContext.of(TestEnumType.class).defaultOrNull());
+    }
+
+    @Test
+    void testArrayDefaultsToNull() {
+        Assertions.assertNull(TypeContext.of(Object[].class).defaultOrNull());
+    }
+
+    @ParameterizedTest
+    @MethodSource("wrapperDefaults")
+    void testWrapperDefaults(final Class<?> wrapper, final Object defaultValue) {
+        Assertions.assertEquals(defaultValue, TypeContext.of(wrapper).defaultOrNull());
+    }
+
+    @Test
+    void testInterfacesAreObtainable() {
+        Assertions.assertEquals(1, TypeContext.of(BoundUserImpl.class).interfaces().size());
+        Assertions.assertEquals(TypeContext.of(User.class), TypeContext.of(BoundUserImpl.class).interfaces().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("primitiveStrings")
+    void testPrimitivesFromString(final Class<?> primitive, final String value, final Object real) throws TypeConversionException {
+        final Object out = TypeContext.toPrimitive(TypeContext.of(primitive), value);
+        Assertions.assertEquals(real, out);
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AbstractTypeWithTP.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AbstractTypeWithTP.java
@@ -1,0 +1,4 @@
+package org.dockbox.hartshorn.core.types;
+
+public class AbstractTypeWithTP<A> {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedElement.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedElement.java
@@ -1,0 +1,7 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.activate.Activator;
+
+@Activator
+public class AnnotatedElement {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ImplementationWithTP.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ImplementationWithTP.java
@@ -1,0 +1,4 @@
+package org.dockbox.hartshorn.core.types;
+
+public class ImplementationWithTP extends AbstractTypeWithTP<Integer> implements InterfaceWithTP<String> {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/InterfaceWithTP.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/InterfaceWithTP.java
@@ -1,0 +1,4 @@
+package org.dockbox.hartshorn.core.types;
+
+public interface InterfaceWithTP<A> {
+}


### PR DESCRIPTION
Fixes #529
Includes tests for #534 and #536 

# Motivation
## Exposing `name` property through `ExecutableElementContext`
> There's no way to get the name from an `ExecutableElementContext<?>` without casting to either a `MethodContext<?,?>` or `ConstructorContext<?>`, despite this being a method of the built-in `Executable`. It may not be known which of these it is and therefore just to get the name, several lines of code must be written.
To make it easier in the future to handle named types, I also added a separate `Named` interface which exposes only the method `String name()`.

## QoL method to get annotation from `AnnotatedElementContext` using `TypeContext<T extends Annotation>`
This is primarily a QoL change, allowing you to get a annotation from a `AnnotatedElementContext` directly using a `TypeContext` which may represent an annotation type. I also included a quick bypass for requests using types (both `Class` and `TypeContext`) which don't represent an annotation.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [ ] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
