### PR TITLE
#611 Filter synthetic bridge methods when looking up methods in `TypeContext`s

### DIFF
--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core;
 
+import org.dockbox.hartshorn.core.bridge.BridgeImpl;
 import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
 import org.dockbox.hartshorn.core.context.ReflectionsPrefixContext;
 import org.dockbox.hartshorn.core.context.element.AnnotatedElementModifier;
@@ -224,6 +225,24 @@ public class ReflectTests {
             if ("parentMethod".equals(method.name())) fail = false;
         }
         if (fail) Assertions.fail("Parent types were not included");
+    }
+
+    @Test
+    void testTypeContextMethodsDoNotIncludeBridgeMethods() {
+        final TypeContext<BridgeImpl> bridge = TypeContext.of(BridgeImpl.class);
+        final List<MethodContext<?, BridgeImpl>> methods = bridge.methods();
+        for (final MethodContext<?, BridgeImpl> method : methods) {
+            Assertions.assertFalse(method.method().isBridge());
+        }
+    }
+
+    @Test
+    void testTypeContextBridgeMethodsCanBeObtained() {
+        final TypeContext<BridgeImpl> bridge = TypeContext.of(BridgeImpl.class);
+        final List<MethodContext<?, BridgeImpl>> methods = bridge.bridgeMethods();
+        Assertions.assertEquals(1, methods.size());
+        Assertions.assertEquals(Object.class, methods.get(0).returnType().type());
+        Assertions.assertTrue(methods.get(0).method().isBridge());
     }
 
     @Test

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/bridge/Bob.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/bridge/Bob.java
@@ -1,0 +1,9 @@
+package org.dockbox.hartshorn.core.bridge;
+
+import org.dockbox.hartshorn.core.annotations.inject.Bound;
+
+public class Bob {
+    @Bound
+    public Bob() {
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/bridge/BridgeImpl.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/bridge/BridgeImpl.java
@@ -1,0 +1,9 @@
+package org.dockbox.hartshorn.core.bridge;
+
+import org.dockbox.hartshorn.core.annotations.service.Service;
+
+@Service
+public interface BridgeImpl extends BridgeParent<Bob>{
+    @Override
+    Bob bridgeMethod();
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/bridge/BridgeParent.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/bridge/BridgeParent.java
@@ -1,0 +1,8 @@
+package org.dockbox.hartshorn.core.bridge;
+
+import org.dockbox.hartshorn.core.annotations.Factory;
+
+public interface BridgeParent<R> {
+    @Factory
+    R bridgeMethod();
+}


### PR DESCRIPTION
Fixes #611

# Motivation
`TypeContext#methods(Class<? extends Annotation>)` also includes synthetic bridge elements. While this makes sense to keep in `#methods()`, annotated elements should never include duplicates and bridge methods.  

This was first noticed by @pumbas600. When a `@Factory` processor attempts to process methods from inherited services, the bridge method is also present. This was caused by the simply hierarchy defined below:
```java
public interface DecoratorFactory<R, T, A extends Annotation> {
    R decorate(T element, A annotation);
}
```
```java
@Service
public interface CooldownDecoratorFactory extends DecoratorFactory<CooldownDecorator, CommandContext, Cooldown> {
    @Factory
    @Override
    CooldownDecorator decorate(CommandContext element, Cooldown annotation);
}
```
Here `#decorate` is provided as two unique methods:
- **Synthetic bridge**: `public default java.lang.Object com.example.application.CooldownDecoratorFactory.decorate(java.lang.Object,java.lang.annotation.Annotation)`
- **Target**: `public abstract com.example.application.CooldownDecorator com.example.application.CooldownDecoratorFactory.decorate(com.example.application.CommandContext,com.example.application.Cooldown)`

This FAQ describes the function of bridge methods quite well: http://www.angelikalanger.com/GenericsFAQ/FAQSections/TechnicalDetails.html#FAQ102
Also see:
- http://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html
- https://stackoverflow.com/a/5007394

# Changes
As I mentioned in #611 the easiest solution was to filter bridge methods from `#methods`, and add a secondary `#bridgeMethods` which allows developers to access them still if ever required.

## Type of change
- [x] Bug fix

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
