### PR TITLE
#532 Include inherited protected methods in `TypeContext#methods`, keep `#declaredMethods` for type-declared methods

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
@@ -127,4 +127,8 @@ public class MethodContext<T, P> extends ExecutableElementContext<Method> implem
         final P instance = context.get(this.parent());
         return this.invoke(instance, args);
     }
+
+    public boolean isProtected() {
+        return this.has(AccessModifier.PROTECTED);
+    }
 }


### PR DESCRIPTION
Fixes #532

# Motivation
While inherited `private` methods should not be accessible through `TypeContext#methods`, protected should be accessible so they can be proxied when needed. Currently protected methods are not always properly included.

# Changes
Updates the implementation of `methods` to recursively obtain all methods which are then filtered by their access modifier (public and protected only). Also adds a separate `declaredMethods` method to obtain all type-declared methods.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing (in #530)

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
