### PR TITLE
#621 Do not overwrite redefined annotations in `TypeContext` annotation validation

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -600,7 +600,10 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             Class<?> type = this.type();
             while (type != null) {
                 for (final Annotation annotation : type.getDeclaredAnnotations()) {
-                    annotations.put(annotation.annotationType(), annotation);
+                    // If it's a duplicate, the annotation was redefined in a higher level class. In this case we prefer
+                    // the one in the highest level class, so we ignore the one in the lower level, or parent, class.
+                    if (!annotations.containsKey(annotation.annotationType()))
+                        annotations.put(annotation.annotationType(), annotation);
                 }
                 type = type.getSuperclass();
             }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core;
 
+import org.dockbox.hartshorn.core.annotations.Base;
 import org.dockbox.hartshorn.core.bridge.BridgeImpl;
 import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
 import org.dockbox.hartshorn.core.context.ReflectionsPrefixContext;
@@ -28,6 +29,7 @@ import org.dockbox.hartshorn.core.context.element.MethodModifier;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.TypeConversionException;
+import org.dockbox.hartshorn.core.types.AnnotatedImpl;
 import org.dockbox.hartshorn.core.types.ParentTestType;
 import org.dockbox.hartshorn.core.types.ReflectTestType;
 import org.dockbox.hartshorn.core.types.TestEnumType;
@@ -471,5 +473,13 @@ public class ReflectTests {
 
     public String helloWorld() {
         return "Hello World";
+    }
+
+    @Test
+    void testRedefinedAnnotationsTakePriority() {
+        final TypeContext<AnnotatedImpl> typeContext = TypeContext.of(AnnotatedImpl.class);
+        final Exceptional<Base> annotation = typeContext.annotation(Base.class);
+        Assertions.assertTrue(annotation.present());
+        Assertions.assertEquals("impl", annotation.get().value());
     }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedImpl.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedImpl.java
@@ -1,0 +1,7 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.Base;
+
+@Base("impl")
+public class AnnotatedImpl implements AnnotatedParent {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedParent.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/AnnotatedParent.java
@@ -1,0 +1,7 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.Base;
+
+@Base("parent")
+public interface AnnotatedParent {
+}


### PR DESCRIPTION
# Description
When a type inherits from an annotated type, and wishes to modify the annotation contents of its parent, the type itself will be annotated with the same annotation, but with different values. To put that into code, consider the following example.
```java
public @interface SampleAnnotation {
    boolean value();
}
```
```java
@SampleAnnotation(true)
public interface SampleParent { }
```
```java
@SampleAnnotation(false)
public class SampleImpl implements SampleParent { }
```
In this example, you'd expect `TypeContext.of(SampleImpl.class).annotation(SampleAnnotation.class)` to return `SampleAnnotation(value=false)` as the annotation is redefined on the implementation. However, as the lookup is performed iteratively on each parent, the annotation on `SampleParent` takes precendence at it was added later in time, and is thus able to overwrite the existing value. This causes the returned value to be `SampleAnnotation(value=true)`.

The solution is relatively easy as the redefined annotations will be registered first. This allows us to ignore duplicates, as annotations found later on will be from parent types only.

Fixes #621

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
Please describe how the changes in this pull request have been tested.
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
