### PR TITLE
#542 Defer instance proxies for non-components and resolve lost exceptions through type provisions

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/ContextDrivenProvider.java
@@ -67,6 +67,7 @@ public class ContextDrivenProvider<C> implements Provider<C> {
     }
 
     protected Exceptional<C> create(final ApplicationContext context) {
-        return Exceptional.of(() -> this.optimalConstructor.createInstance(context).orNull());
+        if (this.optimalConstructor() == null) return Exceptional.empty();
+        return this.optimalConstructor().createInstance(context).rethrowUnchecked().map(instance -> (C) instance);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/ContextDrivenProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/ContextDrivenProvider.java
@@ -43,10 +43,11 @@ public class ContextDrivenProvider<C> implements Provider<C> {
     }
 
     protected Exceptional<? extends ConstructorContext<? extends C>> findOptimalConstructor() {
+        if (this.context().isAbstract()) return Exceptional.empty();
         if (this.optimalConstructor == null) {
-            final List<? extends ConstructorContext<? extends C>> constructors = this.context.injectConstructors();
+            final List<? extends ConstructorContext<? extends C>> constructors = this.context().injectConstructors();
             if (constructors.isEmpty()) {
-                final Exceptional<? extends ConstructorContext<? extends C>> defaultConstructor = this.context.defaultConstructor();
+                final Exceptional<? extends ConstructorContext<? extends C>> defaultConstructor = this.context().defaultConstructor();
                 if (defaultConstructor.absent()) return Exceptional.empty();
                 else this.optimalConstructor = defaultConstructor.get();
             } else {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProxier.java
@@ -24,6 +24,8 @@ import org.dockbox.hartshorn.core.proxy.ProxyLookup;
 
 public interface ApplicationProxier extends ProxyLookup {
 
+    <T> Exceptional<T> proxy(TypeContext<T> type);
+
     <T> Exceptional<T> proxy(TypeContext<T> type, T instance);
 
     <T> Exceptional<TypeContext<T>> real(T instance);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
@@ -90,6 +90,11 @@ public class HartshornApplicationManager implements ApplicationManager {
     }
 
     @Override
+    public <T> Exceptional<T> proxy(final TypeContext<T> type) {
+        return this.applicationProxier.proxy(type);
+    }
+
+    @Override
     public <T> Exceptional<T> proxy(final TypeContext<T> type, final T instance) {
         return this.applicationProxier.proxy(type, instance);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationProxier.java
@@ -42,6 +42,11 @@ public class HartshornApplicationProxier implements ApplicationProxier, Applicat
     }
 
     @Override
+    public <T> Exceptional<T> proxy(final TypeContext<T> type) {
+        return this.proxy(type, null);
+    }
+
+    @Override
     public <T> Exceptional<T> proxy(final TypeContext<T> type, final T instance) {
         return Exceptional.of(() -> JavassistProxyUtil.handler(type, instance).proxy(instance));
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/logback/LogbackEncoder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/logback/LogbackEncoder.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.boot.logback;
 
 import ch.qos.logback.classic.PatternLayout;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/logback/LogbackPIDConverter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/logback/LogbackPIDConverter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.boot.logback;
 
 import java.lang.management.ManagementFactory;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
@@ -37,7 +37,7 @@ public interface ApplicationContext extends ApplicationBinder, HartshornContext,
 
     void add(InjectionPoint<?> property);
 
-    <T> T create(Key<T> type, T typeInstance);
+    <T> T create(Key<T> type);
 
     <T> T inject(Key<T> type, T typeInstance);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
@@ -23,7 +23,7 @@ import org.dockbox.hartshorn.core.MetaProvider;
 import org.dockbox.hartshorn.core.annotations.context.LogExclude;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.exceptions.TypeProvisionException;
+import org.dockbox.hartshorn.core.exceptions.BeanProvisionException;
 import org.dockbox.hartshorn.core.inject.InjectionModifier;
 import org.dockbox.hartshorn.core.services.ComponentLocator;
 import org.dockbox.hartshorn.core.services.ComponentProcessor;
@@ -41,9 +41,9 @@ public interface ApplicationContext extends ApplicationBinder, HartshornContext,
 
     <T> T inject(Key<T> type, T typeInstance);
 
-    <T> T raw(TypeContext<T> type) throws TypeProvisionException;
+    <T> T raw(TypeContext<T> type) throws BeanProvisionException;
 
-    <T> T raw(TypeContext<T> type, boolean populate) throws TypeProvisionException;
+    <T> T raw(TypeContext<T> type, boolean populate) throws BeanProvisionException;
 
     void add(ComponentProcessor<?> processor);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -52,7 +52,7 @@ import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
-import org.dockbox.hartshorn.core.exceptions.TypeProvisionException;
+import org.dockbox.hartshorn.core.exceptions.BeanProvisionException;
 import org.dockbox.hartshorn.core.inject.InjectionModifier;
 import org.dockbox.hartshorn.core.inject.ProviderContext;
 import org.dockbox.hartshorn.core.proxy.ProxyLookup;
@@ -164,12 +164,12 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         return typeInstance;
     }
 
-    public <T> T raw(final TypeContext<T> type) throws TypeProvisionException {
+    public <T> T raw(final TypeContext<T> type) throws BeanProvisionException {
         return this.raw(type, true);
     }
 
     @Override
-    public <T> T raw(final TypeContext<T> type, final boolean populate) throws TypeProvisionException {
+    public <T> T raw(final TypeContext<T> type, final boolean populate) throws BeanProvisionException {
         try {
             final Exceptional<T> instance = Providers.of(type).provide(this);
             if (instance.present()) {
@@ -179,7 +179,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
             }
         }
         catch (final Exception e) {
-            throw new TypeProvisionException("Could not provide raw instance of " + type.name(), e);
+            throw new BeanProvisionException("Could not provide instance of " + type.name() + " through constructor injection", e);
         }
         return null;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -255,7 +255,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
     }
 
     private void populateArguments(final Set<String> args) {
-        for (final String arg: args) {
+        for (final String arg : args) {
             final Matcher matcher = ARGUMENTS.matcher(arg);
             if (matcher.find()) this.property(matcher.group(1), matcher.group(2));
         }
@@ -302,7 +302,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
     private <T> T get(final Key<T> key, final boolean enable) {
         if (this.singletons.containsKey(key)) return (T) this.singletons.get(key);
 
-        T instance = this.create(key, null);
+        T instance = this.create(key);
 
         // Recreating field instances ensures all fields are created through bootstrapping, allowing injection
         // points to apply correctly
@@ -341,37 +341,21 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
     }
 
     @Nullable
-    public <T> T create(final Key<T> key, final T typeInstance) {
+    public <T> T create(final Key<T> key) {
+        final Exceptional<T> provision = this.provide(key).rethrowUnchecked();
+        if (provision.present())
+            return provision.get();
+
         final TypeContext<T> type = key.contract();
-        try {
-            if (null == typeInstance) {
-                final Exceptional<T> instanceCandidate = this.provide(key);
-                Throwable cause = null;
-                if (instanceCandidate.caught()) {
-                    cause = instanceCandidate.error();
-                }
 
-                if (instanceCandidate.absent()) {
-                    final Exceptional<T> rawCandidate = instanceCandidate.orElse(() -> this.raw(type));
-                    if (rawCandidate.absent()) {
-                        final Throwable finalCause = cause;
-                        return this.environment().manager().proxy(type, typeInstance).rethrowUnchecked().orThrow(() -> finalCause);
-                    }
-                    else {
-                        return rawCandidate.get();
-                    }
-                }
+        final Exceptional<T> raw = Exceptional.of(() -> this.raw(type)).rethrowUnchecked();
+        if (raw.present())
+            return raw.get();
 
-                return instanceCandidate.get();
-            }
-            return typeInstance;
-        }
-        catch (final Throwable e) {
-            // Services can have no explicit implementation even if they are abstract.
-            // Typically, these services are expected to be populated through injection points later in time.
-            if (type.isAbstract() && this.meta().isComponent(type)) return null;
-            throw new ApplicationException(e).runtime();
-        }
+        if (type.isAbstract() && this.meta().isComponent(type))
+            return this.environment().manager().proxy(type).rethrowUnchecked().orNull();
+
+        return null;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornContext.java
@@ -28,7 +28,7 @@ public interface HartshornContext extends Context {
         return this.get(Key.of(type, named));
     }
 
-    default <T> T get(Class<T> type, Named named) {
+    default <T> T get(final Class<T> type, final Named named) {
         return this.get(Key.of(type, named));
     }
 
@@ -38,8 +38,8 @@ public interface HartshornContext extends Context {
         return this.get(Key.of(type));
     }
 
-    default <T> T get(Class<T> type) {
+    default <T> T get(final Class<T> type) {
         return this.get(Key.of(type));
-    };
+    }
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ConstructorContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ConstructorContext.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.function.Function;
 
 import lombok.Getter;
@@ -64,7 +65,14 @@ public class ConstructorContext<T> extends ExecutableElementContext<Constructor<
 
     private void prepareHandle() {
         if (this.invoker == null) {
-            this.invoker = args -> Exceptional.of(() -> this.constructor.newInstance(args));
+            this.invoker = args -> Exceptional.of(() -> {
+                try {
+                    return this.constructor.newInstance(args);
+                } catch (final InvocationTargetException e) {
+                    if (e.getCause() instanceof Exception ex) throw ex;
+                    throw e;
+                }
+            });
         }
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Named.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Named.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.domain;
 
 public interface Named {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/BeanProvisionException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/BeanProvisionException.java
@@ -17,8 +17,8 @@
 
 package org.dockbox.hartshorn.core.exceptions;
 
-public class TypeProvisionException extends RuntimeException {
-    public TypeProvisionException(final String message, final Throwable cause) {
+public class BeanProvisionException extends RuntimeException {
+    public BeanProvisionException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/NativeProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/NativeProxyLookup.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.proxy;
 
 import org.dockbox.hartshorn.core.AnnotationHelper.AnnotationInvocationHandler;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyLookup.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.proxy;
 
 public interface ProxyLookup {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyLookup.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.proxy.javassist;
 
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -158,9 +158,9 @@ public class ApplicationContextTests extends ApplicationAwareTest {
     @Test
     public void testScannedMetaBindingsCanBeProvided() {
         this.context().bind("test.types.meta");
+        // Ensure that the binding is not bound to the default name
         final SampleInterface sample = this.context().get(SampleInterface.class);
-        Assertions.assertTrue(TypeContext.of(sample).isProxy());
-        Assertions.assertThrows(AbstractMethodError.class, sample::name);
+        Assertions.assertNull(sample); // Non-component, so null
 
         final SampleInterface provided = this.context().get(SampleInterface.class, Bindings.named("meta"));
         Assertions.assertNotNull(provided);

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ElementContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ElementContextTests.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core;
 
 import org.dockbox.hartshorn.core.annotations.activate.Activator;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AbstractTypeWithTP.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AbstractTypeWithTP.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 public class AbstractTypeWithTP<A> {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedElement.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedElement.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 import org.dockbox.hartshorn.core.annotations.activate.Activator;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ComponentType.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ComponentType.java
@@ -1,0 +1,7 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.component.Component;
+
+@Component
+public interface ComponentType {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ImplementationWithTP.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/ImplementationWithTP.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 public class ImplementationWithTP extends AbstractTypeWithTP<Integer> implements InterfaceWithTP<String> {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/InterfaceWithTP.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/InterfaceWithTP.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 public interface InterfaceWithTP<A> {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonComponentType.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonComponentType.java
@@ -1,0 +1,4 @@
+package org.dockbox.hartshorn.core.types;
+
+public interface NonComponentType {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 import org.dockbox.hartshorn.core.Enableable;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithEnabledInjectField.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithEnabledInjectField.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 import org.dockbox.hartshorn.core.annotations.component.Component;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithFailingConstructor.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithFailingConstructor.java
@@ -1,0 +1,8 @@
+package org.dockbox.hartshorn.core.types;
+
+public class TypeWithFailingConstructor {
+
+    public TypeWithFailingConstructor() {
+        throw new IllegalStateException("This type cannot be instantiated");
+    }
+}

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookup.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookup.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.persistence.hibernate;
 
 import org.dockbox.hartshorn.core.proxy.ProxyLookup;

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookupInitializer.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookupInitializer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.persistence.hibernate;
 
 import org.dockbox.hartshorn.core.annotations.service.Service;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.web.jetty;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;


### PR DESCRIPTION
Fixes #542

# Motivation
> Currently all provided types follow three main steps when being created:
> 1. Attempt to create through provider(s) if present
> 2. Attempt to create raw instance through constructor injection
> 3. Attempt to create proxy instance
> 
> This order makes sense for almost all types, except for step 3. Empty proxies should only ever be created for types which can later be modified to carry method handlers. These types are always components, as modifiers cannot target other types. Thus, step 3 should never be applied to non-components.  
> 
> Additionally, exceptions in step 1 are ignored unless an additional exception is thrown in step 2. This should be deferred since the introduction of `Provider`s, as providers should be able to yield an exception. If a provider cannot supply an instance, but does not throw an exception, the result is empty either way. We should only proceed to step 2 if step 1 yields no results, and no exceptions.  
> 
> For reference, see:  
https://github.com/GuusLieben/Hartshorn/blob/6e7b2caa5a8d75a91e85b5dfb2bd55611febab80/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L377

# Changes
Follows the guidelines outlined above. Non-components will no longer be proxied, and will fail if they cannot be created through a provider or constructor injection. Additionally exceptions in providers will be rethrown immediately instead of waiting for secondary options to fail.

## Type of change
- [x] Bug fix
- [x] Enhancement of core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove it is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
