### PR TITLE
#528 Change default flush mode to always be active for `@Query` methods

### DIFF
--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/annotations/Query.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/annotations/Query.java
@@ -28,7 +28,7 @@ public @interface Query {
     String value();
     QueryType type() default QueryType.JPQL;
     boolean automaticClear() default false;
-    boolean automaticFlush() default false;
+    boolean automaticFlush() default true;
     Class<?> entityType() default Void.class;
 
     public enum QueryType {


### PR DESCRIPTION
Fixes #528

# Motivation
> `@Query` defines the property `autoFlush`, currently this defaults to `false`. However this can quickly lead to memory leaks and unexpected behavior on multithreaded applications.

## Type of change
- [x] Enhancement of existing feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
