### PR TITLE
#617 Add component-level proxy permission and global validated proxy processor

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
@@ -128,4 +128,13 @@ public @interface Component {
      */
     @Deprecated(since = "4.2.5", forRemoval = true)
     boolean enabled() default true;
+
+    /**
+     * Indicates whether the component should be allowed to be proxied. Proxied components may be modified by changing
+     * the behavior of the proxy.
+     *
+     * @return {@code true} if the component should be proxied
+     * @see ComponentContainer#permitsProxying()
+     */
+    boolean permitProxying() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Service.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Service.java
@@ -89,4 +89,10 @@ public @interface Service {
      * @see org.dockbox.hartshorn.core.services.ComponentLocator
      */
     Class<? extends Annotation>[] activators() default Service.class;
+
+    /**
+     * @see Component#permitProxying()
+     * @return Whether the service is permitted to be proxied.
+     */
+    boolean permitProxying() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProxier.java
@@ -35,4 +35,6 @@ public interface ApplicationProxier extends ProxyLookup {
     <T, P extends T> Exceptional<T> delegator(final TypeContext<T> type, ProxyHandler<P> handler);
 
     <T> ProxyHandler<T> handler(final TypeContext<T> type, final T instance);
+
+    <T> Exceptional<ProxyHandler<T>> handler(T instance);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
@@ -127,6 +127,11 @@ public class HartshornApplicationManager implements ApplicationManager {
         return this.applicationProxier.handler(type, instance);
     }
 
+    @Override
+    public <T> Exceptional<ProxyHandler<T>> handler(final T instance) {
+        return this.applicationProxier.handler(instance);
+    }
+
     public void applicationContext(final ApplicationContext applicationContext) {
         if (this.applicationContext == null) this.applicationContext = applicationContext;
         else throw new IllegalArgumentException("Application context has already been configured");

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -634,4 +634,8 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     public boolean isFinal() {
         return Modifier.isFinal(this.type().getModifiers());
     }
+
+    public boolean isDeclaredIn(final String prefix) {
+        return this.type().getPackageName().startsWith(prefix);
+    }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistInterfaceHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistInterfaceHandler.java
@@ -119,6 +119,11 @@ public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHan
         return this.handler().proxyInstance();
     }
 
+    @Override
+    public Exceptional<T> instance() {
+        return this.handler().instance();
+    }
+
     public Object invoke(final Object self, final Method thisMethod, final Method proceed, final Object[] args) throws Throwable {
         return this.handler().invoke(self, thisMethod, proceed, args);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/MethodInvoker.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/MethodInvoker.java
@@ -1,0 +1,9 @@
+package org.dockbox.hartshorn.core.proxy.javassist;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@FunctionalInterface
+public interface MethodInvoker {
+    Object invoke(Method method) throws InvocationTargetException, IllegalAccessException;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
@@ -82,4 +82,6 @@ public interface ComponentContainer {
         final String[] parts = HartshornUtils.splitCapitals(raw);
         return HartshornUtils.capitalize(String.join(" ", parts));
     }
+
+    boolean permitsProxying();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
@@ -114,6 +114,11 @@ public class ComponentContainerImpl implements ComponentContainer {
     }
 
     @Override
+    public boolean permitsProxying() {
+        return this.annotation.permitProxying();
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProxyPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProxyPostProcessor.java
@@ -1,0 +1,41 @@
+package org.dockbox.hartshorn.core.services;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.boot.ExceptionHandler;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.proxy.ProxyHandler;
+
+@AutomaticActivation
+public class ComponentProxyPostProcessor implements ComponentPostProcessor<Service> {
+
+    @Override
+    public Class<Service> activator() {
+        return Service.class;
+    }
+
+    @Override
+    public <T> T process(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
+        try {
+            final ProxyHandler<T> handler = context.environment().manager().handler(type, instance);
+            return handler.proxy(context, instance);
+        } catch (final ApplicationException e) {
+            return ExceptionHandler.unchecked(e);
+        }
+    }
+
+    @Override
+    public <T> boolean modifies(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
+        final Exceptional<ComponentContainer> container = context.locator().container(type);
+        return container.present() && container.get().permitsProxying();
+    }
+
+    @Override
+    public ProcessingOrder order() {
+        return ProcessingOrder.FIRST;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FunctionalComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FunctionalComponentPostProcessor.java
@@ -24,7 +24,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.annotation.Annotation;
 
-public abstract class ServicePostProcessor<A extends Annotation> implements ComponentPostProcessor<A> {
+public abstract class FunctionalComponentPostProcessor<A extends Annotation> implements ComponentPostProcessor<A> {
 
     @Override
     public <T> boolean preconditions(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceImpl.java
@@ -53,6 +53,11 @@ public class ServiceImpl implements Service {
     }
 
     @Override
+    public boolean permitProxying() {
+        return true;
+    }
+
+    @Override
     public Class<? extends Annotation> annotationType() {
         return Service.class;
     }

--- a/hartshorn-core/src/test/java/com/example/application/ActivatorScanningTests.java
+++ b/hartshorn-core/src/test/java/com/example/application/ActivatorScanningTests.java
@@ -48,13 +48,4 @@ public class ActivatorScanningTests {
         Assertions.assertNotNull(demoService);
         Assertions.assertTrue(applicationContext.environment().manager().isProxy(demoService));
     }
-
-    @InjectTest
-    void testProcessorsFromActivatorPrefixIsPresentAndInjectedWithLocalValues(final ApplicationContext applicationContext) {
-        final DemoProcessor demoProcessor = applicationContext.get(DemoProcessor.class);
-        Assertions.assertNotNull(demoProcessor);
-        Assertions.assertTrue(demoProcessor.demo() instanceof DemoImpl);
-        Assertions.assertNotNull(demoProcessor.demoService());
-        Assertions.assertTrue(applicationContext.environment().manager().isProxy(demoProcessor.demoService()));
-    }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -31,6 +31,7 @@ import org.dockbox.hartshorn.core.types.CircularDependencyB;
 import org.dockbox.hartshorn.core.types.ComponentType;
 import org.dockbox.hartshorn.core.types.ContextInjectedType;
 import org.dockbox.hartshorn.core.types.NonComponentType;
+import org.dockbox.hartshorn.core.types.NonProxyComponentType;
 import org.dockbox.hartshorn.core.types.Person;
 import org.dockbox.hartshorn.core.types.SampleContext;
 import org.dockbox.hartshorn.core.types.TypeWithEnabledInjectField;
@@ -354,10 +355,16 @@ public class ApplicationContextTests {
     }
 
     @Test
-    void testComponentsAreProxiedWhenRegularProvisionFails() {
+    void testPermittedComponentsAreProxiedWhenRegularProvisionFails() {
         final ComponentType instance = this.applicationContext().get(ComponentType.class);
         Assertions.assertNotNull(instance);
         Assertions.assertTrue(this.applicationContext().environment().manager().isProxy(instance));
+    }
+
+    @Test
+    void testNonPermittedComponentsAreNotProxied() {
+        final NonProxyComponentType instance = this.applicationContext().get(NonProxyComponentType.class);
+        Assertions.assertNull(instance);
     }
 
     @Test

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
@@ -48,6 +48,7 @@ public class ComponentProvisionTests {
                 .locator()
                 .containers().stream()
                 .map(ComponentContainer::type)
+                .filter(type -> !type.isDeclaredIn("org.dockbox.hartshorn.core.types"))
                 .map(Arguments::of);
     }
 

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProxyComponentType.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProxyComponentType.java
@@ -15,25 +15,10 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.core.proxy;
+package org.dockbox.hartshorn.core.types;
 
-import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.Context;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 
-public interface ProxyHandler<T> extends Context {
-
-    Exceptional<T> proxyInstance();
-
-    Exceptional<T> instance();
-
-    TypeContext<T> type();
-
-    void delegate(final MethodProxyContext<T, ?> property);
-
-    T proxy(ApplicationContext context) throws ApplicationException;
-
-    T proxy(ApplicationContext context, T existing) throws ApplicationException;
+@Component(permitProxying = false)
+public interface NonProxyComponentType {
 }


### PR DESCRIPTION
Fixes #617

# Motivation
Currently proxies are only properly created through `ServiceMethodPostProcessor`s. This limits the presence of proxies to the presence of appropriate activators.

# Changes
- Moves initialization of proxy components to `ComponentProxyPostProcessor`, where the component will first be validated
- Adds `permitProxying` to `Component` and `Service` stereotypes (both default to `true`)
- Adds `permitsProxying` to `ComponentContainer`
- Exposes delegated instance in `ProxyHandler`s
- Will no longer copy `static` fields in `ProxyHandler` proxy initializers
- Will now ensure methods are accessible when invoked dynamically in `ProxyHandler`s (due to `protected` methods)

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
