### PR TITLE
#596 Allow modification of `ApplicationFactory` during test initialization

### DIFF
--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -43,8 +42,8 @@ public class ComponentProvisionTests {
     @Getter
     private ApplicationContext applicationContext;
 
-    public static Stream<Arguments> components() throws IOException {
-        return HartshornExtension.createContext(ComponentProvisionTests.class)
+    public static Stream<Arguments> components() {
+        return HartshornExtension.createContext(new HartshornApplicationFactory().loadDefaults(), ComponentProvisionTests.class)
                 .rethrowUnchecked().get()
                 .locator()
                 .containers().stream()

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/testsuite/HartshornFactoryTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/testsuite/HartshornFactoryTests.java
@@ -1,0 +1,22 @@
+package org.dockbox.hartshorn.testsuite;
+
+import org.dockbox.hartshorn.core.boot.ApplicationFactory;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.junit.jupiter.api.Assertions;
+
+@HartshornTest
+public class HartshornFactoryTests {
+
+    @HartshornFactory
+    public static ApplicationFactory<?, ?> factory(final ApplicationFactory<?, ?> factory) {
+        return factory.argument("-Hfactory.modified=true");
+    }
+
+    @InjectTest
+    void testFactoryWasModified(final ApplicationContext applicationContext) {
+        final Exceptional<Object> property = applicationContext.property("factory.modified");
+        Assertions.assertTrue(property.present());
+        Assertions.assertEquals("true", property.get());
+    }
+}

--- a/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/HartshornFactory.java
+++ b/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/HartshornFactory.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.testsuite;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(java.lang.annotation.ElementType.METHOD)
+public @interface HartshornFactory {
+}

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.i18n;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.boot.HartshornApplicationFactory;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -79,7 +80,7 @@ public final class TranslationBatchGenerator {
     private TranslationBatchGenerator() {}
 
     public static void main(final String[] args) throws Exception {
-        final ApplicationContext context = HartshornExtension.createContext(TranslationBatchGenerator.class).orNull();
+        final ApplicationContext context = HartshornExtension.createContext(new HartshornApplicationFactory().loadDefaults(), TranslationBatchGenerator.class).orNull();
         final Map<String, String> batches = migrateBatches(context);
         final String date = SDF.format(LocalDateTime.now());
         final Path outputPath = existingBatch().toPath().resolve("batches/" + date);


### PR DESCRIPTION
Fixes #596

# Changes
Allows for the modification of the active `ApplicationFactory` which is used to create the `ApplicationContext` for a test class. This method should always be static, and should always return a valid `ApplicationFactory`.  
Optionally, the method may accept the existing `ApplicationFactory`, which has the default values loaded.  

The method is always annotated with `@HartshornFactory`, and should always be static.

## Sample usage
```java
@HartshornFactory
public static ApplicationFactory<?, ?> factory(final ApplicationFactory<?, ?> factory) {
    return factory.componentLocator(CustomComponentLocator::new);
}
```

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
