### PR TITLE
#535 Use annotation type instead of instance class for annotation cache

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
@@ -50,7 +50,7 @@ public abstract class AnnotatedElementContext<A extends AnnotatedElement> extend
         if (this.annotationCache == null) {
             this.annotationCache = HartshornUtils.emptyConcurrentMap();
             for (final Annotation annotation : this.element().getAnnotations()) {
-                this.annotationCache.put(annotation.getClass(), annotation);
+                this.annotationCache.put(annotation.annotationType(), annotation);
             }
         }
         return this.annotationCache;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -46,7 +46,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -546,7 +545,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             Class<?> type = this.type();
             while (type != null) {
                 for (final Annotation annotation : type.getDeclaredAnnotations()) {
-                    annotations.put(annotation.getClass(), annotation);
+                    annotations.put(annotation.annotationType(), annotation);
                 }
                 type = type.getSuperclass();
             }


### PR DESCRIPTION
Fixes #535

# Motivation
When validating annotations, both the `TypeContext` and `AnnotatedElementContext` use the class of present annotation instances. However annotation instances are typically proxies and are thus not correctly compared. This can lead to duplication in the annotation cache.

# Changes
Replaces the use of `annotation.getClass` in annotation cache builders with `annotation.annotationType`.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing (in #530)

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
