### PR TITLE
#609 Resolve duplicate binding of overly specific packages when broader package is bound

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationConfigurator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationConfigurator.java
@@ -41,9 +41,6 @@ public class HartshornApplicationConfigurator implements ApplicationConfigurator
 
     @Override
     public void bind(final ApplicationManager manager, final String prefix) {
-        for (final String scannedPrefix : manager.applicationContext().environment().prefixContext().prefixes()) {
-            if (prefix.startsWith(scannedPrefix) && !prefix.equals(scannedPrefix)) return;
-        }
         manager.applicationContext().bind(prefix);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
@@ -48,7 +48,6 @@ public class ComponentLocatorImpl implements ComponentLocator {
         this.applicationContext().log().debug("Registering prefix '" + prefix + "' for component locating");
 
         final long start = System.currentTimeMillis();
-        this.applicationContext().environment().prefix(prefix);
 
         final List<ComponentContainer> containers = this.applicationContext().environment()
                 .types(prefix, Component.class, false)

--- a/hartshorn-core/src/test/java/com/specific/sub/Demo.java
+++ b/hartshorn-core/src/test/java/com/specific/sub/Demo.java
@@ -1,0 +1,14 @@
+package com.specific.sub;
+
+import org.dockbox.hartshorn.core.annotations.service.ServiceActivator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@ServiceActivator(scanPackages = "com.specific")
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Demo {
+}

--- a/hartshorn-core/src/test/java/com/specific/sub/DemoService.java
+++ b/hartshorn-core/src/test/java/com/specific/sub/DemoService.java
@@ -1,0 +1,8 @@
+package com.specific.sub;
+
+import org.dockbox.hartshorn.core.annotations.service.Service;
+
+// Use service to also ensure prefixes are configured to build annotation hierarchy early on
+@Service
+public class DemoService {
+}

--- a/hartshorn-core/src/test/java/com/specific/sub/DemoServicePreProcessor.java
+++ b/hartshorn-core/src/test/java/com/specific/sub/DemoServicePreProcessor.java
@@ -1,0 +1,34 @@
+package com.specific.sub;
+
+import org.dockbox.hartshorn.core.annotations.service.AutomaticActivation;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.services.ServicePreProcessor;
+
+import javax.inject.Singleton;
+
+import lombok.Getter;
+
+@AutomaticActivation
+@Singleton
+public class DemoServicePreProcessor implements ServicePreProcessor<Demo> {
+
+    @Getter
+    private int processed = 0;
+
+    @Override
+    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
+        return type.is(DemoService.class);
+    }
+
+    @Override
+    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+        context.log().debug("Processing %s".formatted(type.qualifiedName()));
+        this.processed++;
+    }
+
+    @Override
+    public Class<Demo> activator() {
+        return Demo.class;
+    }
+}

--- a/hartshorn-core/src/test/java/com/specific/sub/SpecificPackageTests.java
+++ b/hartshorn-core/src/test/java/com/specific/sub/SpecificPackageTests.java
@@ -1,0 +1,25 @@
+package com.specific.sub;
+
+import org.dockbox.hartshorn.core.annotations.activate.Activator;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * This test is associated with <a href="https://github.com/GuusLieben/Hartshorn/issues/609">#609</a>. It tests that
+ * overly specific packages like {@code com.specific.sub} are not processed twice if a broader package like
+ * {@code com.specific} is bound to the same application context.
+ */
+@Demo
+@HartshornTest
+@Activator(scanPackages = "com.specific")
+public class SpecificPackageTests {
+
+    @InjectTest
+    public void someTest(final ApplicationContext applicationContext) {
+        Assertions.assertNotNull(applicationContext);
+        final DemoServicePreProcessor processor = applicationContext.get(DemoServicePreProcessor.class);
+        Assertions.assertEquals(1, processor.processed());
+    }
+}


### PR DESCRIPTION
Fixes #609

# Motivation
When a package prefix specifying a specific package like `com.example.specific` is bound to the active `ApplicationContext`, followed by a less specific package prefix being registered, like `com.example`, all components in `com.example.specific` will be processed twice.

# Changes
All prefix bindings will now be queued so they can be filtered for broader packages before being processed. As this could impact annotation hierarchies, the prefix will be registered to the prefix context immediately when it is queued. 

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
