### PR TITLE
#564 Implement element modifiers, supporting virtual annotations

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementModifier.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.core.context.element;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(staticName = "of")
+public final class AnnotatedElementModifier<A extends AnnotatedElement> implements ElementModifier<AnnotatedElementContext<A>> {
+
+    @Getter
+    private final AnnotatedElementContext<A> element;
+
+    public <T extends Annotation> void add(T annotation) {
+        if (annotation == null) return;
+        this.element().validate().put(annotation.annotationType(), annotation);
+    }
+
+    public <T extends Annotation> void remove(Class<T> annotation) {
+        if (!annotation.isAnnotation()) return;
+        this.element().validate().remove(annotation);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ElementModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ElementModifier.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.core.context.element;
+
+/**
+ * Acts as an extension of a given {@link QualifiedElement}, allowing you to modify protected values. Modifiers can not
+ * modify private or final values. Any given modifier will only add or remove values like
+ * {@link java.lang.annotation.Annotation annotations}, or change single non-final values. 
+ @param <E>
+ */
+@FunctionalInterface
+public interface ElementModifier<E extends QualifiedElement> {
+    E element();
+}


### PR DESCRIPTION
Fixes #564

# Motivation
This is a bit of a niche feature, but a feature nonetheless. Imagine we have a type which is processed internally by Hartshorn, this type will be evaluated based on its `TypeContext`, not on its `Class`. This gives us two major advantages, 1. better caching of commonly accessed values, and 2. better control of values.  

This suggestions makes explicit use of advantage 2. As we have full and autonomous control over these values, we can also add 'fake' or virtual values which don't exist on the `Class`. Values like annotations.  

> What I'd like is a way to add annotations to a `TypeContext`, or preferably even to `AnnotatedElementContext`s. This would allow us to 'modify' the present annotations, which can be useful for example in the `HartshornApplicationFactory` (see [L257](https://github.com/GuusLieben/Hartshorn/blob/f27f21c255ef44a408b131b5298819db3ec543fd/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java#L257)).

# Changes
Unlike my original proposal, I decided it would be better to avoid implementing these changes directly in any `QualifiedElement`, to avoid easy misuse through regular `TypeContext` accessors. Instead I've added a modifier type, which can be used to modify **protected** values from a given `QualifiedElement`, the `ElementModifier`.  

As the original issue indicated the need for virtual annotations, one default modifier was added; `AnnotatedElementModifier`. This modifier targets any implementation of `AnnotatedElementContext`, allowing you to modify the annotations present in the context. Before changes are made the real annotations are first validated. This allows you to remove annotations present on the real `AnnotatedElement` and add them without preventing validation from registering real annotations.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
