### PR TITLE
#531 Add `#equals` to `AnnotatedElementContext` to compare underlying reflected element directly for all contexts

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class AnnotatedElementContext<A extends AnnotatedElement> extends DefaultContext implements QualifiedElement {
 
@@ -56,4 +57,17 @@ public abstract class AnnotatedElementContext<A extends AnnotatedElement> extend
     }
 
     protected abstract A element();
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        final AnnotatedElementContext<?> that = (AnnotatedElementContext<?>) o;
+        return this.element().equals(that.element());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.element());
+    }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -477,18 +477,6 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final TypeContext<?> that)) return false;
-        return this.type.equals(that.type);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.type);
-    }
-
-    @Override
     public String toString() {
         return "TypeContext{%s}".formatted(this.type);
     }


### PR DESCRIPTION
Fixes #531

# Motivation
When comparing `MethodContext` on two separately obtained methods with the same signature, the direct comparison will return `false`. However when comparing the real `Method`, the result is `true`. This is because the `MethodContext` does not have a explicit `equals` and `hashCode` override.

# Changes
`AnnotatedElementContext` now defines a explicit override for `equals` and `hashCode`, which affects the following contexts directly:
- `ConstructorContext`
- `FieldContext`
- `MethodContext`
- `ParameterContext`
- `TypeContext`
- `WildcardTypeContext`

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing (added in #529)

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
