### PR TITLE
#527 Add support for Hibernate proxies

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameterValidator.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameterValidator.java
@@ -29,11 +29,6 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 public class CommandParameterValidator implements LifecycleObserver {
 
     @Override
-    public void onCreated(final ApplicationContext applicationContext) {
-        // Nothing happens
-    }
-
-    @Override
     public void onStarted(final ApplicationContext applicationContext) {
         final MethodContext<?, CommandParameterValidator> preload = TypeContext.of(this).method("onStarted", ApplicationContext.class).get();
         final ParameterContext<?> parameter = preload.parameters().get(0);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProxier.java
@@ -20,8 +20,9 @@ package org.dockbox.hartshorn.core.boot;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
+import org.dockbox.hartshorn.core.proxy.ProxyLookup;
 
-public interface ApplicationProxier {
+public interface ApplicationProxier extends ProxyLookup {
 
     <T> Exceptional<T> proxy(TypeContext<T> type, T instance);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
@@ -184,9 +184,6 @@ public class HartshornApplicationFactory implements ApplicationFactory<Hartshorn
         final ApplicationConfigurator configurator = this.applicationConfigurator;
         configurator.configure(manager);
 
-        for (final LifecycleObserver observer : manager.observers())
-            observer.onCreated(applicationContext);
-
         for (final Annotation serviceActivator : this.serviceActivators)
             applicationContext.addActivator(serviceActivator);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import lombok.Getter;
 
 @LogExclude
+@Getter
 public class HartshornApplicationManager implements ApplicationManager {
 
     private static final String BANNER = """
@@ -43,15 +44,11 @@ public class HartshornApplicationManager implements ApplicationManager {
                                              -- Hartshorn v%s --
             """.formatted(Hartshorn.VERSION);
 
-    @Getter
     private final Set<LifecycleObserver> observers = HartshornUtils.emptyConcurrentSet();
     private final ApplicationFSProvider applicationFSProvider;
-
-    @Getter
-    private ApplicationContext applicationContext;
-
     private final ApplicationLogger applicationLogger;
     private final ApplicationProxier applicationProxier;
+    private ApplicationContext applicationContext;
 
     public HartshornApplicationManager(
             final TypeContext<?> activator,
@@ -130,5 +127,20 @@ public class HartshornApplicationManager implements ApplicationManager {
     @Override
     public Path applicationPath() {
         return this.applicationFSProvider.applicationPath();
+    }
+
+    @Override
+    public <T> Class<T> unproxy(final T instance) {
+        return this.applicationProxier.unproxy(instance);
+    }
+
+    @Override
+    public boolean isProxy(final Object instance) {
+        return this.applicationProxier.isProxy(instance);
+    }
+
+    @Override
+    public boolean isProxy(final Class<?> candidate) {
+        return this.applicationProxier.isProxy(candidate);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationProxier.java
@@ -36,6 +36,11 @@ public class HartshornApplicationProxier implements ApplicationProxier, Applicat
     private ApplicationManager applicationManager;
     private final Set<ProxyLookup> proxyLookups = HartshornUtils.emptyConcurrentSet();
 
+    public HartshornApplicationProxier() {
+        this.proxyLookups.add(new NativeProxyLookup());
+        this.proxyLookups.add(new JavassistProxyLookup());
+    }
+
     @Override
     public <T> Exceptional<T> proxy(final TypeContext<T> type, final T instance) {
         return Exceptional.of(() -> JavassistProxyUtil.handler(type, instance).proxy(instance));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationProxier.java
@@ -17,10 +17,16 @@
 
 package org.dockbox.hartshorn.core.boot;
 
+import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.proxy.JavassistProxyUtil;
+import org.dockbox.hartshorn.core.proxy.NativeProxyLookup;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
+import org.dockbox.hartshorn.core.proxy.ProxyLookup;
+import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyLookup;
+import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyUtil;
+
+import java.util.Set;
 
 import lombok.Getter;
 
@@ -28,19 +34,20 @@ public class HartshornApplicationProxier implements ApplicationProxier, Applicat
 
     @Getter
     private ApplicationManager applicationManager;
+    private final Set<ProxyLookup> proxyLookups = HartshornUtils.emptyConcurrentSet();
 
     @Override
-    public <T> Exceptional<T> proxy(TypeContext<T> type, T instance) {
+    public <T> Exceptional<T> proxy(final TypeContext<T> type, final T instance) {
         return Exceptional.of(() -> JavassistProxyUtil.handler(type, instance).proxy(instance));
     }
 
     @Override
-    public <T> Exceptional<TypeContext<T>> real(T instance) {
-        return JavassistProxyUtil.handler(instance).map(ProxyHandler::type);
+    public <T> Exceptional<TypeContext<T>> real(final T instance) {
+        return Exceptional.of(TypeContext.of(this.unproxy(instance)));
     }
 
     @Override
-    public <T, P extends T> Exceptional<T> delegator(TypeContext<T> type, P instance) {
+    public <T, P extends T> Exceptional<T> delegator(final TypeContext<T> type, final P instance) {
         return JavassistProxyUtil.delegator(this.applicationManager().applicationContext(), type, instance);
     }
 
@@ -50,13 +57,35 @@ public class HartshornApplicationProxier implements ApplicationProxier, Applicat
     }
 
     @Override
-    public <T> ProxyHandler<T> handler(TypeContext<T> type, T instance) {
+    public <T> ProxyHandler<T> handler(final TypeContext<T> type, final T instance) {
         return JavassistProxyUtil.handler(type, instance);
     }
 
     @Override
-    public void applicationManager(ApplicationManager applicationManager) {
+    public void applicationManager(final ApplicationManager applicationManager) {
         if (this.applicationManager == null) this.applicationManager = applicationManager;
         else throw new IllegalArgumentException("Application manager has already been configured");
+    }
+
+    @Override
+    public <T> Class<T> unproxy(final T instance) {
+        for (final ProxyLookup lookup : this.proxyLookups) {
+            if (lookup.isProxy(instance)) return lookup.unproxy(instance);
+        }
+        return instance != null ? (Class<T>) instance.getClass() : null;
+    }
+
+    @Override
+    public boolean isProxy(final Object instance) {
+        return this.proxyLookups.stream().anyMatch(lookup -> lookup.isProxy(instance));
+    }
+
+    @Override
+    public boolean isProxy(final Class<?> candidate) {
+        return this.proxyLookups.stream().anyMatch(lookup -> lookup.isProxy(candidate));
+    }
+
+    public void registerProxyLookup(final ProxyLookup lookup) {
+        this.proxyLookups.add(lookup);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/LifecycleObserver.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/LifecycleObserver.java
@@ -20,7 +20,6 @@ package org.dockbox.hartshorn.core.boot;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 
 public interface LifecycleObserver {
-    void onCreated(ApplicationContext applicationContext);
     void onStarted(ApplicationContext applicationContext);
     void onExit(ApplicationContext applicationContext);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/JavaInterfaceProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/JavaInterfaceProxyHandler.java
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.core.context.NamedContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyHandler;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -45,7 +46,7 @@ public class JavaInterfaceProxyHandler<T> implements InvocationHandler, ProxyHan
     }
 
     public T proxy() {
-        T proxy = (T) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{
+        final T proxy = (T) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{
                 this.handler().type().type()
         }, this);
         this.handler().proxyInstance(proxy);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/NativeProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/NativeProxyLookup.java
@@ -1,0 +1,35 @@
+package org.dockbox.hartshorn.core.proxy;
+
+import org.dockbox.hartshorn.core.AnnotationHelper.AnnotationInvocationHandler;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+public class NativeProxyLookup implements ProxyLookup {
+
+    @Override
+    public <T> Class<T> unproxy(final T instance) {
+        final InvocationHandler invocationHandler = Proxy.getInvocationHandler(instance);
+        if (invocationHandler instanceof JavaInterfaceProxyHandler proxyInterfaceHandler) {
+            return proxyInterfaceHandler.handler().type().type();
+        }
+        else if (invocationHandler instanceof AnnotationInvocationHandler annotationInvocationHandler) {
+            return (Class<T>) annotationInvocationHandler.annotation().annotationType();
+        }
+        else if (instance instanceof Annotation annotation) {
+            return (Class<T>) annotation.annotationType();
+        }
+        return instance != null ? (Class<T>) instance.getClass() : null;
+    }
+
+    @Override
+    public boolean isProxy(final Object instance) {
+        return instance != null && this.isProxy(instance.getClass());
+    }
+
+    @Override
+    public boolean isProxy(final Class<?> candidate) {
+        return Proxy.isProxyClass(candidate);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyLookup.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.core.proxy;
+
+public interface ProxyLookup {
+
+    <T> Class<T> unproxy(T instance);
+
+    boolean isProxy(Object instance);
+    boolean isProxy(Class<?> candidate);
+
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyHandler.java
@@ -15,7 +15,7 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.core.proxy;
+package org.dockbox.hartshorn.core.proxy.javassist;
 
 import org.dockbox.hartshorn.core.ArrayListMultiMap;
 import org.dockbox.hartshorn.core.MultiMap;
@@ -25,6 +25,10 @@ import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.proxy.JavaInterfaceProxyHandler;
+import org.dockbox.hartshorn.core.proxy.MethodProxyContext;
+import org.dockbox.hartshorn.core.proxy.Phase;
+import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -173,7 +177,7 @@ public class JavassistProxyHandler<T> extends DefaultContext implements ProxyHan
         return Exceptional.of(this.proxyInstance);
     }
 
-    void proxyInstance(T proxyInstance) {
+    public void proxyInstance(T proxyInstance) {
         this.proxyInstance = proxyInstance;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyLookup.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyLookup.java
@@ -1,0 +1,29 @@
+package org.dockbox.hartshorn.core.proxy.javassist;
+
+import org.dockbox.hartshorn.core.proxy.ProxyHandler;
+import org.dockbox.hartshorn.core.proxy.ProxyLookup;
+
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+
+public class JavassistProxyLookup implements ProxyLookup {
+
+    @Override
+    public <T> Class<T> unproxy(final T instance) {
+        final MethodHandler methodHandler = ProxyFactory.getHandler((javassist.util.proxy.Proxy) instance);
+        if (methodHandler instanceof ProxyHandler proxyHandler) {
+            return proxyHandler.type().type();
+        }
+        return instance != null ? (Class<T>) instance.getClass() : null;
+    }
+
+    @Override
+    public boolean isProxy(final Object instance) {
+        return instance != null && this.isProxy(instance.getClass());
+    }
+
+    @Override
+    public boolean isProxy(final Class<?> candidate) {
+        return ProxyFactory.isProxyClass(candidate);
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.annotations.proxy.UseProxying;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyHandler;
 import org.dockbox.hartshorn.core.proxy.types.ConcreteProxyTarget;
 import org.dockbox.hartshorn.core.proxy.types.FinalProxyTarget;
 import org.dockbox.hartshorn.core.proxy.types.ProviderService;

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
@@ -37,11 +37,6 @@ import java.util.stream.Collectors;
 public class EventValidator implements LifecycleObserver {
 
     @Override
-    public void onCreated(final ApplicationContext applicationContext) {
-        // Nothing happens
-    }
-
-    @Override
     public void onStarted(final ApplicationContext applicationContext) {
         if (applicationContext.hasActivator(UseEvents.class)) {
             new EngineChangedState<Started>() {

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookup.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookup.java
@@ -1,0 +1,25 @@
+package org.dockbox.hartshorn.persistence.hibernate;
+
+import org.dockbox.hartshorn.core.proxy.ProxyLookup;
+import org.hibernate.proxy.HibernateProxy;
+
+public class HibernateProxyLookup implements ProxyLookup {
+
+    @Override
+    public <T> Class<T> unproxy(final T instance) {
+        if (instance instanceof HibernateProxy hibernateProxy) {
+            return (Class<T>) hibernateProxy.getHibernateLazyInitializer().getPersistentClass();
+        }
+        return instance != null ? (Class<T>) instance.getClass() : null;
+    }
+
+    @Override
+    public boolean isProxy(final Object instance) {
+        return instance instanceof HibernateProxy;
+    }
+
+    @Override
+    public boolean isProxy(final Class<?> candidate) {
+        return HibernateProxy.class.isAssignableFrom(candidate);
+    }
+}

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookupInitializer.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/hibernate/HibernateProxyLookupInitializer.java
@@ -1,0 +1,28 @@
+package org.dockbox.hartshorn.persistence.hibernate;
+
+import org.dockbox.hartshorn.core.annotations.service.Service;
+import org.dockbox.hartshorn.core.boot.ApplicationManager;
+import org.dockbox.hartshorn.core.boot.HartshornApplicationManager;
+import org.dockbox.hartshorn.core.boot.HartshornApplicationProxier;
+import org.dockbox.hartshorn.core.boot.LifecycleObserver;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.persistence.annotations.UsePersistence;
+
+@Service(activators = UsePersistence.class)
+public class HibernateProxyLookupInitializer implements LifecycleObserver {
+
+    @Override
+    public void onStarted(final ApplicationContext applicationContext) {
+        final ApplicationManager manager = applicationContext.environment().manager();
+        if (manager instanceof HartshornApplicationManager applicationManager) {
+            if (applicationManager.applicationProxier() instanceof HartshornApplicationProxier applicationProxier) {
+                applicationProxier.registerProxyLookup(new HibernateProxyLookup());
+            }
+        }
+    }
+
+    @Override
+    public void onExit(final ApplicationContext applicationContext) {
+        // Nothing happens
+    }
+}

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/PersistentTypeService.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/service/PersistentTypeService.java
@@ -32,11 +32,6 @@ import javax.persistence.Entity;
 public class PersistentTypeService implements LifecycleObserver {
 
     @Override
-    public void onCreated(final ApplicationContext applicationContext) {
-        // Nothing happens
-    }
-
-    @Override
     public void onStarted(final ApplicationContext applicationContext) {
         final Collection<TypeContext<?>> entities = applicationContext.environment().types(Entity.class);
         applicationContext.add(new EntityContext(entities));

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -58,11 +58,6 @@ public class HttpWebServerInitializer implements LifecycleObserver {
     private HttpWebServer webServer;
 
     @Override
-    public void onCreated(final ApplicationContext applicationContext) {
-        // Nothing happens
-    }
-
-    @Override
     public void onStarted(final ApplicationContext applicationContext) {
         final Map<String, Servlet> servlets = HartshornUtils.emptyMap();
 


### PR DESCRIPTION
Fixes #527

# Motivation
> Explicit support was already added to support proxies generated by Java (native interface proxies), Javassist, and interface proxies. However support for Hibernate proxies is still lacking. While this is currently not required internally, this does not mean it won't be needed elsewhere.

# Changes
As Core doesn't have access to Hibernate, we needed an alternative method of efficiently getting proxy context for Hibernate proxies. To support this, I have added a new way of validating proxy types; `ProxyLookup`. This is implemented in the `HartshornApplicationProxier` so additional lookups can be registered through lifecycle observers or during processing.  

The `ProxyLookup` supports two things:
- Getting the real unproxied class of a provided instance
- Validating whether a given instance or class is a proxy(class)

Finally, the `onCreated` lifecycle state was removed, as no observers could be registered at that point.

## Type of change
- [x] New core feature

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
