### PR TITLE
#588 Remove duplicated `prefixes` argument

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
@@ -187,7 +187,7 @@ public class HartshornApplicationFactory implements ApplicationFactory<Hartshorn
         );
         final ApplicationEnvironment environment = this.applicationEnvironment.apply(manager);
 
-        final HartshornApplicationContext applicationContext = new HartshornApplicationContext(environment, this.componentLocator, this.activator, this.prefixes, this.arguments, this.modifiers);
+        final HartshornApplicationContext applicationContext = new HartshornApplicationContext(environment, this.componentLocator, this.activator, this.arguments, this.modifiers);
         manager.applicationContext(applicationContext);
 
         applicationContext.addActivator(new ServiceImpl());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -106,8 +106,9 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
     private MetaProvider metaProvider;
 
     public HartshornApplicationContext(final ApplicationEnvironment environment, final Function<ApplicationContext, ComponentLocator> componentLocator,
-                                       final TypeContext<?> activationSource, final Set<String> prefixes, final Set<String> args, final Set<Modifier> modifiers) {
+                                       final TypeContext<?> activationSource, final Set<String> args, final Set<Modifier> modifiers) {
         this.singletons.put(Key.of(ApplicationContext.class), this);
+
         this.environment = environment;
         final Exceptional<Activator> activator = activationSource.annotation(Activator.class);
         if (activator.absent()) {


### PR DESCRIPTION
Fixes #588

> The `prefixes` argument in the constructor of `HartshornApplicationContext` is unused, as active prefixes are already handled by the `HartshornFactory`. 
> 
> https://github.com/GuusLieben/Hartshorn/blob/17c5b8afca8448583da02c00f0a3e5d641d97dbb/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L107