### PR TITLE
#619 Add support for setter/method injection

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Context.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Context.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * @since 4.2.3
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 public @interface Context {
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Enable.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Enable.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  * @since 4.1.2
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.METHOD})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 public @interface Enable {
     boolean value() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Populate.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Populate.java
@@ -1,0 +1,13 @@
+package org.dockbox.hartshorn.core.annotations.inject;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Populate {
+    boolean fields() default true;
+    boolean executables() default true;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Required.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Required.java
@@ -23,16 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Indicates a type will always require a binding to be present.
- *
- * @deprecated If validation is required, a {@link org.dockbox.hartshorn.core.services.ComponentProcessor},
- * or {@link org.dockbox.hartshorn.core.boot.LifecycleObserver} should be used instead.
+ * Indicates that a field or parameter is required. If the output of a binding is {@code null} during population phases, this will
+ * yield an exception.
  *
  * @author Guus Lieben
- * @since Unknown
+ * @since 4.2.5
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-@Deprecated(since = "4.2.5", forRemoval = true)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 public @interface Required {
+    boolean value() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
@@ -78,6 +78,10 @@ public interface ApplicationContext extends
         return this.environment().manager().log();
     }
 
+    default <C extends Context> Exceptional<C> first(final TypeContext<C> context) {
+        return this.first(context.type());
+    }
+
     default <C extends Context> Exceptional<C> first(final Class<C> context) {
         return this.first(this, context);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ComponentProvider.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core.context;
 
+import org.dockbox.hartshorn.core.Enableable;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
@@ -26,7 +27,7 @@ import javax.inject.Named;
  * A component provider is a class that is capable of providing components. Components are identified using
  * {@link Key keys}. Components can be either managed or unmanaged. Managed components are typically bound to an active
  * {@link ApplicationContext} and are therefore available to all components in the application. Unmanaged components are
- * typically not explicitely registered, and are treated as injectable beans.
+ * typically not explicitly registered, and are treated as injectable beans.
  */
 public interface ComponentProvider extends Context {
 
@@ -61,6 +62,16 @@ public interface ComponentProvider extends Context {
      * @return The component for the given key.
      */
     <T> T get(Key<T> key);
+
+    /**
+     * Returns the component for the given key. Unlike {@link #get(Key)}, this method will not run {@link Enableable#enable()}
+     * on the component if {@code enable} is false.
+     * @param key The key of the component to return.
+     * @param enable Whether to enable the component if it is an implementation of {@link Enableable}.
+     * @param <T> The type of the component to return.
+     * @return The component for the given key.
+     */
+    <T> T get(Key<T> key, boolean enable);
 
     /**
      * Returns the component for the given type.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/Context.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/Context.java
@@ -17,6 +17,8 @@
 
 package org.dockbox.hartshorn.core.context;
 
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.List;
@@ -65,6 +67,31 @@ public interface Context {
     <C extends Context> Exceptional<C> first(ApplicationContext applicationContext, Class<C> context);
 
     /**
+     * Returns the first context of the given type and name. If it doesn't exist, but the context is annotated with
+     * {@link org.dockbox.hartshorn.core.annotations.context.AutoCreating}, it will be created using the provided
+     * {@link ApplicationContext}.
+     *
+     * @param applicationContext The application context to use when creating the context.
+     * @param context The type of the context.
+     * @param name The name of the context.
+     * @param <C> The type of the context.
+     * @return The first context of the given type and name.
+     */
+    <C extends Context> Exceptional<C> first(ApplicationContext applicationContext, Class<C> context, String name);
+
+    /**
+     * Returns the first context of the given type and name, which are represented by the given key. If it doesn't exist,
+     * but the context is annotated with {@link org.dockbox.hartshorn.core.annotations.context.AutoCreating}, it will be
+     * created using the provided {@link ApplicationContext}.
+     *
+     * @param applicationContext The application context to use when creating the context.
+     * @param context The key of the context.
+     * @param <C> The type of the context.
+     * @return The first context of the given type and name.
+     */
+    <C extends Context> Exceptional<C> first(ApplicationContext applicationContext, Key<C> context);
+
+    /**
      * Returns the first context of the given name.
      *
      * @param name The name of the context.
@@ -81,6 +108,10 @@ public interface Context {
      * @return The first named context of the given named and type, if it exists.
      */
     <N extends Context> Exceptional<N> first(String name, Class<N> context);
+
+    default <N extends Context> Exceptional<N> first(final String name, final TypeContext<N> context) {
+        return this.first(name, context.type());
+    }
 
     /**
      * Returns all contexts of the given type. If no contexts of the given type exist, an empty {@link List} will be

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/DelegatingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/DelegatingContext.java
@@ -17,12 +17,12 @@
 
 package org.dockbox.hartshorn.core.context;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.List;
 
 @FunctionalInterface
-@Deprecated(since = "4.2.5", forRemoval = true)
 public interface DelegatingContext<D extends Context> extends Context {
 
     @Override
@@ -44,6 +44,16 @@ public interface DelegatingContext<D extends Context> extends Context {
 
     @Override
     default <C extends Context> Exceptional<C> first(final ApplicationContext applicationContext, final Class<C> context) {
+        return this.get().first(applicationContext, context);
+    }
+
+    @Override
+    default <C extends Context> Exceptional<C> first(final ApplicationContext applicationContext, final Class<C> context, final String name) {
+        return this.get().first(applicationContext, context, name);
+    }
+
+    @Override
+    default <C extends Context> Exceptional<C> first(final ApplicationContext applicationContext, final Key<C> context) {
         return this.get().first(applicationContext, context);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ParameterLoaderContext.java
@@ -17,7 +17,7 @@
 
 package org.dockbox.hartshorn.core.context;
 
-import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.ExecutableElementContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 import lombok.AllArgsConstructor;
@@ -26,7 +26,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ParameterLoaderContext extends DefaultContext implements ContextCarrier {
-    private final MethodContext<?, ?> method;
+    private final ExecutableElementContext<?> executable;
     private final TypeContext<?> type;
     private final Object instance;
     private final ApplicationContext applicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
@@ -23,6 +23,7 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -33,7 +34,7 @@ public abstract class AnnotatedElementContext<A extends AnnotatedElement> extend
     private Map<Class<?>, Annotation> annotationCache;
 
     public Set<Annotation> annotations() {
-        return Set.copyOf(this.validate().values());
+        return new HashSet<>(this.validate().values());
     }
 
     public <T extends Annotation> Exceptional<T> annotation(final TypeContext<T> annotation) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
@@ -70,6 +70,11 @@ public class MethodContext<T, P> extends ExecutableElementContext<Method> {
         }
         return this.invoker.invoke(this, instance, arguments);
     }
+
+    public Exceptional<T> invoke(final ApplicationContext context, final P instance) {
+        final Object[] args = this.arguments(context);
+        return this.invoke(instance, args);
+    }
     
     public Exceptional<T> invoke(final ApplicationContext context, final Collection<Object> arguments) {
         return this.invoke(context.get(this.parent()), arguments);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistInterfaceHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistInterfaceHandler.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.core.proxy.javassist;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.Context;
-import org.dockbox.hartshorn.core.context.NamedContext;
+import org.dockbox.hartshorn.core.context.DelegatingContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
@@ -29,11 +29,10 @@ import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.List;
 
 import lombok.Getter;
 
-public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHandler<T> {
+public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHandler<T>, DelegatingContext {
 
     @Getter private final JavassistProxyHandler<T> handler;
 
@@ -60,48 +59,8 @@ public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHan
     }
 
     @Override
-    public <C extends Context> void add(final C context) {
-        this.handler().add(context);
-    }
-
-    @Override
-    public <N extends NamedContext> void add(final N context) {
-        this.handler().add(context);
-    }
-
-    @Override
-    public <C extends Context> void add(final String name, final C context) {
-        this.handler().add(name, context);
-    }
-
-    @Override
-    public <C extends Context> Exceptional<C> first(final ApplicationContext applicationContext, final Class<C> context) {
-        return this.handler().first(applicationContext, context);
-    }
-
-    @Override
-    public Exceptional<Context> first(final String name) {
-        return this.handler().first(name);
-    }
-
-    @Override
-    public <N extends Context> Exceptional<N> first(final String name, final Class<N> context) {
-        return this.handler().first(name, context);
-    }
-
-    @Override
-    public <C extends Context> List<C> all(final Class<C> context) {
-        return this.handler().all(context);
-    }
-
-    @Override
-    public List<Context> all(final String name) {
-        return this.handler().all(name);
-    }
-
-    @Override
-    public <N extends Context> List<N> all(final String name, final Class<N> context) {
-        return this.handler().all(name, context);
+    public Context get() {
+        return this.handler();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ContextParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ContextParameterLoaderRule.java
@@ -1,0 +1,37 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.annotations.inject.Context;
+import org.dockbox.hartshorn.core.annotations.inject.Required;
+import org.dockbox.hartshorn.core.boot.ExceptionHandler;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+
+import javax.inject.Named;
+
+public class ContextParameterLoaderRule implements ParameterLoaderRule<ParameterLoaderContext> {
+
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        return parameter.annotation(Context.class).present() && parameter.type().childOf(org.dockbox.hartshorn.core.context.Context.class);
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        final TypeContext<org.dockbox.hartshorn.core.context.Context> type = (TypeContext<org.dockbox.hartshorn.core.context.Context>) parameter.type();
+        final ApplicationContext applicationContext = context.applicationContext();
+        final String name = parameter.annotation(Named.class).map(Named::value).orNull();
+
+        final Exceptional<org.dockbox.hartshorn.core.context.Context> out = name == null
+                ? applicationContext.first(type)
+                : applicationContext.first(applicationContext, type.type(), name);
+
+        final boolean required = parameter.annotation(Required.class).map(Required::value).or(false);
+        if (required && out.absent()) return ExceptionHandler.unchecked(new ApplicationException("Parameter " + parameter.name() + " on " + parameter.declaredBy().qualifiedName() + " is required"));
+
+        return out.map(c -> (T) c);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ContextParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ContextParameterLoaderRule.java
@@ -10,8 +10,6 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
-import javax.inject.Named;
-
 public class ContextParameterLoaderRule implements ParameterLoaderRule<ParameterLoaderContext> {
 
     @Override
@@ -23,7 +21,7 @@ public class ContextParameterLoaderRule implements ParameterLoaderRule<Parameter
     public <T> Exceptional<T> load(final ParameterContext<T> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
         final TypeContext<org.dockbox.hartshorn.core.context.Context> type = (TypeContext<org.dockbox.hartshorn.core.context.Context>) parameter.type();
         final ApplicationContext applicationContext = context.applicationContext();
-        final String name = parameter.annotation(Named.class).map(Named::value).orNull();
+        final String name = parameter.annotation(Context.class).map(Context::value).orNull();
 
         final Exceptional<org.dockbox.hartshorn.core.context.Context> out = name == null
                 ? applicationContext.first(type)

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ExecutableElementContextParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/ExecutableElementContextParameterLoader.java
@@ -1,0 +1,31 @@
+package org.dockbox.hartshorn.core.services.parameter;
+
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.annotations.inject.Enable;
+import org.dockbox.hartshorn.core.annotations.inject.Required;
+import org.dockbox.hartshorn.core.boot.ExceptionHandler;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
+
+import javax.inject.Named;
+
+public class ExecutableElementContextParameterLoader extends RuleBasedParameterLoader<ParameterLoaderContext> {
+
+    public ExecutableElementContextParameterLoader() {
+        this.add(new ContextParameterLoaderRule());
+    }
+
+    @Override
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        final Named named = parameter.annotation(Named.class).orNull();
+        final Key<T> key = Key.of(parameter.type(), named);
+        final boolean enable = parameter.annotation(Enable.class).map(Enable::value).or(true);
+        final T out = context.applicationContext().get(key, enable);
+
+        final boolean required = parameter.annotation(Required.class).map(Required::value).or(false);
+        if (required && out == null) return ExceptionHandler.unchecked(new ApplicationException("Parameter " + parameter.name() + " on " + parameter.declaredBy().qualifiedName() + " is required"));
+
+        return out;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/GlobalProxyParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/GlobalProxyParameterLoader.java
@@ -20,7 +20,7 @@ package org.dockbox.hartshorn.core.services.parameter;
 import org.dockbox.hartshorn.core.annotations.inject.Binds;
 import org.dockbox.hartshorn.core.annotations.inject.Instance;
 import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
-import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.ExecutableElementContext;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,12 +29,13 @@ import java.util.List;
 
 import javax.inject.Named;
 
+@Deprecated(since = "4.2.5", forRemoval = true)
 @Binds(value = ParameterLoader.class, named = @Named("global_proxy"))
 public class GlobalProxyParameterLoader extends ParameterLoader<ParameterLoaderContext> {
 
     @Override
     public List<Object> loadArguments(final ParameterLoaderContext context, final Object... args) {
-        final MethodContext<?, ?> method = context.method();
+        final ExecutableElementContext<?> method = context.executable();
         final Collection<Object> arguments = new ArrayList<>();
         if (method.parameterCount() >= 1 && method.parameters().get(0).annotation(Instance.class).present()) {
             arguments.add(context.instance());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
@@ -44,7 +44,7 @@ public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends 
     @Override
     public List<Object> loadArguments(final C context, final Object... args) {
         final List<Object> arguments = new ArrayList<>();
-        final LinkedList<ParameterContext<?>> parameters = context.method().parameters();
+        final LinkedList<ParameterContext<?>> parameters = context.executable().parameters();
         parameters:
         for (int i = 0; i < parameters.size(); i++) {
             final ParameterContext<?> parameter = parameters.get(i);

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.core.boot.EmptyService;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.HartshornApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.CyclicComponentException;
 import org.dockbox.hartshorn.core.proxy.ExtendedProxy;
 import org.dockbox.hartshorn.core.types.CircularConstructorA;
@@ -35,6 +36,8 @@ import org.dockbox.hartshorn.core.types.NonProxyComponentType;
 import org.dockbox.hartshorn.core.types.Person;
 import org.dockbox.hartshorn.core.types.SampleContext;
 import org.dockbox.hartshorn.core.types.SetterInjectedComponent;
+import org.dockbox.hartshorn.core.types.SetterInjectedComponentWithAbsentBinding;
+import org.dockbox.hartshorn.core.types.SetterInjectedComponentWithNonRequiredAbsentBinding;
 import org.dockbox.hartshorn.core.types.TypeWithEnabledInjectField;
 import org.dockbox.hartshorn.core.types.TypeWithFailingConstructor;
 import org.dockbox.hartshorn.core.types.User;
@@ -396,5 +399,27 @@ public class ApplicationContextTests {
         final SetterInjectedComponent component = this.applicationContext().get(SetterInjectedComponent.class);
         Assertions.assertNotNull(component);
         Assertions.assertNotNull(component.component());
+    }
+
+    @Test
+    void testSetterInjectionWithAbsentRequiredComponent() {
+        Assertions.assertThrows(ApplicationException.class, () -> this.applicationContext().get(SetterInjectedComponentWithAbsentBinding.class));
+    }
+
+    @Test
+    void testSetterInjectionWithAbsentComponent() {
+        final var component = Assertions.assertDoesNotThrow(() -> this.applicationContext().get(SetterInjectedComponentWithNonRequiredAbsentBinding.class));
+        Assertions.assertNotNull(component);
+        Assertions.assertNull(component.person());
+    }
+
+    @Test
+    void testSetterInjectionWithContext() {
+        final SampleContext sampleContext = new SampleContext("setter");
+        this.applicationContext().add("setter", sampleContext);
+        final SetterInjectedComponent component = this.applicationContext().get(SetterInjectedComponent.class);
+        Assertions.assertNotNull(component);
+        Assertions.assertNotNull(component.context());
+        Assertions.assertSame(sampleContext, component.context());
     }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -34,6 +34,7 @@ import org.dockbox.hartshorn.core.types.NonComponentType;
 import org.dockbox.hartshorn.core.types.NonProxyComponentType;
 import org.dockbox.hartshorn.core.types.Person;
 import org.dockbox.hartshorn.core.types.SampleContext;
+import org.dockbox.hartshorn.core.types.SetterInjectedComponent;
 import org.dockbox.hartshorn.core.types.TypeWithEnabledInjectField;
 import org.dockbox.hartshorn.core.types.TypeWithFailingConstructor;
 import org.dockbox.hartshorn.core.types.User;
@@ -388,5 +389,12 @@ public class ApplicationContextTests {
     void testCircularDependenciesYieldExceptionOnConstructorInject() {
         Assertions.assertThrows(CyclicComponentException.class, () -> this.applicationContext().get(CircularConstructorA.class));
         Assertions.assertThrows(CyclicComponentException.class, () -> this.applicationContext().get(CircularConstructorB.class));
+    }
+
+    @Test
+    void testSetterInjectionWithRegularComponent() {
+        final SetterInjectedComponent component = this.applicationContext().get(SetterInjectedComponent.class);
+        Assertions.assertNotNull(component);
+        Assertions.assertNotNull(component.component());
     }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponent.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponent.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.inject.Required;
+
+import javax.inject.Inject;
+
+import lombok.Getter;
+
+public class SetterInjectedComponent {
+
+    @Getter
+    @Inject
+    private ComponentType component;
+
+    @Inject
+    public void setComponent(@Required final ComponentType component) {
+        this.component = component;
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponent.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponent.java
@@ -1,19 +1,25 @@
 package org.dockbox.hartshorn.core.types;
 
+import org.dockbox.hartshorn.core.annotations.inject.Context;
 import org.dockbox.hartshorn.core.annotations.inject.Required;
 
 import javax.inject.Inject;
 
 import lombok.Getter;
 
+@Getter
 public class SetterInjectedComponent {
 
-    @Getter
-    @Inject
     private ComponentType component;
+    private SampleContext context;
 
     @Inject
     public void setComponent(@Required final ComponentType component) {
         this.component = component;
+    }
+
+    @Inject
+    public void setContext(@Context("setter") final SampleContext context) {
+        this.context = context;
     }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithAbsentBinding.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithAbsentBinding.java
@@ -1,0 +1,20 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.inject.Required;
+
+import javax.inject.Inject;
+
+import lombok.Getter;
+
+public class SetterInjectedComponentWithAbsentBinding {
+
+    @Getter
+    @Inject
+    private Person person;
+
+    @Inject
+    // Person is bound, so this will result in a null value
+    public void setPerson(@Required final Person person) {
+        this.person = person;
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithNonRequiredAbsentBinding.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithNonRequiredAbsentBinding.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.core.types;
+
+import javax.inject.Inject;
+
+import lombok.Getter;
+
+public class SetterInjectedComponentWithNonRequiredAbsentBinding {
+
+    @Getter
+    @Inject
+    private Person person;
+
+    @Inject
+    // Person is bound, so this will result in a null value
+    public void setPerson(final Person person) {
+        this.person = person;
+    }
+}

--- a/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
+++ b/hartshorn-core/src/testFixtures/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
@@ -17,6 +17,8 @@
 
 package org.dockbox.hartshorn.testsuite;
 
+import org.dockbox.hartshorn.core.annotations.Extends;
+import org.dockbox.hartshorn.core.annotations.inject.Populate;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -42,6 +44,8 @@ import javax.inject.Inject;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(HartshornExtension.class)
+@Extends(Populate.class)
+@Populate(executables = false)
 public @interface HartshornTest {
     Class<? extends Annotation>[] activators() default {};
 }


### PR DESCRIPTION
Fixes #619

# Motivation
Currently only two primary ways of injection are supported: field- and constructor injection. This means one other primary approach is currently missing: setter injection.

# Changes
- Adds proper support for `@Enable`, `@Required`, `@Context`, and `@Inject` to executable context invokers
- Adds parameter loaders for the above parameter rules
- Adds setter/method injection during population phases
- Adds `@Populate` to allow/disallow field and executable injection during population phases
- Adds appropriate interface methods to `Context`, `ComponentProvider`, and `ApplicationContext` to support the changes mentioned above.

## Type of change
- [x] New core feature

# How Has This Been Tested?
- [x] Unit testing

**Test Configuration**:
* Java version: 16.0.2

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
