### PR TITLE
#628 Expose declaring parent through executable element context

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ParameterLoaderContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ParameterLoaderContext.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ParameterLoaderContext extends DefaultContext implements ContextCarrier {
-    private final ExecutableElementContext<?> executable;
+    private final ExecutableElementContext<?, ?> executable;
     private final TypeContext<?> type;
     private final Object instance;
     private final ApplicationContext applicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ConstructorContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ConstructorContext.java
@@ -28,11 +28,10 @@ import java.util.function.Function;
 
 import lombok.Getter;
 
-public final class ConstructorContext<T> extends ExecutableElementContext<Constructor<T>> implements TypedElementContext<T> {
+public final class ConstructorContext<T> extends ExecutableElementContext<Constructor<T>, T> implements TypedElementContext<T> {
 
     @Getter
     private final Constructor<T> constructor;
-    private TypeContext<T> type;
     private Function<Object[], Exceptional<T>> invoker;
 
     private ConstructorContext(final Constructor<T> constructor) {
@@ -77,9 +76,9 @@ public final class ConstructorContext<T> extends ExecutableElementContext<Constr
         }
     }
 
+    @Override
     public TypeContext<T> type() {
-        if (this.type == null) this.type = TypeContext.of(this.element().getDeclaringClass());
-        return this.type;
+        return this.parent();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ExecutableElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ExecutableElementContext.java
@@ -29,8 +29,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public abstract class ExecutableElementContext<A extends Executable> extends AnnotatedMemberContext<A> implements Named {
+public abstract class ExecutableElementContext<A extends Executable, P> extends AnnotatedMemberContext<A> implements Named {
 
+    private TypeContext<P> parent;
     private LinkedList<ParameterContext<?>> parameters;
     protected ExecutableElementContextParameterLoader parameterLoader = new ExecutableElementContextParameterLoader();
 
@@ -57,6 +58,13 @@ public abstract class ExecutableElementContext<A extends Executable> extends Ann
 
     public int parameterCount() {
         return this.element().getParameterCount();
+    }
+
+    public TypeContext<P> parent() {
+        if (this.parent == null) {
+            this.parent = (TypeContext<P>) TypeContext.of(this.element().getDeclaringClass());
+        }
+        return this.parent;
     }
 
     protected Object[] arguments(final ApplicationContext context) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
@@ -33,7 +33,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-public class MethodContext<T, P> extends ExecutableElementContext<Method> {
+public class MethodContext<T, P> extends ExecutableElementContext<Method, P> {
 
     private static final Map<Method, MethodContext<?, ?>> cache = new ConcurrentHashMap<>();
 
@@ -45,7 +45,6 @@ public class MethodContext<T, P> extends ExecutableElementContext<Method> {
 
     private TypeContext<T> returnType;
     private TypeContext<T> genericReturnType;
-    private TypeContext<P> parent;
     private String qualifiedName;
 
     @Setter(AccessLevel.PACKAGE)
@@ -118,13 +117,6 @@ public class MethodContext<T, P> extends ExecutableElementContext<Method> {
             else this.genericReturnType = TypeContext.of((ParameterizedType) genericReturnType);
         }
         return this.genericReturnType;
-    }
-
-    public TypeContext<P> parent() {
-        if (this.parent == null) {
-            this.parent = (TypeContext<P>) TypeContext.of(this.method.getDeclaringClass());
-        }
-        return this.parent;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ParameterContext.java
@@ -39,7 +39,7 @@ public final class ParameterContext<T> extends AnnotatedElementContext<Parameter
     private String name;
     private TypeContext<T> type;
     private TypeContext<T> genericType;
-    private ExecutableElementContext<?> declaredBy;
+    private ExecutableElementContext<?, ?> declaredBy;
     private List<TypeContext<?>> typeParameters;
 
     private ParameterContext(final Parameter parameter) {
@@ -59,7 +59,7 @@ public final class ParameterContext<T> extends AnnotatedElementContext<Parameter
         return this.name;
     }
 
-    public ExecutableElementContext<?> declaredBy() {
+    public ExecutableElementContext<?, ?> declaredBy() {
         if (this.declaredBy == null) {
             final Executable executable = this.element().getDeclaringExecutable();
             if (executable instanceof Method method) this.declaredBy = MethodContext.of(method);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionPreProcessor.java
@@ -47,11 +47,11 @@ public class ComponentContextInjectionPreProcessor extends ComponentPreValidator
         for (final FieldContext<?> field : type.fields(Context.class))
             this.validate(field, type);
 
-        final List<ExecutableElementContext<?>> constructors = type.injectConstructors().stream().map(c -> (ExecutableElementContext<?>) c).collect(Collectors.toList());
-        final List<ExecutableElementContext<?>> methods = type.methods().stream().map(m -> (ExecutableElementContext<?>) m).collect(Collectors.toList());
-        final Collection<ExecutableElementContext<?>> executables = HartshornUtils.merge(constructors, methods);
+        final List<ExecutableElementContext<?, ?>> constructors = type.injectConstructors().stream().map(c -> (ExecutableElementContext<?, ?>) c).collect(Collectors.toList());
+        final List<ExecutableElementContext<?, ?>> methods = type.methods().stream().map(m -> (ExecutableElementContext<?, ?>) m).collect(Collectors.toList());
+        final Collection<ExecutableElementContext<?, ?>> executables = HartshornUtils.merge(constructors, methods);
 
-        for (final ExecutableElementContext<?> executable : executables)
+        for (final ExecutableElementContext<?, ?> executable : executables)
             for (final ParameterContext<?> parameter : executable.parameters(Context.class))
                 this.validate(parameter, type);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/GlobalProxyParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/GlobalProxyParameterLoader.java
@@ -35,7 +35,7 @@ public class GlobalProxyParameterLoader extends ParameterLoader<ParameterLoaderC
 
     @Override
     public List<Object> loadArguments(final ParameterLoaderContext context, final Object... args) {
-        final ExecutableElementContext<?> method = context.executable();
+        final ExecutableElementContext<?, ?> method = context.executable();
         final Collection<Object> arguments = new ArrayList<>();
         if (method.parameterCount() >= 1 && method.parameters().get(0).annotation(Instance.class).present()) {
             arguments.add(context.instance());

--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
@@ -88,7 +88,7 @@ public class RequestArgumentProcessorTests {
         final ParameterContext<Message> context = Mockito.mock(ParameterContext.class);
         Mockito.when(context.type()).thenReturn(TypeContext.of(Message.class));
 
-        final ExecutableElementContext<?> declaring = Mockito.mock(ExecutableElementContext.class);
+        final ExecutableElementContext<?, ?> declaring = Mockito.mock(ExecutableElementContext.class);
         final HttpRequest httpRequest = Mockito.mock(HttpRequest.class);
         Mockito.when(httpRequest.consumes()).thenReturn(mediaType);
         Mockito.when(declaring.annotation(HttpRequest.class)).thenReturn(Exceptional.of(httpRequest));


### PR DESCRIPTION
# Description
Currently, there's no way to directly get the declaring class of an `ExecutableElementContext<?>` without having to do:
```java
if (executable instanceof MethodContext methodContext)
    return methodContext.parent();
return ((TypedElementContext<?>) executable).type()
```

As `Executable` defines `#getDeclaringClass`, it is safe to expose the parent directly through the `ExecutableElementContext`.

Fixes #628 

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing
 
# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
