### PR TITLE
#594 Resolve invocation of default methods in service proxies

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/JavaInterfaceProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/JavaInterfaceProxyHandler.java
@@ -42,7 +42,7 @@ public class JavaInterfaceProxyHandler<T> implements InvocationHandler, ProxyHan
 
     @Override
     public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        return this.handler().invoke(null, method, null, args);
+        return this.handler().invoke(proxy, method, null, args);
     }
 
     public T proxy() {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -17,6 +17,8 @@
 
 package org.dockbox.hartshorn.core;
 
+import org.dockbox.hartshorn.core.types.Person;
+
 import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.boot.EmptyService;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -323,6 +325,13 @@ public class ApplicationContextTests {
         Assertions.assertNotNull(sample);
         Assertions.assertNotNull(sample.name());
         Assertions.assertEquals("Factory", sample.name());
+    }
+
+    @Test
+    void testFactoryAllowsPassThroughDefaults() {
+        final PassThroughFactory factoryDemo = this.applicationContext().get(PassThroughFactory.class);
+        final Person person = factoryDemo.create("Bob");
+        Assertions.assertNotNull(person);
     }
 
     @Test

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/PassThroughFactory.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/PassThroughFactory.java
@@ -1,0 +1,16 @@
+package org.dockbox.hartshorn.core;
+
+import org.dockbox.hartshorn.core.types.Person;
+
+import org.dockbox.hartshorn.core.annotations.Factory;
+import org.dockbox.hartshorn.core.annotations.service.Service;
+
+@Service
+public interface PassThroughFactory {
+    @Factory
+    Person create(String name, int age);
+
+    default Person create(final String name) {
+        return this.create(name, -1);
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/Person.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/Person.java
@@ -1,0 +1,6 @@
+package org.dockbox.hartshorn.core.types;
+
+public interface Person {
+    String name();
+    int age();
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/PersonImpl.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/PersonImpl.java
@@ -1,0 +1,15 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.annotations.inject.Bound;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Binds(Person.class)
+@AllArgsConstructor(onConstructor_ = @Bound)
+@Getter
+public class PersonImpl implements Person{
+    private final String name;
+    private final int age;
+}


### PR DESCRIPTION
Fixes #594

# Motivation
> When there is a default method in a proxied service interface, the default method cannot be invoked properly as the proceeding method method cannot be invoked directly using the `Proxy` instance.  
> 
> For example, say we have a `Person` interface which defines a name and age, and a `PersonImpl` with a constructor for these attributes. We wish to use a factory provider for this, so we do not need to be aware of the `PersonImpl` class. We also want to add a default value for `age` in our factory, so we don't need to implement that elsewhere. This results in the following factory service:
> ```java
> @Service
> public interface PassThroughFactory {
>     @Factory
>     Person create(String name, int age);
> 
>     default Person create(final String name) {
>         return this.create(name, -1);
>     }
> }
> ```
> 
> When we use `PassThroughFactory#create(name)`, the invocation will fail. See the attached error message provided by @pumbas600 
![image](https://user-images.githubusercontent.com/10957963/145674115-b4e25283-23ca-48df-9163-2c194db1c6c2.png)

# Changes
Adds additional rules to the `JavassistProxyHandler` to use method handles if the method is `default`. It will now also fall back to the `self` instance if the stored `instance` is null and `self` is not an instance of `Proxy`.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
