### PR TITLE
#599 Validate that components are registered when requested

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -315,6 +315,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
 
     private <T> T get(final Key<T> key, final boolean enable) {
         if (this.singletons.containsKey(key)) return (T) this.singletons.get(key);
+        this.locator().validate(key);
 
         T instance = this.create(key);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocator.java
@@ -17,9 +17,10 @@
 
 package org.dockbox.hartshorn.core.services;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.ComponentType;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.Collection;
 
@@ -32,4 +33,6 @@ public interface ComponentLocator {
     Collection<ComponentContainer> containers(ComponentType functional);
 
     Exceptional<ComponentContainer> container(TypeContext<?> type);
+
+    <T> void validate(Key<T> key);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.ComponentType;
 import org.dockbox.hartshorn.core.HashSetMultiMap;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MultiMap;
 import org.dockbox.hartshorn.core.annotations.component.Component;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -28,36 +29,39 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 import java.util.Collection;
 import java.util.List;
 
+import lombok.Getter;
+
 public class ComponentLocatorImpl implements ComponentLocator {
 
     private final MultiMap<String, ComponentContainer> cache = new HashSetMultiMap<>();
-    private final ApplicationContext context;
+    @Getter
+    private final ApplicationContext applicationContext;
 
-    public ComponentLocatorImpl(final ApplicationContext context) {
-        this.context = context;
+    public ComponentLocatorImpl(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
     }
 
     @Override
     public void register(final String prefix) {
         if (this.cache.containsKey(prefix)) return;
 
-        this.context.log().debug("Registering prefix '" + prefix + "' for component locating");
+        this.applicationContext().log().debug("Registering prefix '" + prefix + "' for component locating");
 
         final long start = System.currentTimeMillis();
-        this.context.environment().prefix(prefix);
+        this.applicationContext().environment().prefix(prefix);
 
-        final List<ComponentContainer> containers = this.context.environment()
+        final List<ComponentContainer> containers = this.applicationContext().environment()
                 .types(prefix, Component.class, false)
                 .stream()
-                .map(type -> new ComponentContainerImpl(this.context, type))
+                .map(type -> new ComponentContainerImpl(this.applicationContext(), type))
                 .filter(ComponentContainerImpl::enabled)
                 .filter(container -> !container.type().isAnnotation()) // Exclude extended annotations
                 .map(ComponentContainer.class::cast)
-                .filter(container -> container.activators().stream().allMatch(this.context::hasActivator))
+                .filter(container -> container.activators().stream().allMatch(this.applicationContext()::hasActivator))
                 .toList();
 
         final long duration = System.currentTimeMillis() - start;
-        this.context.log().info("Located %d components with prefix %s in %dms".formatted(containers.size(), prefix, duration));
+        this.applicationContext().log().info("Located %d components with prefix %s in %dms".formatted(containers.size(), prefix, duration));
 
         this.cache.putAll(prefix, containers);
     }
@@ -81,5 +85,13 @@ public class ComponentLocatorImpl implements ComponentLocator {
                 .filter(container -> container.type().equals(type))
                 .findFirst()
         );
+    }
+
+    @Override
+    public <T> void validate(final Key<T> key) {
+        final TypeContext<T> contract = key.contract();
+        if (contract.annotation(Component.class).present() && this.container(contract).absent()) {
+            this.applicationContext().log().warn("Component key '%s' is annotated with @Component, but is not registered.".formatted(contract.qualifiedName()));
+        }
     }
 }

--- a/hartshorn-core/src/test/java/com/nonregistered/DemoComponent.java
+++ b/hartshorn-core/src/test/java/com/nonregistered/DemoComponent.java
@@ -1,0 +1,7 @@
+package com.nonregistered;
+
+import org.dockbox.hartshorn.core.annotations.component.Component;
+
+@Component
+public class DemoComponent {
+}

--- a/hartshorn-core/src/test/java/com/nonregistered/NonRegisteredComponentTests.java
+++ b/hartshorn-core/src/test/java/com/nonregistered/NonRegisteredComponentTests.java
@@ -1,0 +1,23 @@
+package com.nonregistered;
+
+import org.dockbox.hartshorn.core.boot.ApplicationFactory;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.testsuite.HartshornFactory;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.junit.jupiter.api.Assertions;
+
+@HartshornTest
+public class NonRegisteredComponentTests {
+
+    @HartshornFactory
+    public static ApplicationFactory<?, ?> factory(final ApplicationFactory<?, ?> factory) {
+        return factory.componentLocator(ThrowingComponentLocatorImpl::new);
+    }
+
+    @InjectTest
+    void testComponents(final ApplicationContext applicationContext) {
+        Assertions.assertThrows(ApplicationException.class, () -> applicationContext.get(DemoComponent.class));
+    }
+}

--- a/hartshorn-core/src/test/java/com/nonregistered/ThrowingComponentLocatorImpl.java
+++ b/hartshorn-core/src/test/java/com/nonregistered/ThrowingComponentLocatorImpl.java
@@ -1,0 +1,38 @@
+package com.nonregistered;
+
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.services.ComponentLocatorImpl;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+public class ThrowingComponentLocatorImpl extends ComponentLocatorImpl {
+
+    private final ApplicationContext proxy;
+    private boolean mock = false;
+
+    public ThrowingComponentLocatorImpl(final ApplicationContext applicationContext) {
+        super(applicationContext);
+        this.proxy = Mockito.spy(applicationContext);
+    }
+
+    @Override
+    public ApplicationContext applicationContext() {
+        if (this.mock) return this.proxy;
+        return super.applicationContext();
+    }
+
+    @Override
+    public <T> void validate(final Key<T> key) {
+        this.mock = true;
+        final Logger logger = Mockito.spy(this.proxy.log());
+        Mockito.doAnswer(invocation -> {
+            final String message = invocation.getArgument(0, String.class);
+            throw new ApplicationException(message);
+        }).when(logger).warn(Mockito.anyString());
+        Mockito.when(this.proxy.log()).thenReturn(logger);
+        super.validate(key);
+        this.mock = false;
+    }
+}


### PR DESCRIPTION
Fixes #599

# Motivation
Currently it is not always clear when a component or service is not properly registered. This may lead to the component being used without it properly being processed early on.

# Changes
When obtaining an instance of a type, the type will now be validated through the active `ComponentLocator`. If the type is a component, but is not registered, a warning will yield (default behavior). As previously indicated, this should not throw an exception by default, as components may be registered manually through other means.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
