### PR TITLE
#622 Disable automatic `KeyGen` activation

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/activate/AutomaticActivation.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/activate/AutomaticActivation.java
@@ -35,4 +35,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface AutomaticActivation {
+    boolean value() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -648,7 +648,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         for (final TypeContext<? extends ComponentProcessor> processor : children) {
             if (processor.isAbstract()) continue;
 
-            if (processor.annotation(AutomaticActivation.class).present()) {
+            if (processor.annotation(AutomaticActivation.class).map(AutomaticActivation::value).or(false)) {
                 final ComponentProcessor componentProcessor = this.get(processor);
                 if (this.hasActivator(componentProcessor.activator()))
                     this.add(componentProcessor);

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.i18n;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.boot.HartshornApplicationFactory;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -186,6 +187,7 @@ public final class TranslationBatchGenerator {
         return batch;
     }
 
+    @AutomaticActivation(false)
     private static class KeyGen extends TranslationInjectPostProcessor {
 
         private static final KeyGen INSTANCE = new KeyGen();


### PR DESCRIPTION
# Description
While running unit tests and debugging service post-processors for unrelated reasons, I noticed that translation injectors (service methods annotated with `@InjectTranslation`) are processed twice by the `TranslationInjectPostProcessor`. I noticed the first processor was indeed a proper instance of `TranslationInjectPostProcessor`, however the second time it was processed the processor instance was a `KeyGen`.  

The `KeyGen` in the translation batch generator does indeed extend `TranslationInjectPostProcessor`. However as demonstrated, this does lead to duplicate processing. While this may not be a breaking issue in this scenario, it may lead to issues in other scenarios.

As the `KeyGen` is not used as a dedicated processor, but rather as a way to expose protected methods in `TranslationInjectPostProcessor`, the `KeyGen` should not be automatically active. 

To resolve this I added an additional attribute to `AutomaticActivation` to allow disabling automatic activation on inherited processors.

Fixes #622

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
