### PR TITLE
#555 Media type enhancements for HTTP request mappings

### DIFF
--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/DefaultObjectMapper.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/DefaultObjectMapper.java
@@ -21,20 +21,20 @@ import org.dockbox.hartshorn.persistence.mapping.ObjectMapper;
 
 public abstract class DefaultObjectMapper implements ObjectMapper {
 
-    protected FileFormats fileFormat;
+    protected FileFormat fileFormat;
 
-    protected DefaultObjectMapper(final FileFormats fileFormat) {
+    protected DefaultObjectMapper(final FileFormat fileFormat) {
         this.fileFormat = fileFormat;
     }
 
     @Override
-    public ObjectMapper fileType(final FileFormats fileFormat) {
+    public ObjectMapper fileType(final FileFormat fileFormat) {
         this.fileFormat = fileFormat;
         return this;
     }
 
     @Override
-    public FileFormats fileType() {
+    public FileFormat fileType() {
         return this.fileFormat;
     }
 }

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/jackson/JacksonObjectMapper.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/jackson/JacksonObjectMapper.java
@@ -50,6 +50,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.persistence.DefaultObjectMapper;
+import org.dockbox.hartshorn.persistence.FileFormat;
 import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.persistence.properties.PersistenceModifier;
 
@@ -193,7 +194,7 @@ public class JacksonObjectMapper extends DefaultObjectMapper {
     }
 
     @Override
-    public JacksonObjectMapper fileType(final FileFormats fileFormat) {
+    public JacksonObjectMapper fileType(final FileFormat fileFormat) {
         super.fileType(fileFormat);
         this.objectMapper = null;
         return this;
@@ -235,7 +236,7 @@ public class JacksonObjectMapper extends DefaultObjectMapper {
         return this.objectMapper;
     }
 
-    protected MapperBuilder<?, ?> mapper(final FileFormats fileFormat) {
+    protected MapperBuilder<?, ?> mapper(final FileFormat fileFormat) {
         for (final JacksonObjectMapper.Mappers mapper : JacksonObjectMapper.Mappers.values()) {
             if (mapper.fileFormat.equals(fileFormat)) return (MapperBuilder<?, ?>) mapper.mapper.get();
         }

--- a/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/mapping/ObjectMapper.java
+++ b/hartshorn-persistence/src/main/java/org/dockbox/hartshorn/persistence/mapping/ObjectMapper.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.core.GenericType;
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.persistence.FileFormats;
+import org.dockbox.hartshorn.persistence.FileFormat;
 import org.dockbox.hartshorn.persistence.properties.PersistenceModifier;
 
 import java.net.URI;
@@ -81,9 +81,9 @@ public interface ObjectMapper {
 
     <T> Exceptional<String> write(T content);
 
-    ObjectMapper fileType(FileFormats fileFormat);
+    ObjectMapper fileType(FileFormat fileFormat);
 
-    FileFormats fileType();
+    FileFormat fileType();
 
     ObjectMapper skipBehavior(PersistenceModifier modifier);
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/MediaType.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/MediaType.java
@@ -1,0 +1,47 @@
+package org.dockbox.hartshorn.web;
+
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.persistence.FileFormat;
+import org.dockbox.hartshorn.persistence.FileFormats;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public enum MediaType {
+    ALL("*", "*"),
+    APPLICATION_JSON("application", "json", FileFormats.JSON),
+    APPLICATION_XML("application", "xml", FileFormats.XML),
+    APPLICATION_YAML("application", "x-yaml", FileFormats.YAML),
+    APPLICATION_TOML("application", "toml", FileFormats.TOML),
+    TEXT_PLAIN("text", "plain"),
+    TEXT_HTML("text", "html"),
+    TEXT_CSS("text", "css"),
+    TEXT_XML("text", "xml"),
+    TEXT_YAML("text", "yaml"),
+    TEXT_TOML("text", "toml"),
+    TEXT_MARKDOWN("text", "markdown"),
+    ;
+
+    private final String type;
+    private final String subtype;
+
+    @Getter(AccessLevel.NONE)
+    private FileFormat format;
+
+    public boolean isSerializable() {
+        return this.format != null;
+    }
+
+    public Exceptional<FileFormat> fileFormat() {
+        return Exceptional.of(this.format);
+    }
+
+    public String value() {
+        return "%s/%s".formatted(this.type(), this.subtype());
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpDelete.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpDelete.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.web.annotations.http;
 
-import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.core.annotations.Extends;
 import org.dockbox.hartshorn.web.HttpMethod;
+import org.dockbox.hartshorn.web.MediaType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @HttpRequest(method = HttpMethod.DELETE, value = "")
 public @interface HttpDelete {
     String value();
-    FileFormats responseFormat() default FileFormats.JSON;
-    FileFormats bodyFormat() default FileFormats.JSON;
+    MediaType produces() default MediaType.APPLICATION_JSON;
+    MediaType consumes() default MediaType.APPLICATION_JSON;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpGet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpGet.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.web.annotations.http;
 
-import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.core.annotations.Extends;
 import org.dockbox.hartshorn.web.HttpMethod;
+import org.dockbox.hartshorn.web.MediaType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @HttpRequest(method = HttpMethod.GET, value = "")
 public @interface HttpGet {
     String value();
-    FileFormats responseFormat() default FileFormats.JSON;
-    FileFormats bodyFormat() default FileFormats.JSON;
+    MediaType produces() default MediaType.APPLICATION_JSON;
+    MediaType consumes() default MediaType.APPLICATION_JSON;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpPost.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpPost.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.web.annotations.http;
 
-import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.core.annotations.Extends;
 import org.dockbox.hartshorn.web.HttpMethod;
+import org.dockbox.hartshorn.web.MediaType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @HttpRequest(method = HttpMethod.POST, value = "")
 public @interface HttpPost {
     String value();
-    FileFormats responseFormat() default FileFormats.JSON;
-    FileFormats bodyFormat() default FileFormats.JSON;
+    MediaType produces() default MediaType.APPLICATION_JSON;
+    MediaType consumes() default MediaType.APPLICATION_JSON;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpPut.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpPut.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.web.annotations.http;
 
-import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.core.annotations.Extends;
 import org.dockbox.hartshorn.web.HttpMethod;
+import org.dockbox.hartshorn.web.MediaType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -32,6 +32,6 @@ import java.lang.annotation.Target;
 @HttpRequest(method = HttpMethod.PUT, value = "")
 public @interface HttpPut {
     String value();
-    FileFormats responseFormat() default FileFormats.JSON;
-    FileFormats bodyFormat() default FileFormats.JSON;
+    MediaType produces() default MediaType.APPLICATION_JSON;
+    MediaType consumes() default MediaType.APPLICATION_JSON;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpRequest.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/http/HttpRequest.java
@@ -17,8 +17,8 @@
 
 package org.dockbox.hartshorn.web.annotations.http;
 
-import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.web.HttpMethod;
+import org.dockbox.hartshorn.web.MediaType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -30,6 +30,6 @@ import java.lang.annotation.Target;
 public @interface HttpRequest {
     String value();
     HttpMethod method();
-    FileFormats responseFormat() default FileFormats.JSON;
-    FileFormats bodyFormat() default FileFormats.JSON;
+    MediaType produces() default MediaType.APPLICATION_JSON;
+    MediaType consumes() default MediaType.APPLICATION_JSON;
 }

--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
@@ -21,13 +21,12 @@ import org.dockbox.hartshorn.core.context.element.ExecutableElementContext;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.persistence.FileFormats;
 import org.dockbox.hartshorn.testsuite.ApplicationAwareTest;
 import org.dockbox.hartshorn.web.annotations.RequestHeader;
 import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
+import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.HeaderRequestParameterRule;
-import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -48,11 +47,10 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
 
     public static Stream<Arguments> bodies() {
         return Stream.of(
-                Arguments.of("{\"message\":\"Hello world!\"}", FileFormats.JSON),
-                Arguments.of("message: 'Hello world!'", FileFormats.YAML),
-                Arguments.of("<message>Hello world!</message>", FileFormats.XML),
-                Arguments.of("message='Hello world!'", FileFormats.TOML),
-                Arguments.of("message=Hello world!", FileFormats.PROPERTIES)
+                Arguments.of("{\"message\":\"Hello world!\"}", MediaType.APPLICATION_JSON),
+                Arguments.of("message: 'Hello world!'", MediaType.APPLICATION_YAML),
+                Arguments.of("<message>Hello world!</message>", MediaType.APPLICATION_XML),
+                Arguments.of("message='Hello world!'", MediaType.APPLICATION_TOML)
         );
     }
 
@@ -73,7 +71,7 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("bodies")
-    void testBodyIsParsedForAllFormats(final String body, final FileFormats fileFormat) throws IOException {
+    void testBodyIsParsedForAllFormats(final String body, final MediaType mediaType) throws IOException {
         final BufferedReader reader = new BufferedReader(new StringReader(body));
         final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getReader()).thenReturn(reader);
@@ -83,7 +81,7 @@ public class RequestArgumentProcessorTests extends ApplicationAwareTest {
 
         final ExecutableElementContext<?> declaring = Mockito.mock(ExecutableElementContext.class);
         final HttpRequest httpRequest = Mockito.mock(HttpRequest.class);
-        Mockito.when(httpRequest.bodyFormat()).thenReturn(fileFormat);
+        Mockito.when(httpRequest.consumes()).thenReturn(mediaType);
         Mockito.when(declaring.annotation(HttpRequest.class)).thenReturn(Exceptional.of(httpRequest));
         // Different order due to generic return type
         Mockito.doReturn(declaring).when(context).declaredBy();


### PR DESCRIPTION
Fixes #555
- [x] Breaking change (Web and Persistence only)

# Changes
- Adds a new `MediaType` enum which defines information about the associated `type`, `subtype`, and optional `FileFormat`
- Renames `responseFormat` and `bodyFormat` in `HttpRequest` (and derivatives) to `produces` and `consumes`, respectively
- Matches the response content type header with the intended `MediaType`

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
