### PR TITLE
#625 Allow obtaining annotated annotations on a given element

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/AnnotatedElementContext.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public abstract class AnnotatedElementContext<A extends AnnotatedElement> extends DefaultContext implements QualifiedElement {
 
@@ -35,6 +36,16 @@ public abstract class AnnotatedElementContext<A extends AnnotatedElement> extend
 
     public Set<Annotation> annotations() {
         return new HashSet<>(this.validate().values());
+    }
+
+    public <T extends Annotation> Set<Annotation> annotations(final TypeContext<T> annotation) {
+        return this.annotations(annotation.type());
+    }
+
+    public <T extends Annotation> Set<Annotation> annotations(final Class<T> annotation) {
+        return this.annotations().stream()
+                .filter(a -> TypeContext.of(a.annotationType()).annotation(annotation).present())
+                .collect(Collectors.toSet());
     }
 
     public <T extends Annotation> Exceptional<T> annotation(final TypeContext<T> annotation) {


### PR DESCRIPTION
# Description
Currently the only way to get all annotations annotated with a given annotation of a given element is to use `AnnotatedElementContext#annotations().stream().filter(a -> a.annotation(MyAnnotation.class).present()).toList()`. While this works fine, it's a common source of code duplication and thus potential errors.

To resolve this a new utility method was added to `AnnotatedElementContext` allowing you to get all annotated annotations on an element.

Fixes #625

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
