### PR TITLE
#627 Resolve factory bindings not respecting correct binding priorities

### DIFF
--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/FactoryProvided.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/FactoryProvided.java
@@ -1,0 +1,4 @@
+package org.dockbox.hartshorn.core.factory;
+
+public interface FactoryProvided {
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/FactoryService.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/FactoryService.java
@@ -1,0 +1,10 @@
+package org.dockbox.hartshorn.core.factory;
+
+import org.dockbox.hartshorn.core.annotations.Factory;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+
+@Service
+public interface FactoryService {
+    @Factory
+    FactoryProvided provide(String name);
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/FactoryTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/FactoryTests.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.core.factory;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.junit.jupiter.api.Assertions;
+
+@HartshornTest
+public class FactoryTests {
+
+    @InjectTest
+    void testFactoryRespectsPriorities(final ApplicationContext applicationContext) {
+        final FactoryService factoryService = applicationContext.get(FactoryService.class);
+        final FactoryProvided provided = factoryService.provide("");
+        Assertions.assertNotNull(provided);
+        Assertions.assertTrue(provided instanceof HighPriorityFactoryBound);
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/HighPriorityFactoryBound.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/HighPriorityFactoryBound.java
@@ -1,0 +1,12 @@
+package org.dockbox.hartshorn.core.factory;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.annotations.inject.Bound;
+
+@Binds(value = FactoryProvided.class, priority = 1)
+public class HighPriorityFactoryBound implements FactoryProvided {
+    @Bound
+    public HighPriorityFactoryBound(final String name) {
+        // Name is ignored
+    }
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/LowPriorityFactoryBound.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/factory/LowPriorityFactoryBound.java
@@ -1,0 +1,12 @@
+package org.dockbox.hartshorn.core.factory;
+
+import org.dockbox.hartshorn.core.annotations.inject.Binds;
+import org.dockbox.hartshorn.core.annotations.inject.Bound;
+
+@Binds(FactoryProvided.class)
+public class LowPriorityFactoryBound implements FactoryProvided {
+    @Bound
+    public LowPriorityFactoryBound(final String name) {
+        // Name is ignored
+    }
+}


### PR DESCRIPTION
# Description
During application startup, the `FactoryServicePreProcessor` looks up the appropriate constructor of the implementation of the return type of the method. However, when there is more than one binding present, this lookup would reverse their priority causing the lowest priority to be bound, instead of the highest priority.

Fixes #627

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
