### PR TITLE
#585 Separate prefix binding queue and processing of bound prefixes

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
@@ -34,6 +34,7 @@ import org.dockbox.hartshorn.core.services.ComponentLocator;
 import org.dockbox.hartshorn.core.services.ComponentLocatorImpl;
 import org.dockbox.hartshorn.core.services.ComponentPostProcessor;
 import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
+import org.dockbox.hartshorn.core.services.ServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -189,38 +190,42 @@ public class HartshornApplicationFactory implements ApplicationFactory<Hartshorn
         final HartshornApplicationContext applicationContext = new HartshornApplicationContext(environment, this.componentLocator, this.activator, this.prefixes, this.arguments, this.modifiers);
         manager.applicationContext(applicationContext);
 
+        applicationContext.addActivator(new ServiceImpl());
+
         final ApplicationConfigurator configurator = this.applicationConfigurator;
         configurator.configure(manager);
 
         for (final Annotation serviceActivator : this.serviceActivators)
             applicationContext.addActivator(serviceActivator);
 
-        applicationContext.lookupActivatables();
-
-        this.componentPreProcessors.forEach(applicationContext::add);
-        this.componentPostProcessors.forEach(applicationContext::add);
+        // Always load Hartshorn internals first
+        configurator.bind(manager, Hartshorn.PACKAGE_PREFIX);
 
         final Activator activator = this.activatorAnnotation();
-        final Set<InjectConfiguration> configurations = Arrays.stream(activator.configs())
-                .map(InjectConfig::value)
-                .map(TypeContext::of)
-                .map(applicationContext::raw)
-                .collect(Collectors.toSet());
-
-        configurator.apply(manager, configurations);
-        configurator.apply(manager, this.injectConfigurations);
-
-        final Set<String> scanPackages = HartshornUtils.asSet(activator.scanPackages());
+        final Set<String> scanPackages = Set.of(activator.scanPackages());
         final Collection<String> scanPrefixes = HartshornUtils.merge(this.prefixes, scanPackages);
 
         if (activator.includeBasePackage())
             scanPrefixes.add(this.activator.type().getPackageName());
 
-        // Always load Hartshorn internals first
-        configurator.bind(manager, Hartshorn.PACKAGE_PREFIX);
+        final Set<InjectConfiguration> configurations = Arrays.stream(activator.configs())
+                .map(InjectConfig::value)
+                .map(TypeContext::of)
+                .map(applicationContext::get)
+                .collect(Collectors.toSet());
+
+        configurator.apply(manager, configurations);
+        configurator.apply(manager, this.injectConfigurations);
 
         for (final String prefix : scanPrefixes)
             configurator.bind(manager, prefix);
+
+        applicationContext.lookupActivatables();
+
+        this.componentPreProcessors.forEach(applicationContext::add);
+        applicationContext.process();
+
+        this.componentPostProcessors.forEach(applicationContext::add);
 
         for (final LifecycleObserver observer : manager.observers())
             observer.onStarted(applicationContext);

--- a/hartshorn-core/src/test/java/com/example/application/ActivatorScanningTests.java
+++ b/hartshorn-core/src/test/java/com/example/application/ActivatorScanningTests.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package com.example.application;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Set;
+
+@UseDemo
+@HartshornTest
+public class ActivatorScanningTests {
+
+    @InjectTest
+    void testPrefixFromActivatorIsRegistered(final ApplicationContext applicationContext) {
+        final Set<String> prefixes = applicationContext.environment().prefixContext().prefixes();
+        Assertions.assertTrue(prefixes.contains("com.example.application"));
+    }
+
+    @InjectTest
+    void testBindingsFromActivatorPrefixArePresent(final ApplicationContext applicationContext) {
+        final Demo demo = applicationContext.get(Demo.class);
+        Assertions.assertNotNull(demo);
+        Assertions.assertEquals("Demo", demo.demo());
+        Assertions.assertTrue(demo instanceof DemoImpl);
+    }
+}

--- a/hartshorn-core/src/test/java/com/example/application/Demo.java
+++ b/hartshorn-core/src/test/java/com/example/application/Demo.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package com.example.application;
+
+public interface Demo {
+    String demo();
+}

--- a/hartshorn-core/src/test/java/com/example/application/DemoImpl.java
+++ b/hartshorn-core/src/test/java/com/example/application/DemoImpl.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package com.example.application;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+
+@Binds(Demo.class)
+public class DemoImpl implements Demo{
+    @Override
+    public String demo() {
+        return "Demo";
+    }
+}

