### PR TITLE
#537 Use correct activator for `HttpWebServerInitializer` and specify presence of MVC activator for MVC servlets

### DIFF
--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RestIntegrationTest.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RestIntegrationTest.java
@@ -41,7 +41,7 @@ import java.util.function.Function;
 @UseHttpServer
 public abstract class RestIntegrationTest extends ApplicationAwareTest {
 
-    protected static final String ADDRESS = "http://localhost:" + ServerBootstrap.DEFAULT_PORT;
+    protected static final String ADDRESS = "http://localhost:" + HttpWebServerInitializer.DEFAULT_PORT;
 
     protected CloseableHttpResponse request(final String uri, final HttpMethod method, final String body, final Header... headers) throws IOException {
         final CloseableHttpClient client = HttpClients.createDefault();


### PR DESCRIPTION
Fixes #537

# Motivation
> The `ServerBootstrap` used to activate the `HttpWebServer` (sidenote, `ServerBootstrap` needs to be renamed asap, it's too ambiguous), requires the activator `UseBootstrap` instead of `UseHttpServer`. See:  
https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServerBootstrap.java#L42

# Changes
Changes the activator for the `HttpWebServerInitializer` (previously `ServerBootstrap`) to `UseHttpServer` with additional checks for the presence of `UseMvcServer` before registering MVC servlets.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing

**Test Configuration**:
* Platform: Jetty Embedded
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
