### PR TITLE
#574 Add type-erasure based 'unchecked' exception rethrowing

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Hartshorn.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Hartshorn.java
@@ -68,7 +68,7 @@ public final class Hartshorn {
         StackTraceElement element = null;
         for (final StackTraceElement ste : Thread.currentThread().getStackTrace()) {
             final boolean isJavaModule = ste.getModuleName() != null && ste.getModuleName().startsWith("java.");
-            final boolean isExcluded = TypeContext.lookup(ste.getClassName()).annotation(LogExclude.class).present();
+            final boolean isExcluded = TypeContext.lookup(ste.getClassName().split("\\$")[0]).annotation(LogExclude.class).present();
             if (isJavaModule || isExcluded) continue;
             else {
                 element = ste;
@@ -78,7 +78,7 @@ public final class Hartshorn {
 
         if (element == null) throw new IllegalStateException("Could not determine caller from stacktrace");
 
-        final String className = element.getClassName();
+        final String className = element.getClassName().split("\\$")[0];
         if (LOGGERS.containsKey(className)) return LOGGERS.get(className);
 
         final Logger logger = LoggerFactory.getLogger(TypeContext.lookup(className).type());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplication.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplication.java
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.core.boot.LogLevelModifier.LogLevel;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -55,7 +56,7 @@ public final class HartshornApplication {
             return load(TypeContext.of(activator), args, modifiers);
         }
         catch (final InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e) {
-            throw new ApplicationException("Could not bootstrap application " + activator.getSimpleName(), e).runtime();
+            return Except.unchecked(new ApplicationException("Could not bootstrap application " + activator.getSimpleName(), e));
         }
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/logback/LogbackErrorConverter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/logback/LogbackErrorConverter.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.core.boot.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.color.ANSIConstants;
+import ch.qos.logback.core.pattern.color.ForegroundCompositeConverterBase;
+
+public class LogbackErrorConverter extends ForegroundCompositeConverterBase<ILoggingEvent> {
+    @Override
+    protected String getForegroundColorCode(ILoggingEvent event) {
+        Level level = event.getLevel();
+        if (level.toInt() == Level.ERROR_INT)
+            return ANSIConstants.RED_FG;
+        return ANSIConstants.DEFAULT_FG;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -53,6 +53,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.BeanProvisionException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.inject.InjectionModifier;
 import org.dockbox.hartshorn.core.inject.ProviderContext;
 import org.dockbox.hartshorn.core.proxy.ProxyLookup;
@@ -318,7 +319,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
                 Bindings.enable(instance);
             }
             catch (final ApplicationException e) {
-                throw e.runtime();
+                Except.unchecked(e);
             }
         }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/FieldContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/FieldContext.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.core.annotations.Property;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.exceptions.Except;
 
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class FieldContext<T> extends AnnotatedMemberContext<Field> implements Ty
             if (property.present() && !"".equals(property.get().setter())) {
                 final String setter = property.get().setter();
                 final Exceptional<? extends MethodContext<?, ?>> method = this.declaredBy().method(setter, HartshornUtils.asList(this.type()));
-                final MethodContext<?, Object> methodContext = (MethodContext<?, Object>) method.orThrow(() -> new ApplicationException("Setter for field '" + this.name() + "' (" + setter + ") does not exist!").runtime());
+                final MethodContext<?, Object> methodContext = (MethodContext<?, Object>) method.orThrowUnchecked(() -> new ApplicationException("Setter for field '" + this.name() + "' (" + setter + ") does not exist!"));
                 this.setter = (o, v) -> methodContext.invoke(instance, v);
             } else {
                 this.setter = (o, v) -> {
@@ -71,7 +72,7 @@ public class FieldContext<T> extends AnnotatedMemberContext<Field> implements Ty
                         this.field.set(o, v);
                     }
                     catch (final IllegalAccessException ex) {
-                        throw new ApplicationException("Cannot access field " + this.name()).runtime();
+                        Except.unchecked(new ApplicationException("Cannot access field " + this.name()));
                     }
                 };
             }
@@ -89,7 +90,7 @@ public class FieldContext<T> extends AnnotatedMemberContext<Field> implements Ty
             if (property.present() && !"".equals(property.get().getter())) {
                 final String getter = property.get().getter();
                 final Exceptional<? extends MethodContext<?, ?>> method = this.declaredBy().method(getter);
-                final MethodContext<?, Object> methodContext = (MethodContext<?, Object>) method.orThrow(() -> new ApplicationException("Getter for field '" + this.name() + "' (" + getter + ") does not exist!").runtime());
+                final MethodContext<?, Object> methodContext = (MethodContext<?, Object>) method.orThrowUnchecked(() -> new ApplicationException("Getter for field '" + this.name() + "' (" + getter + ") does not exist!"));
                 this.getter = o -> methodContext.invoke(instance).map(v -> (T) v);
             } else {
                 this.getter = o -> Exceptional.of(() -> (T) this.field.get(o));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -27,6 +27,7 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.tuple.Tristate;
 import org.dockbox.hartshorn.core.domain.tuple.Tuple;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.exceptions.NotPrimitiveException;
 import org.dockbox.hartshorn.core.exceptions.TypeConversionException;
 import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyUtil;
@@ -153,7 +154,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         }
         if (context.environment().manager().isProxy(instance)) {
             return context.environment().manager().real(instance)
-                    .orThrow(() -> new ApplicationException("Could not derive real type of instance " + instance).runtime());
+                    .orThrowUnchecked(() -> new ApplicationException("Could not derive real type of instance " + instance));
         }
         else return of(instance);
     }
@@ -569,7 +570,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     }
 
     private void verifyMetadataAvailable() {
-        if (this.isProxy()) throw new ApplicationException("Cannot collect metadata of proxied type '%s'".formatted(this.qualifiedName())).runtime();
+        if (this.isProxy()) Except.unchecked(new ApplicationException("Cannot collect metadata of proxied type '%s'".formatted(this.qualifiedName())));
     }
 
     public T defaultOrNull() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Exceptional.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/domain/Exceptional.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.core.domain;
 
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.function.CheckedBiFunction;
 import org.dockbox.hartshorn.core.function.CheckedFunction;
 import org.dockbox.hartshorn.core.function.CheckedSupplier;
@@ -528,6 +529,18 @@ public final class Exceptional<T> {
         return null;
     }
 
+    public T orThrowUnchecked(final Supplier<Throwable> exceptionSupplier) {
+        if (null != this.value) {
+            return this.value;
+        }
+        else {
+            final Throwable exception = exceptionSupplier.get();
+            if (exception != null)
+                Except.unchecked(exception);
+        }
+        return null;
+    }
+
     /**
      * Return {@code true} if there is no throwable present, otherwise {@code false}.
      *
@@ -563,7 +576,7 @@ public final class Exceptional<T> {
     public Exceptional<T> rethrowUnchecked() {
         if (null != this.throwable) {
             if (this.throwable instanceof RuntimeException) throw (RuntimeException) this.throwable;
-            else throw new RuntimeException(this.throwable);
+            else Except.unchecked(this.throwable);
         }
         return this;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/ApplicationException.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/ApplicationException.java
@@ -36,13 +36,18 @@ public class ApplicationException extends Exception {
         super(cause);
     }
 
+    /**
+     * @return The current exception, wrapped in a {@link RuntimeException}.
+     * @deprecated Use {@link Except#unchecked(Throwable)} instead.
+     */
+    @Deprecated(since = "4.2.5", forRemoval = true)
     public RuntimeException runtime() {
         return new RuntimeException(this);
     }
 
     public Throwable unwrap() {
         Throwable root = this;
-        while (root.getCause() instanceof ApplicationException applicationException && root.getCause() != root) {
+        while (root.getCause() instanceof ApplicationException && root.getCause() != root) {
             root = root.getCause();
         }
         return root;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/Except.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/Except.java
@@ -86,4 +86,18 @@ public final class Except {
         return message;
     }
 
+    /**
+     * Throw the provided {@link Throwable} as if it were unchecked. This treats the exception as if it were unchecked,
+     * and will not require it to be handled by javac. This is possible because of a side effect of type erasure, see
+     * the link below for more details. The return result is only used to mimic a return value when it is needed, as the
+     * <code>throws</code> cause is not enough to make the compiler know that the method will throw an exception.
+     *
+     * @param t The exception to throw.
+     * @param <T> The type of the exception.
+     * @throws T The exception to throw.
+     * @see <a href="https://blog.jooq.org/throw-checked-exceptions-like-runtime-exceptions-in-java/">Throw checked exceptions like runtime exceptions in Java</a>
+     */
+    public static <T extends Throwable, R> R unchecked(Throwable t) throws T {
+        throw (T) t;
+    }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/Except.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/Except.java
@@ -17,9 +17,11 @@
 
 package org.dockbox.hartshorn.core.exceptions;
 
+import org.dockbox.hartshorn.core.annotations.context.LogExclude;
 import org.dockbox.hartshorn.core.function.CheckedRunnable;
 import org.jetbrains.annotations.Nullable;
 
+@LogExclude
 public final class Except {
 
     private static ExceptionHandle handle = ExceptionLevel.FRIENDLY;
@@ -72,18 +74,6 @@ public final class Except {
             }
         }
         return "No message provided";
-    }
-
-    public static String causeMessage(final Throwable throwable) {
-        String message = throwable.getMessage();
-        Throwable next = throwable;
-        while (next != null) {
-            if (null != next.getMessage()) message = next.getMessage();
-            // Avoid infinitely looping if the throwable has itself as cause
-            if (!next.equals(throwable.getCause())) next = next.getCause();
-            else break;
-        }
-        return message;
     }
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/ExceptionLevel.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/exceptions/ExceptionLevel.java
@@ -17,12 +17,14 @@
 
 package org.dockbox.hartshorn.core.exceptions;
 
+import org.dockbox.hartshorn.core.annotations.context.LogExclude;
 import org.dockbox.hartshorn.core.function.TriConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
+@LogExclude
 public enum ExceptionLevel implements ExceptionHandle {
     FRIENDLY(ExceptionHelper::printFriendly),
     MINIMAL(ExceptionHelper::printMinimal),

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyHandler.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.proxy.JavaInterfaceProxyHandler;
 import org.dockbox.hartshorn.core.proxy.MethodProxyContext;
 import org.dockbox.hartshorn.core.proxy.Phase;
@@ -72,7 +73,7 @@ public class JavassistProxyHandler<T> extends DefaultContext implements ProxyHan
     @Override
     public void delegate(final MethodProxyContext<T, ?> property) {
         if (Modifier.isFinal(property.target().getModifiers()))
-            throw new ApplicationException("Cannot proxy final method " + property.target().getName()).runtime();
+            Except.unchecked(new ApplicationException("Cannot proxy final method " + property.target().getName()));
         
         this.handlers.put(property.target(), property);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionProcessor.java
@@ -28,6 +28,7 @@ import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.context.element.TypedElementContext;
 import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.exceptions.Except;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,10 +58,10 @@ public class ComponentContextInjectionProcessor extends ComponentValidator<Servi
 
     private void validate(final TypedElementContext<?> context, final TypeContext<?> parent) {
         if (!context.type().childOf(org.dockbox.hartshorn.core.context.Context.class))
-            throw new ApplicationException("%s is annotated with %s but does not extend %s".formatted(
+            Except.unchecked(new ApplicationException("%s is annotated with %s but does not extend %s".formatted(
                     context.qualifiedName(),
                     Context.class.getSimpleName(),
                     org.dockbox.hartshorn.core.context.Context.class.getSimpleName())
-            ).runtime();
+            ));
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServiceModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServiceModifier.java
@@ -28,6 +28,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.context.element.ConstructorContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 
 @AutomaticActivation
@@ -68,7 +69,7 @@ public class FactoryServiceModifier extends ServiceAnnotatedMethodModifier<Facto
             if (enable) Bindings.enable(instance);
             return instance;
         } catch (ApplicationException e) {
-            throw e.runtime();
+            return Except.unchecked(e);
         }
     }
 

--- a/hartshorn-core/src/main/resources/logback.xml
+++ b/hartshorn-core/src/main/resources/logback.xml
@@ -1,11 +1,13 @@
 <configuration>
     <!--Disable Logback default init output-->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <conversionRule conversionWord="ec" converterClass="org.dockbox.hartshorn.core.boot.logback.LogbackErrorConverter" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <withJansi>true</withJansi>
         <!--Custom encoder to support process_id-->
         <encoder class="org.dockbox.hartshorn.core.boot.logback.LogbackEncoder">
-            <pattern>%d{HH:mm:ss.SSS} %white([ %-15.15t]) @ %green(%process_id) -> %cyan(%-38.38logger{36}) %magenta(%-5level) - %msg%n
+            <pattern>%d{HH:mm:ss.SSS} %white([ %-15.15t]) @ %green(%process_id) -> %cyan(%-38.38logger{36}) %magenta(%-5level) - %ec(%msg) %n
             </pattern>
         </encoder>
     </appender>

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ExceptionalTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ExceptionalTests.java
@@ -424,9 +424,8 @@ public class ExceptionalTests {
             Assertions.fail();
         }
         catch (final Throwable t) {
-            Assertions.assertTrue(t instanceof RuntimeException);
-            Assertions.assertNotNull(t.getCause());
-            Assertions.assertEquals("error", t.getCause().getMessage());
+            Assertions.assertTrue(t instanceof Exception);
+            Assertions.assertEquals("error", t.getMessage());
         }
     }
 

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -56,7 +56,7 @@ public class ProxyTests extends ApplicationAwareTest {
                 FinalProxyTarget.class.getMethod("name"),
                 (instance, args, proxyContext) -> "Hartshorn");
         final ProxyHandler<FinalProxyTarget> handler = new JavassistProxyHandler<>(new FinalProxyTarget());
-        Assertions.assertThrows(RuntimeException.class, () -> handler.delegate(property));
+        Assertions.assertThrows(ApplicationException.class, () -> handler.delegate(property));
 
         // Ensure the exception isn't thrown after registration
         final FinalProxyTarget proxy = handler.proxy();

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -276,7 +276,7 @@ public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enab
             try {
                 Bindings.enable(this);
             } catch (ApplicationException e) {
-                throw e.runtime();
+                return Except.unchecked(e);
             }
         }
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/AbstractPersistenceServiceModifier.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/AbstractPersistenceServiceModifier.java
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.TypedOwner;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.exceptions.Except;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.services.ComponentContainer;
 import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodModifier;
@@ -95,11 +96,11 @@ public abstract class AbstractPersistenceServiceModifier<M extends Annotation, C
                 Files.createDirectory(root);
             }
             catch (final IOException e) {
-                throw new ApplicationException(e).runtime();
+                Except.unchecked(e);
             }
         }
 