--- a/hartshorn-core/src/test/java/com/example/application/UseDemo.java
+++ b/hartshorn-core/src/test/java/com/example/application/UseDemo.java
@@ -22,6 +22,6 @@ import org.dockbox.hartshorn.core.annotations.service.ServiceActivator;
 import java.lang.annotation.Retention;
 
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@ServiceActivator(scanPackages = "nz.pumbas.halpbot")
+@ServiceActivator(scanPackages = "com.example.application")
 public @interface UseDemo {
 }

--- a/hartshorn-core/src/test/java/com/example/application/UseDemo.java
+++ b/hartshorn-core/src/test/java/com/example/application/UseDemo.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2020 Guus Lieben
+ *
+ *  This framework is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 2.1 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ *  the GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package com.example.application;
+
+import org.dockbox.hartshorn.core.annotations.service.ServiceActivator;
+
+import java.lang.annotation.Retention;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@ServiceActivator(scanPackages = "nz.pumbas.halpbot")
+public @interface UseDemo {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core;
 import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.boot.EmptyService;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.HartshornApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.proxy.ExtendedProxy;
 import org.dockbox.hartshorn.core.types.ComponentType;
@@ -164,7 +165,11 @@ public class ApplicationContextTests {
 
     @Test
     public void testScannedBindingCanBeProvided() {
+        // This is a bit of a hack, but we need to ensure that the prefix binding is present and processed. Usually
+        // you'd do this through a service activator.
         this.applicationContext().bind("test.types.scan");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+
         final SampleInterface provided = this.applicationContext().get(SampleInterface.class);
         Assertions.assertNotNull(provided);
 
@@ -176,7 +181,11 @@ public class ApplicationContextTests {
 
     @Test
     public void testScannedMetaBindingsCanBeProvided() {
+        // This is a bit of a hack, but we need to ensure that the prefix binding is present and processed. Usually
+        // you'd do this through a service activator.
         this.applicationContext().bind("test.types.meta");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+
         // Ensure that the binding is not bound to the default name
         final SampleInterface sample = this.applicationContext().get(SampleInterface.class);
         Assertions.assertNull(sample); // Non-component, so null
@@ -200,7 +209,11 @@ public class ApplicationContextTests {
 
     @Test
     public void testScannedMultiBindingsCanBeProvided() {
+        // This is a bit of a hack, but we need to ensure that the prefix binding is present and processed. Usually
+        // you'd do this through a service activator.
         this.applicationContext().bind("test.types.multi");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+
         final SampleInterface provided = this.applicationContext().get(SampleInterface.class);
         Assertions.assertNotNull(provided);
 
@@ -212,7 +225,11 @@ public class ApplicationContextTests {
 
     @Test
     public void testScannedMultiMetaBindingsCanBeProvided() {
+        // This is a bit of a hack, but we need to ensure that the prefix binding is present and processed. Usually
+        // you'd do this through a service activator.
         this.applicationContext().bind("test.types.multi");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+
         final SampleInterface provided = this.applicationContext().get(Key.of(SampleInterface.class, "meta"));
         Assertions.assertNotNull(provided);
 
@@ -256,7 +273,11 @@ public class ApplicationContextTests {
     @ParameterizedTest
     @MethodSource("providers")
     void testProvidersCanApply(final String meta, final String name, final boolean field, final String fieldMeta, final boolean singleton) {
+        // This is a bit of a hack, but we need to ensure that the prefix binding is present and processed. Usually
+        // you'd do this through a service activator.
         this.applicationContext().bind("test.types.provision");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+
         if (field) {
             if (fieldMeta == null) {this.applicationContext().bind(Key.of(SampleField.class), SampleFieldImplementation.class);}
             else this.applicationContext().bind(Key.of(SampleField.class, fieldMeta), SampleFieldImplementation.class);


### PR DESCRIPTION
Fixes #585

# Motivation
These changes are made based on my earlier issue #585, where I stated that scannable prefixes in service activators were not applied even though they were registered.
> When registering additional prefixes through `ServiceActivator#scanPackages`, the prefixes are registered to the application environment, but are never processed to the application after that. This results in the prefix being known, but components and processors never being bound and/or activated. 
> https://github.com/GuusLieben/Hartshorn/blob/17c5b8afca8448583da02c00f0a3e5d641d97dbb/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L151

The solution for this issue was quite annoying to implement with the existing situation of registering and processing prefixes. If we register a prefix for a service activator, when should it be processed? If we do it later, how do we ensure we don't skip prefixes? If we do it directly, how do we prevent locking prefixes if other activators are not yet present?  

Because of this issue, I opted to implement a long-standing idea of mine; removing direct processing of singular prefixes, and only allowing them to be processed all at once later in time. This allows us to first ensure bindings are present for all prefixes, which in turn allows `ComponentProcessor`s to function more reliably. Additionally, this allows us to use proper provision of processors, as long as the injected values do not require modification.  

## Type of change
- [x] Bug fix
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: Corretto 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
