### PR TITLE
#607 Resolve direct use of Jackson data formats

### DIFF
--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonDataMapper.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+
+import org.dockbox.hartshorn.data.FileFormat;
+
+public interface JacksonDataMapper {
+    FileFormat fileFormat();
+    MapperBuilder<?, ?> get();
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JavaPropsDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JavaPropsDataMapper.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.data.FileFormat;
+import org.dockbox.hartshorn.data.FileFormats;
+
+import javax.inject.Named;
+
+@Binds(value = JacksonDataMapper.class, named = @Named("properties"))
+public class JavaPropsDataMapper implements JacksonDataMapper {
+    @Override
+    public FileFormat fileFormat() {
+        return FileFormats.PROPERTIES;
+    }
+
+    @Override
+    public MapperBuilder<?, ?> get() {
+        return JavaPropsMapper.builder();
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JsonDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JsonDataMapper.java
@@ -1,0 +1,24 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.data.FileFormat;
+import org.dockbox.hartshorn.data.FileFormats;
+
+import javax.inject.Named;
+
+@Binds(value = JacksonDataMapper.class, named = @Named("json"))
+public class JsonDataMapper implements JacksonDataMapper{
+
+    @Override
+    public FileFormat fileFormat() {
+        return FileFormats.JSON;
+    }
+
+    @Override
+    public MapperBuilder<?, ?> get() {
+        return JsonMapper.builder();
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/TomlDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/TomlDataMapper.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.dataformat.toml.TomlMapper;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.data.FileFormat;
+import org.dockbox.hartshorn.data.FileFormats;
+
+import javax.inject.Named;
+
+@Binds(value = JacksonDataMapper.class, named = @Named("toml"))
+public class TomlDataMapper implements JacksonDataMapper {
+    @Override
+    public FileFormat fileFormat() {
+        return FileFormats.TOML;
+    }
+
+    @Override
+    public MapperBuilder<?, ?> get() {
+        return TomlMapper.builder();
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/XmlDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/XmlDataMapper.java
@@ -1,0 +1,23 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.data.FileFormat;
+import org.dockbox.hartshorn.data.FileFormats;
+
+import javax.inject.Named;
+
+@Binds(value = JacksonDataMapper.class, named = @Named("xml"))
+public class XmlDataMapper implements JacksonDataMapper {
+    @Override
+    public FileFormat fileFormat() {
+        return FileFormats.XML;
+    }
+
+    @Override
+    public MapperBuilder<?, ?> get() {
+        return XmlMapper.builder();
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/YamlDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/YamlDataMapper.java
@@ -1,0 +1,30 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.data.FileFormat;
+import org.dockbox.hartshorn.data.FileFormats;
+
+import javax.inject.Named;
+
+@Binds(value = JacksonDataMapper.class, named = @Named("yml"))
+public class YamlDataMapper implements JacksonDataMapper {
+    @Override
+    public FileFormat fileFormat() {
+        return FileFormats.YAML;
+    }
+
+    @Override
+    public MapperBuilder<?, ?> get() {
+        final YAMLFactory yamlFactory = new YAMLFactory();
+        yamlFactory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
+        yamlFactory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+        yamlFactory.disable(YAMLParser.Feature.EMPTY_STRING_AS_NULL);
+        return YAMLMapper.builder(yamlFactory);
+    }
+}


### PR DESCRIPTION
Fixes #607

# Motivation
The internal `Mappers` enum inside `JacksonObjectMapper` uses direct imports to look up different `ObjectMapper` (Jackson) implementations. While this is fine when all dataformats are present on the classpath, this will yield a `NoClassDefFoundError`, causing the entire `JacksonObjectMapper` to be unusable.

# Changes
Replaces the internal enum `Mappers` in `JacksonObjectMapper` with dedicated `JacksonDataMapper` implementations. These implementations are accessed through internal DI, allowing them to be overridden, as well as capturing classpath errors if the Jackson dataformat for the mapper is absent.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
