### PR TITLE
#601 Allow modifying method invoker and access level

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodInvoker.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodInvoker.java
@@ -1,0 +1,8 @@
+package org.dockbox.hartshorn.core.context.element;
+
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+@FunctionalInterface
+public interface MethodInvoker<T, P> {
+    Exceptional<T> invoke(MethodContext<T, P> method, P instance, Object[] args);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodModifier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodModifier.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.core.context.element;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(staticName = "of")
+public class MethodModifier<T, P> implements ElementModifier<MethodContext<T, P>> {
+
+    @Getter
+    private final MethodContext<T, P> element;
+
+    public void invoker(final MethodInvoker<T, P> invoker) {
+        this.element.invoker(invoker);
+    }
+
+    public void access(final boolean expose) {
+        this.element().method().setAccessible(expose);
+    }
+
+    public static void defaultInvoker(final MethodInvoker<?, ?> invoker) {
+        MethodContext.defaultInvoker(invoker);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ReflectionMethodInvoker.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ReflectionMethodInvoker.java
@@ -1,0 +1,17 @@
+package org.dockbox.hartshorn.core.context.element;
+
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+public class ReflectionMethodInvoker<T, P> implements MethodInvoker<T, P> {
+
+    @Override
+    public Exceptional<T> invoke(final MethodContext<T, P> method, final P instance, final Object[] args) {
+        final Exceptional<T> result = Exceptional.of(() -> (T) method.method().invoke(instance, args));
+        if (result.caught()) {
+            Throwable cause = result.error();
+            if (result.error().getCause() != null) cause = result.error().getCause();
+            return Exceptional.of(result.orNull(), cause);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes #601

# Motivation
Currently, the way methods are invoked through `MethodContext#invoke` and `#invokeStatic`, are limited to the default behavior of the `MethodContext`. The only way this can currently be changed, is by creating an override of the `MethodContext`. However this leaves internal invokers unchanged. https://github.com/GuusLieben/Hartshorn/blob/362a6a572e2df6a8ac97d4063579a21981d156ca/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java#L62

# Changes
This PR introduces two relevant changes; method invokers, and method modifiers. A `MethodInvoker` is used by a `MethodContext` to determine how a method should be invoked. By default this uses the `ReflectionMethodInvoker` which uses Java Reflections to invoke methods, as has previously also been the default.  

The `MethodModifier` is a new `ElementModifier` specific to `MethodContext`s. It allows for the modification of the active `MethodInvoker` for a given `MethodContext`, as well as the default `MethodInvoker` for all new contexts. As the default access level for the invocation of methods is `public` only, it is also possible to change the access level of the underlying method (through `setAccessible`). This remains a modifier-only action, as this should be a choice made by the implementing developer, and never be the default behavior.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
