### PR TITLE
#540 Resolve duplicate field injection when field is annotated with both `@Inject` and `@Enable`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
@@ -41,8 +41,6 @@ public interface ApplicationContext extends ApplicationBinder, HartshornContext,
 
     <T> T inject(Key<T> type, T typeInstance);
 
-    <T> void enableFields(T typeInstance);
-
     <T> T raw(TypeContext<T> type) throws TypeProvisionException;
 
     <T> T raw(TypeContext<T> type, boolean populate) throws TypeProvisionException;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -167,20 +167,6 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
 
         unproxied.fields(Enable.class)
                 .forEach(field -> this.enableField(field, typeInstance));
-
-        unproxied.fields(Inject.class).stream()
-                .filter(field -> field.annotation(Enable.class).absent())
-                .forEach(field -> {
-                    final Exceptional<?> instance = field.get(typeInstance);
-                    if (instance.present()) {
-                        try {
-                            Bindings.enable(instance.get());
-                        }
-                        catch (final ApplicationException e) {
-                            throw new ApplicationException("Could not enable injected field " + field.name(), e).runtime();
-                        }
-                    }
-                });
     }
 
     protected void enableField(final FieldContext<?> field, final Object typeInstance) {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.proxy.ExtendedProxy;
 import org.dockbox.hartshorn.core.types.ContextInjectedType;
 import org.dockbox.hartshorn.core.types.SampleContext;
+import org.dockbox.hartshorn.core.types.TypeWithEnabledInjectField;
 import org.dockbox.hartshorn.core.types.User;
 import org.dockbox.hartshorn.testsuite.ApplicationAwareTest;
 import org.junit.jupiter.api.Assertions;
@@ -168,6 +169,14 @@ public class ApplicationContextTests extends ApplicationAwareTest {
         Assertions.assertEquals(SampleMetaAnnotatedImplementation.class, providedClass);
 
         Assertions.assertEquals("MetaAnnotatedHartshorn", provided.name());
+    }
+
+    @Test
+    void testEnabledInjectDoesNotInjectTwice() {
+        final TypeWithEnabledInjectField instance = this.context().get(TypeWithEnabledInjectField.class);
+        Assertions.assertNotNull(instance);
+        Assertions.assertNotNull(instance.singletonEnableable());
+        Assertions.assertEquals(1, instance.singletonEnableable().enabled());
     }
 
     @Test

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.Enableable;
+
+import javax.inject.Singleton;
+
+import lombok.Getter;
+
+@Singleton
+public class SingletonEnableable implements Enableable {
+
+    @Getter
+    private int enabled = 0;
+
+    @Override
+    public void enable() {
+        this.enabled++;
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithEnabledInjectField.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithEnabledInjectField.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.component.Component;
+import org.dockbox.hartshorn.core.annotations.inject.Enable;
+
+import javax.inject.Inject;
+
+import lombok.Getter;
+
+@Component
+public class TypeWithEnabledInjectField {
+
+    @Inject
+    @Enable
+    @Getter
+    private SingletonEnableable singletonEnableable;
+
+}


### PR DESCRIPTION
Fixes #540

# Motivation
> When a field is annotated with `@Inject` as well as `@Enable`, it is injected and enabled in the `enableFields` method in `HartshornApplicationContext`, see: https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L171  
> 
> However, two lines above that the fields are already enabled as they are annotated with `@Enable`, see https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L168  
> 
> Even more so, the fields are already populated through `HartshornApplicationContext#populate`, see https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L470
> 
> In `HartshornApplicationContext#get`, these two methods are called in the order `#populate` -> `#enableFields`, which causes these fields specifically to inject and enable twice. See https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L341-L348

# Changes
Removes the duplicate injection in `#enableFields`, no further changes were required.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
