### PR TITLE
#562 Avoid leaking resource lookup strategies across application states

### DIFF
--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceProcessor.java
@@ -44,16 +44,16 @@ import java.util.regex.Pattern;
 @AutomaticActivation
 public class ConfigurationServiceProcessor implements ServiceProcessor<UseConfigurations> {
 
-    private static final Pattern STRATEGY_PATTERN = Pattern.compile("(.+):(.+)");
-    private static final Map<String, ResourceLookupStrategy> strategies = HartshornUtils.emptyConcurrentMap();
+    private final Pattern STRATEGY_PATTERN = Pattern.compile("(.+):(.+)");
+    private final Map<String, ResourceLookupStrategy> strategies = HartshornUtils.emptyConcurrentMap();
 
-    static {
-        addStrategy(new ClassPathResourceLookupStrategy());
-        addStrategy(new FileSystemLookupStrategy());
+    public ConfigurationServiceProcessor() {
+        this.addStrategy(new ClassPathResourceLookupStrategy());
+        this.addStrategy(new FileSystemLookupStrategy());
     }
 
-    public static void addStrategy(final ResourceLookupStrategy strategy) {
-        strategies.put(strategy.name(), strategy);
+    public void addStrategy(final ResourceLookupStrategy strategy) {
+        this.strategies.put(strategy.name(), strategy);
     }
 
     @Override
@@ -74,10 +74,10 @@ public class ConfigurationServiceProcessor implements ServiceProcessor<UseConfig
         final TypeContext<?> owner = TypeContext.of(configuration.owner());
         final FileFormats filetype = configuration.filetype();
 
-        final Matcher matcher = STRATEGY_PATTERN.matcher(source);
+        final Matcher matcher = this.STRATEGY_PATTERN.matcher(source);
         ResourceLookupStrategy strategy = new FileSystemLookupStrategy();
         if (matcher.find()) {
-            strategy = strategies.getOrDefault(matcher.group(1), strategy);
+            strategy = this.strategies.getOrDefault(matcher.group(1), strategy);
             source = matcher.group(2);
         }
 


### PR DESCRIPTION
Fixes #562

# Motivation
The `ConfigurationServiceProcessor` allows us to define custom `ResourceLookupStrategy` instances. However, these are currently stored in a static field. This causes the strategies to be shared across global states, while these may only be expected to be present in specific states.
https://github.com/GuusLieben/Hartshorn/blob/f27f21c255ef44a408b131b5298819db3ec543fd/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServiceProcessor.java#L48

# Changes
Refactors the `strategies` field to be non-static, to avoid leaking to other states.

## Type of change
- [x] Bug fix

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