-        if (!root.toFile().isDirectory()) throw new ApplicationException("Expected " + root + " to be a directory, but found a file instead").runtime();
+        if (!root.toFile().isDirectory()) Except.unchecked(new ApplicationException("Expected " + root + " to be a directory, but found a file instead"));
 
         return annotationContext.filetype().asPath(root, annotationContext.file().value());
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -90,7 +90,7 @@ public class HttpWebServerInitializer implements LifecycleObserver {
             this.webServer.start(this.port);
         }
         catch (final ApplicationException e) {
-            throw e.runtime();
+            Except.unchecked(e);
         }
     }
 


### PR DESCRIPTION
Fixes #574

# Motivation
> Due to generic type erasure, javac will allow you to rethrow a checked exception without requiring it to be checked. This can be done using the following method:  
> ```java
> public <T extends Throwable> void runtime(Throwable t) throws T {
>     throw (T) t;
> }
> ```
> 
> Currently, all unchecked rethrows of `ApplicationException` require it to be wrapped in a `RuntimeException` before it is (re)thrown. With the snippet above, you can rethrow the same exception without wrapping it, and without requiring it to be caught.  
> 
> Preferably this should be added to `Except`, and `ApplicationException#runtime` should be deprecated for removal.

# Changes
Adds the snippet mentioned above to `Except` as a static utility, and replaces existing `throw ApplicationException.runtime()` usages with `Except.unchecked(ApplicationException)`.

## Type of change
- [x] New core feature

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
