### PR TITLE
#570 Configuration based remotes for `JpaRepository` instances

### DIFF
--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -249,6 +249,7 @@ public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enab
     public void close() {
         if (this.session != null && this.session.isOpen()) {
             this.session.close();
+            this.session = null;
         }
     }
 
@@ -263,6 +264,8 @@ public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enab
         if (connection == null) throw new IllegalStateException("Connection has not been configured!");
 
         this.applicationContext().log().debug("Opening remote session to %s".formatted(connection.url()));
-        return this.factory().openSession();
+        this.session = this.factory().openSession();
+
+        return this.session;
     }
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -116,6 +116,12 @@ public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enab
 
     @Override
     public void enable() throws ApplicationException {
+        if (this.connection == null) {
+            this.applicationContext().log().debug("No connection was set for JPA repository instance, using configuration values instead.");
+            HibernateRemoteImpl remote = this.applicationContext().get(HibernateRemoteImpl.class);
+            this.connection = new PersistenceConnection(remote.url(), remote.username(), remote.password(), remote);
+        }
+
         this.registerDefaultDialects();
 
         if (HartshornUtils.notEmpty(this.connection.username()) || HartshornUtils.notEmpty(this.connection.password())) {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemote.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemote.java
@@ -17,9 +17,14 @@
 
 package org.dockbox.hartshorn.data.hibernate;
 
+import org.dockbox.hartshorn.core.annotations.component.Component;
+import org.dockbox.hartshorn.data.remote.PersistenceConnection;
 import org.dockbox.hartshorn.data.remote.Remote;
 import org.hibernate.dialect.Dialect;
 
+@Component(singleton = true)
 public interface HibernateRemote extends Remote {
     Class<? extends Dialect> dialect();
+
+    PersistenceConnection connection();
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
@@ -17,7 +17,7 @@
 
 package org.dockbox.hartshorn.data.hibernate;
 
-import org.dockbox.hartshorn.core.annotations.component.Component;
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.data.remote.PersistenceConnection;
@@ -27,8 +27,8 @@ import javax.inject.Inject;
 
 import lombok.Getter;
 
-@Component(singleton = true)
 @Getter
+@Binds(HibernateRemote.class)
 public class HibernateRemoteImpl implements HibernateRemote {
 
     private final String driver;
@@ -61,5 +61,10 @@ public class HibernateRemoteImpl implements HibernateRemote {
     @Override
     public PersistenceConnection connection(Object target, String user, String password) {
         throw new UnsupportedOperationException("Cannot create targeted connection from pre-configured remote.");
+    }
+
+    @Override
+    public PersistenceConnection connection() {
+        return new PersistenceConnection(this.url(), this.username(), this.password(), this);
     }
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.data.hibernate;
+
+import org.dockbox.hartshorn.core.annotations.component.Component;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.data.remote.PersistenceConnection;
+import org.hibernate.dialect.Dialect;
+
+import javax.inject.Inject;
+
+import lombok.Getter;
+
+@Component(singleton = true)
+@Getter
+public class HibernateRemoteImpl implements HibernateRemote {
+
+    private final String driver;
+    private final Class<? extends Dialect> dialect;
+
+    private final String username;
+    private final String password;
+    private final String url;
+
+    @Inject
+    public HibernateRemoteImpl(final ApplicationContext context) {
+        this.driver = (String) context.property("hartshorn.data.hibernate.driver_class").orNull();
+        if (this.driver == null) throw new IllegalStateException("Driver class was not configured, expected hartshorn.data.hibernate.driver_class to be set, but got null");
+
+        String dialect = (String) context.property("hartshorn.data.hibernate.dialect").orNull();
+        if (dialect == null) throw new IllegalStateException("Dialect was not configured, expected hartshorn.data.hibernate.dialect to be set, but got null");
+
+        TypeContext<?> dialectContext = TypeContext.lookup(dialect);
+        if (!dialectContext.childOf(Dialect.class)) throw new IllegalStateException("Expected dialect to be a subtype of " + Dialect.class.getCanonicalName());
+
+        this.dialect = (Class<? extends Dialect>) dialectContext.type();
+
+        this.username = (String) context.property("hartshorn.data.username").orNull();
+        this.password = (String) context.property("hartshorn.data.password").orNull();
+
+        this.url = (String) context.property("hartshorn.data.url").orNull();
+        if (this.url == null) throw new IllegalStateException("Connection string was not configured, expected hartshorn.data.url to be set, but got null");
+    }
+
+    @Override
+    public PersistenceConnection connection(Object target, String user, String password) {
+        throw new UnsupportedOperationException("Cannot create targeted connection from pre-configured remote.");
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/remote/PersistenceConnection.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/remote/PersistenceConnection.java
@@ -23,16 +23,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class PersistenceConnection {
-
     private final String url;
     private final String username;
     private final String password;
     private final Remote remote;
-
-    public <T> PersistenceConnection(T target, String username, String password, Remote<T> remote) {
-        this.url = remote.connection(target, username, password).url();
-        this.username = username;
-        this.password = password;
-        this.remote = remote;
-    }
 }

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
@@ -17,7 +17,7 @@
 
 package org.dockbox.hartshorn.data;
 
-import com.mysql.jdbc.Driver;
+import com.mysql.cj.jdbc.Driver;
 
 import org.dockbox.hartshorn.core.Enableable;
 import org.dockbox.hartshorn.core.domain.Exceptional;
@@ -26,12 +26,12 @@ import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.hibernate.HibernateJpaRepository;
 import org.dockbox.hartshorn.data.jpa.JpaRepository;
 import org.dockbox.hartshorn.data.remote.DerbyFileRemote;
+import org.dockbox.hartshorn.data.remote.JdbcRemoteConfiguration;
 import org.dockbox.hartshorn.data.remote.MariaDbRemote;
 import org.dockbox.hartshorn.data.remote.MySQLRemote;
 import org.dockbox.hartshorn.data.remote.PersistenceConnection;
 import org.dockbox.hartshorn.data.remote.PostgreSQLRemote;
 import org.dockbox.hartshorn.data.remote.Remote;
-import org.dockbox.hartshorn.data.remote.JdbcRemoteConfiguration;
 import org.dockbox.hartshorn.data.service.JpaRepositoryFactory;
 import org.dockbox.hartshorn.testsuite.ApplicationAwareTest;
 import org.hibernate.Session;
@@ -54,6 +54,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import javax.persistence.EntityManager;
 
 @Testcontainers
 @UsePersistence
@@ -82,10 +84,10 @@ class SqlServiceTest extends ApplicationAwareTest {
 
     public static Stream<Arguments> dialects() {
         return Stream.of(
-                Arguments.of(DerbyFileRemote.INSTANCE, directory(DerbyFileRemote.INSTANCE, "derby")),
-                Arguments.of(MySQLRemote.INSTANCE, connection(MySQLRemote.INSTANCE, mySql, MySQLContainer.MYSQL_PORT)),
-                Arguments.of(PostgreSQLRemote.INSTANCE, connection(PostgreSQLRemote.INSTANCE, postgreSql, PostgreSQLContainer.POSTGRESQL_PORT)),
-                Arguments.of(MariaDbRemote.INSTANCE, connection(MariaDbRemote.INSTANCE, mariaDb, 3306))
+                Arguments.of(directory(DerbyFileRemote.INSTANCE, "derby")),
+                Arguments.of(connection(MySQLRemote.INSTANCE, mySql, MySQLContainer.MYSQL_PORT)),
+                Arguments.of(connection(PostgreSQLRemote.INSTANCE, postgreSql, PostgreSQLContainer.POSTGRESQL_PORT)),
+                Arguments.of(connection(MariaDbRemote.INSTANCE, mariaDb, 3306))
         );
     }
 
@@ -107,7 +109,7 @@ class SqlServiceTest extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("dialects")
-    public void testJpaSave(final Remote<?> remote, final PersistenceConnection target) {
+    public void testJpaSave(final PersistenceConnection target) {
         final JpaRepository<User, Long> sql = this.sql(target);
         sql.save(new User("Guus"));
         sql.save(new User("Simon"));
@@ -127,7 +129,7 @@ class SqlServiceTest extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("dialects")
-    void testJpaDelete(final Remote<?> remote, final PersistenceConnection target) {
+    void testJpaDelete(final PersistenceConnection target) {
         final JpaRepository<User, Long> sql = this.sql(target);
         final User guus = new User("Guus");
         sql.save(guus);
@@ -145,7 +147,7 @@ class SqlServiceTest extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("dialects")
-    void testJpaPersists(final Remote<?> remote, final PersistenceConnection target) {
+    void testJpaPersists(final PersistenceConnection target) {
         final JpaRepository<User, Long> sql = this.sql(target);
         final User user = new User("Guus");
         Assertions.assertEquals(0, user.id());
@@ -156,7 +158,7 @@ class SqlServiceTest extends ApplicationAwareTest {
 
     @ParameterizedTest
     @MethodSource("dialects")
-    void testJpaUpdate(final Remote<?> remote, final PersistenceConnection target) {
+    void testJpaUpdate(final PersistenceConnection target) {
         final JpaRepository<User, Long> sql = this.sql(target);
         final User guus = new User("Guus");
 
@@ -192,5 +194,24 @@ class SqlServiceTest extends ApplicationAwareTest {
         Assertions.assertNotNull(session);
 
         ((HibernateJpaRepository<User, ?>) repository).close();
+    }
+
+    @Test
+    void testAutomaticConnectionForUserRepository() {
+        // Data API specific
+        this.context().property("hartshorn.data.username", mySql.getUsername());
+        this.context().property("hartshorn.data.password", mySql.getPassword());
+
+        String connectionUrl = "jdbc:mysql://%s:%s/%s".formatted(mySql.getHost(), mySql.getMappedPort(MySQLContainer.MYSQL_PORT), DEFAULT_DATABASE);
+        this.context().property("hartshorn.data.url", connectionUrl);
+
+        // Hibernate specific
+        this.context().property("hartshorn.data.hibernate.dialect", MySQL8Dialect.class.getCanonicalName());
+        this.context().property("hartshorn.data.hibernate.driver_class", Driver.class.getCanonicalName());
+
+        UserJpaRepository repository = this.context().get(UserJpaRepository.class);
+
+        EntityManager em = repository.entityManager();
+        Assertions.assertNotNull(em);
     }
 }


### PR DESCRIPTION
Fixes #570

# Motivation
Currently the driver and dialect for a `HibernateJpaRepository` always need to be defined beforehand through a `Remote` implementation.  

# Changes
Adds a default remote implementation for `Hibernate` repositories. This remote acquires all required information from the application properties, and will validate them before attempting to construct a final connection.  
This allows you to create repositories without explicitely defining the connection.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing

**Test Configuration**:
* Platform: MySQL (container based)
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
