### PR TITLE
#592 Allow reflecting on `TypeContext`s and add `isTypeContext` rule

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -128,6 +128,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     @Getter private final boolean isEnum;
     @Getter private final boolean isAnnotation;
     @Getter private final boolean isArray;
+    @Getter private final boolean isTypeContext;
 
     private final Map<String, FieldContext<?>> fields = new ConcurrentHashMap<>();
 
@@ -148,9 +149,6 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     private Tristate isProxy = Tristate.UNDEFINED;
 
     protected TypeContext(final Class<T> type) {
-        if (TypeContext.class.equals(type)) {
-            throw new IllegalArgumentException("TypeContext can not be reflected on");
-        }
         this.type = type;
         this.isVoid = Void.TYPE.equals(type) || Void.class.equals(type);
         this.isAnonymous = type.isAnonymousClass();
@@ -158,6 +156,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         this.isEnum = type.isEnum();
         this.isAnnotation = type.isAnnotation();
         this.isArray = type.isArray();
+        this.isTypeContext = TypeContext.class.isAssignableFrom(type);
     }
 
     public static <T> TypeContext<T> unproxy(final ApplicationContext context, final T instance) {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ElementContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ElementContextTests.java
@@ -366,4 +366,14 @@ public class ElementContextTests {
     void testAnnotatedTypeCanGetAnnotationFromAnnotation() {
         Assertions.assertTrue(TypeContext.of(AnnotatedElement.class).annotation(Activator.class).present());
     }
+
+    @Test
+    void testTypeContextCanReflect() {
+        Assertions.assertDoesNotThrow(() -> TypeContext.of(TypeContext.class));
+    }
+
+    @Test
+    void testWrappedTypeContextIsTypeContext() {
+        Assertions.assertTrue(TypeContext.of(TypeContext.class).isTypeContext());
+    }
 }


### PR DESCRIPTION
Fixes #591

# Motivation
Currently it is not allowed to reflect on TypeContext values. This was originally done to prevent accidental reflection on wrapped types. However, @pumbas600 pointed out that types may hold a field value with the type `TypeContext`. This will immediately fail as the check for `TypeContext` reflecting is present in the constructor of `TypeContext`.

# Changes
Removes the rule within the `TypeContext` constructor. To allow users to easily check if a type is a `TypeContext`, I also added a `isTypeContext` rule. This is practically a shorthand for `.isChild(TypeContext.class)`.

## Type of change
- [x] Bug fix

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
