### PR TITLE
#541 Remove duplicate activator check for processed components

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -253,12 +253,11 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
     protected void process(final ServiceOrder order, final Collection<ComponentContainer> containers) {
         for (final ComponentProcessor<?> serviceProcessor : this.processors.get(order)) {
             for (final ComponentContainer container : containers) {
-                if (container.activators().stream().allMatch(this::hasActivator)) {
-                    final TypeContext<?> service = container.type();
-                    if (serviceProcessor.processable(this, service)) {
-                        this.log().debug("Processing component %s with registered processor %s in phase %s".formatted(container.id(), TypeContext.of(serviceProcessor).name(), order));
-                        serviceProcessor.process(this, service);
-                    }
+                final TypeContext<?> service = container.type();
+                if (serviceProcessor.processable(this, service)) {
+                    final long start = System.currentTimeMillis();
+                    this.log().debug("Processing component %s with registered processor %s in phase %s".formatted(container.id(), TypeContext.of(serviceProcessor).name(), order));
+                    serviceProcessor.process(this, service);
                 }
             }
         }


### PR DESCRIPTION
Fixes #541

# Motivation
When processing a new prefix, `HartshornApplicationContext` checks all components for activator presence. While this is technically correct, it does not fall within the scope of the application context, and is instead already handled by the `ComponentLocator` implementation. See the line below for refence:  
https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L256

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
