### PR TITLE
#605 Add support for inline default values and collection specifications to `@Value` based configuration postprocessor

### DIFF
--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/annotations/Value.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/annotations/Value.java
@@ -26,8 +26,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation used to indicate a field should be populated with the value obtained
- * from {@link org.dockbox.hartshorn.core.context.ApplicationPropertyHolder#property(String)} or the
- * {@link #or() default value}.
+ * from {@link org.dockbox.hartshorn.core.context.ApplicationPropertyHolder#property(String)}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -52,5 +51,6 @@ public @interface Value {
      *
      * @return The string-based default value.
      */
+    @Deprecated(since = "4.2.5", forRemoval = true)
     String or() default "";
 }

--- a/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
+++ b/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.inject.Inject;
 
@@ -48,6 +49,53 @@ public class ConfigurationManagerTests {
         Assertions.assertNotNull(configuration);
         Assertions.assertNotNull(configuration.classPathValue());
         Assertions.assertEquals("This is a value", configuration.classPathValue());
+    }
+
+    @Test
+    void testDefaultValuesAreUsedIfPropertyIsAbsent() {
+        final DemoClasspathConfiguration configuration = this.applicationContext().get(DemoClasspathConfiguration.class);
+
+        Assertions.assertNotNull(configuration);
+        Assertions.assertNotNull(configuration.classPathValueWithDefault());
+        Assertions.assertEquals("myDefaultValue", configuration.classPathValueWithDefault());
+    }
+
+    @Test
+    void testNumberValuesAreParsed() {
+        final DemoClasspathConfiguration configuration = this.applicationContext().get(DemoClasspathConfiguration.class);
+
+        Assertions.assertNotNull(configuration);
+        Assertions.assertEquals(1, configuration.number());
+    }
+
+    @Test
+    void testCollectionsAreParsed() {
+        final DemoClasspathConfiguration configuration = this.applicationContext().get(DemoClasspathConfiguration.class);
+
+        Assertions.assertNotNull(configuration);
+        Assertions.assertNotNull(configuration.list());
+        Assertions.assertEquals(3, configuration.list().size());
+    }
+
+    @Test
+    void testCollectionsAreSorted() {
+        final DemoClasspathConfiguration configuration = this.applicationContext().get(DemoClasspathConfiguration.class);
+
+        Assertions.assertNotNull(configuration);
+        Assertions.assertNotNull(configuration.copyOnWriteArrayList());
+        Assertions.assertEquals(1, (int) configuration.copyOnWriteArrayList().get(0));
+        Assertions.assertEquals(5, (int) configuration.copyOnWriteArrayList().get(1));
+        Assertions.assertEquals(3, (int) configuration.copyOnWriteArrayList().get(2));
+    }
+
+    @Test
+    void testCustomCollectionsAreConverted() {
+        final DemoClasspathConfiguration configuration = this.applicationContext().get(DemoClasspathConfiguration.class);
+
+        Assertions.assertNotNull(configuration);
+        Assertions.assertNotNull(configuration.copyOnWriteArrayList());
+        Assertions.assertEquals(3, configuration.copyOnWriteArrayList().size());
+        Assertions.assertTrue(configuration.copyOnWriteArrayList() instanceof CopyOnWriteArrayList);
     }
 
     @Test

--- a/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/DemoClasspathConfiguration.java
+++ b/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/DemoClasspathConfiguration.java
@@ -20,13 +20,27 @@ package org.dockbox.hartshorn.config;
 import org.dockbox.hartshorn.config.annotations.Configuration;
 import org.dockbox.hartshorn.config.annotations.Value;
 
+import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import lombok.Getter;
 
+@Getter
 @Configuration(source = "classpath:junit")
 public class DemoClasspathConfiguration {
 
     @Value("junit.cp")
-    @Getter
     private String classPathValue;
 
+    @Value("junit.unset")
+    private String classPathValueWithDefault = "myDefaultValue";
+
+    @Value("junit.number")
+    private int number;
+
+    @Value("junit.list")
+    private Collection<Integer> list;
+
+    @Value("junit.list")
+    private CopyOnWriteArrayList<Integer> copyOnWriteArrayList;
 }

--- a/hartshorn-config/src/test/resources/junit.yml
+++ b/hartshorn-config/src/test/resources/junit.yml
@@ -1,2 +1,7 @@
 junit:
   cp: "This is a value"
+  number: 1
+  list:
+    - 1
+    - 5
+    - 3

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationPropertyHolder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationPropertyHolder.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.core.context;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
 
@@ -39,8 +40,13 @@ public interface ApplicationPropertyHolder {
      * period symbol. For example, in the configuration (JSON) below the deepest value is accessed with
      * <code>config.nested.value</code>, returning the value 'A'
      * <pre><code>
-     *     { "config": {     "nested": {         "value": "A"     } }
+     * {
+     *   "config": {
+     *     "nested": {
+     *       "value": "A"
      *     }
+     *   }
+     * }
      * </code></pre>
      *
      * <p>Configuration values can also represent system/environment variables.
@@ -50,6 +56,23 @@ public interface ApplicationPropertyHolder {
      * @return The value if it exists, or {@link Exceptional#empty()}
      */
     <T> Exceptional<T> property(String key);
+
+    /**
+     * Attempts to obtain a collection of configuration values from the given key. For example, in the configuration
+     * (JSON) below the values are accessed with <code>config.values</code>, returning the values 'A', 'B', and 'C'
+     * <pre><code>
+     * {
+     *   "config": {
+     *     "values": [ "A", "B", "C" ]
+     *   }
+     * }
+     * </code></pre>
+     *
+     * @param key The key used to look up the values
+     * @param <T> The expected type of the values
+     * @return The values if they exist, or {@link Exceptional#empty()}
+     */
+    <T> Exceptional<Collection<T>> properties(String key);
 
     /**
      * Attempts to store a single configuration value from the given key. If there is already a value associated with

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -444,6 +444,21 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         return this.constructors;
     }
 
+    public Exceptional<ConstructorContext<T>> constructor(final Class<?>... parameterTypes) {
+        return this.constructor(Arrays.asList(parameterTypes));
+    }
+
+    public Exceptional<ConstructorContext<T>> constructor(final List<Class<?>> parameterTypes) {
+        return Exceptional.of(this.constructors().stream()
+                .filter(constructor -> {
+                    final List<? extends Class<?>> parameters = constructor.parameterTypes().stream()
+                            .map(TypeContext::type)
+                            .collect(Collectors.toList());
+                    return parameters.equals(parameterTypes);
+                })
+                .findFirst());
+    }
+
     public List<ConstructorContext<T>> constructors(final Class<? extends Annotation> annotation) {
         return this.constructors().stream()
                 .filter(constructor -> constructor.annotation(annotation).present())

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -45,11 +45,11 @@ public class HttpWebServerInitializer implements LifecycleObserver {
 
     public static final int DEFAULT_PORT = 8080;
 
-    @Value(value = "hartshorn.web.port", or = "" + DEFAULT_PORT)
-    private int port;
+    @Value(value = "hartshorn.web.port")
+    private int port = DEFAULT_PORT;
 
-    @Value(value = "hartshorn.web.servlet.directory", or = "true")
-    private boolean useDirectoryServlet;
+    @Value(value = "hartshorn.web.servlet.directory")
+    private boolean useDirectoryServlet = true;
 
     @Inject
     private WebServletFactory webServletFactory;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -57,8 +57,8 @@ public class ServletHandler implements Enableable {
     @Getter
     private ObjectMapper mapper;
 
-    @Value(value = "hartshorn.web.headers.hartshorn", or = "true")
-    private boolean addHeader;
+    @Value(value = "hartshorn.web.headers.hartshorn")
+    private boolean addHeader = true;
 
     @Bound
     public ServletHandler(final HttpWebServer starter, final HttpMethod httpMethod, final MethodContext<?, ?> methodContext) {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
@@ -55,8 +55,8 @@ public class JettyErrorHandler extends ErrorHandler {
     @Inject
     private ErrorServlet errorServlet;
 
-    @Value(value = "hartshorn.web.headers.hartshorn", or = "true")
-    private boolean addHeader;
+    @Value(value = "hartshorn.web.headers.hartshorn")
+    private boolean addHeader = true;
 
     @Override
     protected void generateAcceptableResponse(final Request baseRequest, final HttpServletRequest request, final HttpServletResponse response, final int code, String message, final String contentType)


### PR DESCRIPTION
Fixes #605
- [x] Breaking change (when depending on `@Value#or`)

# Motivation and changes
Originally, #605 reported only that inline values were ignored due to `Value#or` taking priority even when its value is empty. 
> If a field annotated with `@Value` is defined as seen below, without the `sample.key` property being set, the value will always fall back to an empty or default value (in this case an empty `String`).
> ```java
> @Value("sample.key")
> private String key = "myDefaultValue";
> ```
> Expected behavior would be to fall back to `"myDefaultValue"`, as it is set inline, and should only be changed if the property is set or an alternative value is defined in the `@Value` annotation.  

@pumbas600 suggested deprecating `Value#or`, which has been done in this PR. Existing internal usages were updated accordingly.

During development for this, I noticed collections are not correctly restored since the internal format was changed to be stored using keys such as: `list[0]`. This has also been resolved internally in the `HartshornApplicationContext`.  

Additionally, support has been added to transform to any collection. This works by looking up the constructor of the target collection type which accepts an existing collection. e.g. `ArrayList(Collection c)`.

## Type of change
- [x] Bug fix
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
