### PR TITLE
#624 Provide binding `Key` instead of `TypeContext` to component processors

### DIFF
--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGateway.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGateway.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.commands.context.CommandContext;
 import org.dockbox.hartshorn.commands.context.CommandExecutorContext;
 import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.commands.extension.CommandExecutorExtension;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.List;
@@ -56,9 +56,9 @@ public interface CommandGateway {
      * in the provided {@link Class type} as {@link CommandExecutor executors} capable of handling
      * the commands.
      *
-     * @param type The type containing {@link org.dockbox.hartshorn.commands.annotations.Command} methods.
+     * @param key The key containing {@link org.dockbox.hartshorn.commands.annotations.Command} methods.
      */
-    <T> void register(TypeContext<T> type);
+    <T> void register(Key<T> key);
 
     /**
      * Registers the given {@link CommandExecutorContext} to handle the associated command(s).

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -27,6 +27,7 @@ import org.dockbox.hartshorn.commands.extension.CommandExecutorExtension;
 import org.dockbox.hartshorn.commands.extension.ExtensionResult;
 import org.dockbox.hartshorn.core.ArrayListMultiMap;
 import org.dockbox.hartshorn.core.Enableable;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MultiMap;
 import org.dockbox.hartshorn.core.annotations.inject.Binds;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -139,9 +140,9 @@ public class CommandGatewayImpl implements CommandGateway, Enableable {
     }
 
     @Override
-    public <T> void register(final TypeContext<T> type) {
-        for (final MethodContext<?, T> method : type.methods(Command.class)) {
-            this.register(method, type);
+    public <T> void register(final Key<T> key) {
+        for (final MethodContext<?, T> method : key.type().methods(Command.class)) {
+            this.register(method, key);
         }
     }
 
@@ -204,7 +205,7 @@ public class CommandGatewayImpl implements CommandGateway, Enableable {
         this.extensions.add(extension);
     }
 
-    private <T> void register(final MethodContext<?, T> method, final TypeContext<T> type) {
-        this.register(new MethodCommandExecutorContext<>(this.context, method, type));
+    private <T> void register(final MethodContext<?, T> method, final Key<T> key) {
+        this.register(new MethodCommandExecutorContext<>(this.context, method, key));
     }
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServicePreProcessor.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/ArgumentServicePreProcessor.java
@@ -17,15 +17,15 @@
 
 package org.dockbox.hartshorn.commands.service;
 
-import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
-import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.context.ArgumentConverterContext;
 import org.dockbox.hartshorn.commands.definition.ArgumentConverter;
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.FieldContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.services.ProcessingOrder;
 import org.dockbox.hartshorn.core.services.ServicePreProcessor;
 
@@ -40,14 +40,14 @@ import java.util.List;
 public class ArgumentServicePreProcessor implements ServicePreProcessor<UseCommands> {
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return !type.fieldsOf(ArgumentConverter.class).isEmpty();
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return !key.type().fieldsOf(ArgumentConverter.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
-        final List<FieldContext<ArgumentConverter>> fields = type.fieldsOf(ArgumentConverter.class);
-        context.log().debug("Found %d argument converters in %s".formatted(fields.size(), type.qualifiedName()));
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        final List<FieldContext<ArgumentConverter>> fields = key.type().fieldsOf(ArgumentConverter.class);
+        context.log().debug("Found %d argument converters in %s".formatted(fields.size(), key.type().qualifiedName()));
         context.first(ArgumentConverterContext.class).map(converterContext -> {
             for (final FieldContext<ArgumentConverter> field : fields) {
                 if (field.isStatic()) {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameters.java
@@ -17,17 +17,17 @@
 
 package org.dockbox.hartshorn.commands.service;
 
-import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
-import org.dockbox.hartshorn.core.boot.ApplicationManager;
-import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
 import org.dockbox.hartshorn.commands.annotations.Parameter;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.arguments.CustomParameterPattern;
 import org.dockbox.hartshorn.commands.arguments.DynamicPatternConverter;
 import org.dockbox.hartshorn.commands.context.ArgumentConverterContext;
 import org.dockbox.hartshorn.commands.definition.ArgumentConverter;
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
+import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
+import org.dockbox.hartshorn.core.boot.ApplicationManager;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
 import org.dockbox.hartshorn.core.services.ProcessingOrder;
 
@@ -45,16 +45,16 @@ public class CommandParameters implements ComponentPreProcessor<UseCommands> {
     }
 
     @Override
-    public boolean modifies(final ApplicationContext context, final TypeContext<?> type) {
-        return type.annotation(Parameter.class).present();
+    public boolean modifies(final ApplicationContext context, final Key<?> key) {
+        return key.type().annotation(Parameter.class).present();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
-        final Parameter meta = type.annotation(Parameter.class).get();
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        final Parameter meta = key.type().annotation(Parameter.class).get();
         final CustomParameterPattern pattern = context.get(meta.pattern());
-        final String key = meta.value();
-        final ArgumentConverter<?> converter = new DynamicPatternConverter<>(type, pattern, key);
+        final String parameterKey = meta.value();
+        final ArgumentConverter<?> converter = new DynamicPatternConverter<>(key.type(), pattern, parameterKey);
         context.first(ArgumentConverterContext.class).present(converterContext -> converterContext.register(converter));
     }
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandServiceScanner.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandServiceScanner.java
@@ -20,9 +20,9 @@ package org.dockbox.hartshorn.commands.service;
 import org.dockbox.hartshorn.commands.CommandGateway;
 import org.dockbox.hartshorn.commands.annotations.Command;
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServicePreProcessor;
 
 @AutomaticActivation
@@ -34,13 +34,13 @@ public class CommandServiceScanner implements ServicePreProcessor<UseCommands> {
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return !type.methods(Command.class).isEmpty();
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return !key.type().methods(Command.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
         final CommandGateway gateway = context.get(CommandGateway.class);
-        gateway.register(type);
+        gateway.register(key);
     }
 }

--- a/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
+++ b/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
@@ -27,8 +27,8 @@ import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.commands.types.CommandValueEnum;
 import org.dockbox.hartshorn.commands.types.SampleCommand;
 import org.dockbox.hartshorn.commands.types.SampleCommandExtension;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
@@ -51,7 +51,7 @@ public class CommandDefinitionContextTests {
     @Getter
     private ApplicationContext applicationContext;
 
-    private final TypeContext<SampleCommand> typeContext = TypeContext.of(SampleCommand.class);
+    private final Key<SampleCommand> typeContext = Key.of(SampleCommand.class);
 
     @Test
     void testParsingCanSucceed() {
@@ -64,7 +64,7 @@ public class CommandDefinitionContextTests {
     void testExtensionCanSucceed() {
         final CommandGateway gateway = this.applicationContext().get(CommandGatewayImpl.class);
         gateway.register(this.typeContext);
-        gateway.register(TypeContext.of(SampleCommandExtension.class));
+        gateway.register(Key.of(SampleCommandExtension.class));
         Assertions.assertDoesNotThrow(() -> gateway.accept(SystemSubject.instance(this.applicationContext()), "demo second ThisIsMyName"));
     }
 

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServicePreProcessor.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/ConfigurationServicePreProcessor.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.config;
 
 import org.dockbox.hartshorn.config.annotations.Configuration;
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -62,13 +63,13 @@ public class ConfigurationServicePreProcessor implements ServicePreProcessor<Use
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return type.annotation(Configuration.class).present();
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return key.type().annotation(Configuration.class).present();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
-        final Configuration configuration = type.annotation(Configuration.class).get();
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        final Configuration configuration = key.type().annotation(Configuration.class).get();
 
         String source = configuration.source();
         final TypeContext<?> owner = TypeContext.of(configuration.owner());
@@ -81,7 +82,7 @@ public class ConfigurationServicePreProcessor implements ServicePreProcessor<Use
             source = matcher.group(2);
         }
 
-        context.log().debug("Determined strategy " + TypeContext.of(strategy).name() + " for " + filetype.asFileName(source) + ", declared by " + type.name());
+        context.log().debug("Determined strategy " + TypeContext.of(strategy).name() + " for " + filetype.asFileName(source) + ", declared by " + key.type().name());
 
         URI config = strategy.lookup(context, source, owner, filetype).orNull();
 

--- a/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
+++ b/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/ConfigurationManagerTests.java
@@ -18,8 +18,8 @@
 package org.dockbox.hartshorn.config;
 
 import org.dockbox.hartshorn.config.annotations.UseConfigurations;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.data.FileFormats;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
@@ -107,7 +107,7 @@ public class ConfigurationManagerTests {
                     fs: "This is a value"
                     """);
 
-        new ConfigurationServicePreProcessor().process(this.applicationContext(), TypeContext.of(DemoFSConfiguration.class));
+        new ConfigurationServicePreProcessor().process(this.applicationContext(), Key.of(DemoFSConfiguration.class));
 
         final DemoFSConfiguration configuration = this.applicationContext().get(DemoFSConfiguration.class);
         Assertions.assertNotNull(configuration);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/Key.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/Key.java
@@ -30,55 +30,55 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class Key<C> {
-    private final TypeContext<C> contract;
-    private final Named named;
+    private final TypeContext<C> type;
+    private final Named name;
 
-    public static <C> Key<C> of(final TypeContext<C> contract) {
-        return new Key<>(contract, null);
+    public static <C> Key<C> of(final TypeContext<C> type) {
+        return new Key<>(type, null);
     }
 
-    public static <C> Key<C> of(final Class<C> contract) {
-        return of(TypeContext.of(contract));
+    public static <C> Key<C> of(final Class<C> type) {
+        return of(TypeContext.of(type));
     }
 
-    public static <C> Key<C> of(final TypeContext<C> contract, final Named named) {
-        if (named != null && !HartshornUtils.empty(named.value())) {
-            return new Key<>(contract, named);
+    public static <C> Key<C> of(final TypeContext<C> type, final Named name) {
+        if (name != null && !HartshornUtils.empty(name.value())) {
+            return new Key<>(type, name);
         }
-        return new Key<>(contract, null);
+        return new Key<>(type, null);
     }
 
-    public static <C> Key<C> of(final Class<C> contract, final Named named) {
-        return of(TypeContext.of(contract), named);
+    public static <C> Key<C> of(final Class<C> type, final Named name) {
+        return of(TypeContext.of(type), name);
     }
 
-    public static <C> Key<C> of(final Class<C> contract, final String named) {
-        return of(TypeContext.of(contract), new NamedImpl(named));
+    public static <C> Key<C> of(final Class<C> type, final String name) {
+        return of(TypeContext.of(type), new NamedImpl(name));
     }
 
-    public static <C> Key<C> of(final TypeContext<C> contract, final String named) {
-        return of(contract, new NamedImpl(named));
+    public static <C> Key<C> of(final TypeContext<C> type, final String name) {
+        return of(type, new NamedImpl(name));
     }
 
-    public Key<C> named(final String name) {
-        return Key.of(this.contract(), name);
+    public Key<C> name(final String name) {
+        return Key.of(this.type(), name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.contract, this.named);
+        return Objects.hash(this.type, this.name);
     }
 
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof final Key<?> key)) return false;
-        return this.contract.equals(key.contract) && Objects.equals(this.named, key.named);
+        return this.type.equals(key.type) && Objects.equals(this.name, key.name);
     }
 
     @Override
     public String toString() {
-        if (this.named == null) return "Key<" + this.contract.name() + ">";
-        else return "Key<" + this.contract.name() + ", " + this.named.value();
+        if (this.name == null) return "Key<" + this.type.name() + ">";
+        else return "Key<" + this.type.name() + ", " + this.name.value() + ">";
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/Key.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/Key.java
@@ -61,7 +61,11 @@ public class Key<C> {
     }
 
     public Key<C> name(final String name) {
-        return Key.of(this.type(), name);
+        return of(this.type(), name);
+    }
+
+    public Key<C> name(final Named name) {
+        return of(this.type(), name);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/ContextWrappedHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/ContextWrappedHierarchy.java
@@ -91,4 +91,9 @@ public class ContextWrappedHierarchy<C> implements BindingHierarchy<C> {
     public Iterator<Entry<Integer, Provider<C>>> iterator() {
         return this.real().iterator();
     }
+
+    @Override
+    public String toString() {
+        return this.real().toString();
+    }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/NativeBindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/binding/NativeBindingHierarchy.java
@@ -58,7 +58,7 @@ public class NativeBindingHierarchy<C> implements BindingHierarchy<C> {
         if (this.bindings.containsKey(priority) && priority != -1) {
             this.applicationContext().log().warn(("There is already a provider for %s with priority %d. It will be overwritten! " +
                     "To avoid unexpected behavior, ensure the priority is not already present. Current hierarchy: %s").formatted(this.key()
-                    .contract().name(), priority, this));
+                    .type().name(), priority, this));
         }
         this.bindings.put(priority, provider);
         return this;
@@ -97,8 +97,8 @@ public class NativeBindingHierarchy<C> implements BindingHierarchy<C> {
 
     @Override
     public String toString() {
-        final String contract = this.key().contract().name();
-        final Named named = this.key().named();
+        final String contract = this.key().type().name();
+        final Named named = this.key().name();
         String name = "";
         if (named != null) {
             name = "::" + named.value();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
@@ -46,10 +46,10 @@ public interface ApplicationContext extends
     void add(InjectionPoint<?> property);
 
     @Deprecated(since = "4.2.5", forRemoval = true)
-    <T> T create(Key<T> type);
+    <T> T create(Key<T> key);
 
     @Deprecated(since = "4.2.5", forRemoval = true)
-    <T> T inject(Key<T> type, T typeInstance);
+    <T> T inject(Key<T> key, T typeInstance);
 
     <T> T populate(T type);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/DefaultContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/DefaultContext.java
@@ -93,8 +93,8 @@ public abstract class DefaultContext implements Context {
 
     @Override
     public <C extends Context> Exceptional<C> first(final ApplicationContext applicationContext, final Key<C> key) {
-        if (key.named() == null) return this.first(applicationContext, key.contract().type());
-        else return this.first(applicationContext, key.contract().type(), key.named().value());
+        if (key.name() == null) return this.first(applicationContext, key.type().type());
+        else return this.first(applicationContext, key.type().type(), key.name().value());
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -175,12 +175,12 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
 
     public <T> T inject(final Key<T> key, T typeInstance) {
         for (final InjectionPoint<?> injectionPoint : this.injectionPoints) {
-            if (injectionPoint.accepts(key.contract())) {
+            if (injectionPoint.accepts(key.type())) {
                 try {
-                    typeInstance = ((InjectionPoint<T>) injectionPoint).apply(typeInstance, key.contract());
+                    typeInstance = ((InjectionPoint<T>) injectionPoint).apply(typeInstance, key.type());
                 }
                 catch (final ClassCastException e) {
-                    this.log().warn("Attempted to apply injection point to incompatible type [" + key.contract().qualifiedName() + "]");
+                    this.log().warn("Attempted to apply injection point to incompatible type [" + key.type().qualifiedName() + "]");
                 }
             }
         }
@@ -268,9 +268,10 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         for (final ComponentPreProcessor<?> serviceProcessor : this.preProcessors.get(order)) {
             for (final ComponentContainer container : containers) {
                 final TypeContext<?> service = container.type();
-                if (serviceProcessor.modifies(this, service)) {
+                final Key<?> key = Key.of(service);
+                if (serviceProcessor.modifies(this, key)) {
                     this.log().debug("Processing component %s with registered processor %s in phase %s".formatted(container.id(), TypeContext.of(serviceProcessor).name(), order));
-                    serviceProcessor.process(this, service);
+                    serviceProcessor.process(this, key);
                 }
             }
         }
@@ -362,15 +363,15 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         // See ServiceOrder#PHASE_1
         for (final ProcessingOrder order : ProcessingOrder.PHASE_1) {
             for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
-                if (postProcessor.preconditions(this, key.contract(), instance))
-                    instance = postProcessor.process(this, key.contract(), instance);
+                if (postProcessor.preconditions(this, key, instance))
+                    instance = postProcessor.process(this, key, instance);
             }
         }
 
         final MetaProvider meta = this.meta();
         // Ensure the order of resolution is to first resolve the instance singleton state, and only after check the type state.
         // Typically, the implementation decided whether it should be a singleton, so this cuts time complexity in half.
-        if (instance != null && (meta.singleton(key.contract()) || meta.singleton(TypeContext.unproxy(this, instance))))
+        if (instance != null && (meta.singleton(key.type()) || meta.singleton(TypeContext.unproxy(this, instance))))
             this.singletons.put(key, instance);
 
         // Recreating field instances ensures all fields are created through bootstrapping, allowing injection
@@ -384,11 +385,11 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         // See ServiceOrder#PHASE_2
         for (final ProcessingOrder order : ProcessingOrder.PHASE_2) {
             for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
-                if (postProcessor.preconditions(this, key.contract(), instance)) {
-                    final T modified = postProcessor.process(this, key.contract(), instance);
+                if (postProcessor.preconditions(this, key, instance)) {
+                    final T modified = postProcessor.process(this, key, instance);
                     if (modified != instance) {
                         throw new IllegalStateException(("Component %s was modified during phase %s (Phase 2) by %s. " +
-                                "Component processors are only able to discard existing instances in phases: %s").formatted(key.contract().name(), order.name(), TypeContext.of(postProcessor).name(), Arrays.toString(ProcessingOrder.PHASE_2)));
+                                "Component processors are only able to discard existing instances in phases: %s").formatted(key.type().name(), order.name(), TypeContext.of(postProcessor).name(), Arrays.toString(ProcessingOrder.PHASE_2)));
                     }
                 }
             }
@@ -410,8 +411,8 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
 
     protected <T> T modify(final ProcessingOrder order, final Key<T> key, T instance) {
         for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
-            if (postProcessor.preconditions(this, key.contract(), instance))
-                instance = postProcessor.process(this, key.contract(), instance);
+            if (postProcessor.preconditions(this, key, instance))
+                instance = postProcessor.process(this, key, instance);
         }
         return instance;
     }
@@ -422,7 +423,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         if (provision.present())
             return provision.get();
 
-        final TypeContext<T> type = key.contract();
+        final TypeContext<T> type = key.type();
 
         final Exceptional<T> raw = Exceptional.of(() -> this.raw(type)).rethrowUnchecked();
         if (raw.present())
@@ -447,8 +448,8 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         }
     }
 
-    public <T> Exceptional<T> provide(final Key<T> type) {
-        return Exceptional.of(type)
+    public <T> Exceptional<T> provide(final Key<T> key) {
+        return Exceptional.of(key)
                 .map(this::hierarchy)
                 .flatMap(hierarchy -> {
                     // Will continue going through each provider until a provider was successful or no other providers remain

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
@@ -41,13 +41,17 @@ public interface ComponentContainer {
 
     List<Class<? extends Annotation>> activators();
 
+    @Deprecated(since = "4.2.5", forRemoval = true)
     boolean hasActivator();
 
+    @Deprecated(since = "4.2.5", forRemoval = true)
     boolean hasActivator(Class<? extends Annotation> activator);
 
     boolean singleton();
 
     ComponentType componentType();
+
+    boolean permitsProxying();
 
     static String id(final ApplicationContext context, final TypeContext<?> type) {
         return id(context, type, false);
@@ -82,6 +86,4 @@ public interface ComponentContainer {
         final String[] parts = HartshornUtils.splitCapitals(raw);
         return HartshornUtils.capitalize(String.join(" ", parts));
     }
-
-    boolean permitsProxying();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionPreProcessor.java
@@ -18,8 +18,9 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.core.annotations.inject.Context;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
+import org.dockbox.hartshorn.core.annotations.inject.Context;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -43,9 +44,10 @@ public class ComponentContextInjectionPreProcessor extends ComponentPreValidator
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        final TypeContext<T> type = key.type();
         for (final FieldContext<?> field : type.fields(Context.class))
-            this.validate(field, type);
+            this.validate(field, key);
 
         final List<ExecutableElementContext<?, ?>> constructors = type.injectConstructors().stream().map(c -> (ExecutableElementContext<?, ?>) c).collect(Collectors.toList());
         final List<ExecutableElementContext<?, ?>> methods = type.methods().stream().map(m -> (ExecutableElementContext<?, ?>) m).collect(Collectors.toList());
@@ -53,10 +55,10 @@ public class ComponentContextInjectionPreProcessor extends ComponentPreValidator
 
         for (final ExecutableElementContext<?, ?> executable : executables)
             for (final ParameterContext<?> parameter : executable.parameters(Context.class))
-                this.validate(parameter, type);
+                this.validate(parameter, key);
     }
 
-    private void validate(final TypedElementContext<?> context, final TypeContext<?> parent) {
+    private void validate(final TypedElementContext<?> context, final Key<?> parent) {
         if (!context.type().childOf(org.dockbox.hartshorn.core.context.Context.class))
             ExceptionHandler.unchecked(new ApplicationException("%s is annotated with %s but does not extend %s".formatted(
                     context.qualifiedName(),

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
@@ -88,7 +88,7 @@ public class ComponentLocatorImpl implements ComponentLocator {
 
     @Override
     public <T> void validate(final Key<T> key) {
-        final TypeContext<T> contract = key.contract();
+        final TypeContext<T> contract = key.type();
         if (contract.annotation(Component.class).present() && this.container(contract).absent()) {
             this.applicationContext().log().warn("Component key '%s' is annotated with @Component, but is not registered.".formatted(contract.qualifiedName()));
         }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentPreProcessor.java
@@ -18,9 +18,9 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.ServiceActivator;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 import java.lang.annotation.Annotation;
 
@@ -48,13 +48,13 @@ import java.lang.annotation.Annotation;
 public interface ComponentPreProcessor<A extends Annotation> extends ComponentProcessor<A> {
 
     @Override
-    default <T> boolean modifies(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        return this.modifies(context, type);
+    default <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return this.modifies(context, key);
     }
 
     @Override
-    default <T> T process(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        this.process(context, type);
+    default <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        this.process(context, key);
         return instance;
     }
 
@@ -63,22 +63,22 @@ public interface ComponentPreProcessor<A extends Annotation> extends ComponentPr
      * not exist yet, this method does not expect the <code>instance</code> to be specified.
      *
      * @param context The application context.
-     * @param type The type context of the component.
+     * @param key The type context of the component.
      * @return <code>true</code> if the component pre-processor modifies the component, <code>false</code>
      * otherwise.
-     * @see ComponentProcessor#modifies(ApplicationContext, TypeContext, Object)
-     * @see ComponentProcessor#preconditions(ApplicationContext, TypeContext, Object)
+     * @see ComponentProcessor#modifies(ApplicationContext, Key, Object)
+     * @see ComponentProcessor#preconditions(ApplicationContext, Key, Object)
      */
-    boolean modifies(ApplicationContext context, TypeContext<?> type);
+    boolean modifies(ApplicationContext context, Key<?> key);
 
     /**
      * Processes a given component. As component instances will not exist yet, this method does not expect
      * the <code>instance</code> to be specified.
      *
      * @param context The application context.
-     * @param type The type context of the component.
+     * @param key The type context of the component.
      * @param <T> The type of the component.
-     * @see ComponentProcessor#process(ApplicationContext, TypeContext, Object)
+     * @see ComponentProcessor#process(ApplicationContext, Key, Object)
      */
-    <T> void process(ApplicationContext context, TypeContext<T> type);
+    <T> void process(ApplicationContext context, Key<T> key);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentPreValidator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentPreValidator.java
@@ -17,15 +17,15 @@
 
 package org.dockbox.hartshorn.core.services;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 import java.lang.annotation.Annotation;
 
 public abstract class ComponentPreValidator<A extends Annotation> implements ComponentPreProcessor<A> {
 
     @Override
-    public boolean modifies(final ApplicationContext context, final TypeContext<?> type) {
+    public boolean modifies(final ApplicationContext context, final Key<?> key) {
         return true;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProcessor.java
@@ -1,18 +1,18 @@
 /*
- *  Copyright (C) 2020 Guus Lieben
+ * Copyright (C) 2020 Guus Lieben
  *
- *  This framework is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2.1 of the
- *  License, or (at your option) any later version.
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
- *  the GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
 package org.dockbox.hartshorn.core.services;
@@ -41,22 +41,21 @@ public interface ComponentProcessor<A extends Annotation> extends ActivatorFilte
     /**
      * Processes a given component. The given <code>instance</code> may be null, if the component could not
      * be created through regular {@link org.dockbox.hartshorn.core.binding.Provider providers}. The given
-     * {@link TypeContext} will always be valid, and will always contain a valid {@link TypeContext#type()}.
-     * The {@link TypeContext} represents the {@link Key#contract()} of the component. If the instance is
-     * present, the {@link TypeContext} will represent either the type of the component, or a parent of the
+     * {@link Key} will always be valid, and will always contain a valid {@link TypeContext}. If the instance
+     * is present, the {@link TypeContext} will represent either the type of the component, or a parent of the
      * type of the component.
      *
      * <p>The provided {@link ApplicationContext} will always be valid. This is the context which is
      * responsible for the creation of the component.
      *
      * @param context The application context.
-     * @param type The type context of the component.
+     * @param key The key of the component.
      * @param instance The instance of the component.
      * @param <T> The type of the component.
      *
      * @return The processed component.
      */
-    <T> T process(ApplicationContext context, TypeContext<T> type, @Nullable T instance);
+    <T> T process(ApplicationContext context, Key<T> key, @Nullable T instance);
 
     /**
      * Determines whether the component processor should be called for the given component. By default,
@@ -64,28 +63,28 @@ public interface ComponentProcessor<A extends Annotation> extends ActivatorFilte
      * through the active {@link ComponentContainer} of the component.
      *
      * @param context The application context.
-     * @param type The type context of the component.
+     * @param key The key of the component.
      * @param instance The instance of the component.
      * @param <T> The type of the component.
      * @return True if the processor should be called, false otherwise.
      */
-    default <T> boolean preconditions(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        return context.locator().container(type).present() && this.modifies(context, type, instance);
+    default <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return context.locator().container(key.type()).present() && this.modifies(context, key, instance);
     }
 
     /**
      * Determines whether the component processor should be called for the given component. This method
-     * will only be called if the preconditions of {@link #preconditions(ApplicationContext, TypeContext, Object)}
-     * are met, assuming the {@link #preconditions(ApplicationContext, TypeContext, Object)} are not modified
+     * will only be called if the preconditions of {@link #preconditions(ApplicationContext, Key, Object)}
+     * are met, assuming the {@link #preconditions(ApplicationContext, Key, Object)} are not modified
      * by the implementing class.
      *
      * @param context The application context.
-     * @param type The type context of the component.
+     * @param key The key of the component.
      * @param instance The instance of the component.
      * @param <T> The type of the component.
      * @return <code>true</code> if the component processor modifies the component, <code>false</code>
      * otherwise.
      */
-    <T> boolean modifies(ApplicationContext context, TypeContext<T> type, @Nullable T instance);
+    <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance);
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProxyPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProxyPostProcessor.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.services;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
@@ -19,9 +36,9 @@ public class ComponentProxyPostProcessor implements ComponentPostProcessor<Servi
     }
 
     @Override
-    public <T> T process(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
         try {
-            final ProxyHandler<T> handler = context.environment().manager().handler(type, instance);
+            final ProxyHandler<T> handler = context.environment().manager().handler(key.type(), instance);
             return handler.proxy(context, instance);
         } catch (final ApplicationException e) {
             return ExceptionHandler.unchecked(e);
@@ -29,8 +46,8 @@ public class ComponentProxyPostProcessor implements ComponentPostProcessor<Servi
     }
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        final Exceptional<ComponentContainer> container = context.locator().container(type);
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        final Exceptional<ComponentContainer> container = context.locator().container(key.type());
         return container.present() && container.get().permitsProxying();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextMethodPostProcessor.java
@@ -40,7 +40,7 @@ public class ContextMethodPostProcessor extends ServiceAnnotatedMethodPostProces
             final String name = annotation.value();
 
             Key<?> key = Key.of(methodContext.method().returnType());
-            if (!name.isEmpty()) key = key.named(name);
+            if (!name.isEmpty()) key = key.name(name);
             return (R) context.get(key);
         };
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServicePreProcessor.java
@@ -40,21 +40,21 @@ public class FactoryServicePreProcessor implements ServicePreProcessor<Service> 
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return !type.methods(Factory.class).isEmpty();
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return !key.type().methods(Factory.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
         final FactoryContext factoryContext = context.first(FactoryContext.class).get();
 
         methods:
-        for (final MethodContext<?, T> method : type.methods(Factory.class)) {
+        for (final MethodContext<?, T> method : key.type().methods(Factory.class)) {
             final Factory annotation = method.annotation(Factory.class).get();
-            Key<?> key = Key.of(method.returnType());
-            if (!"".equals(annotation.value())) key = Key.of(method.returnType(), annotation.value());
+            Key<?> returnKey = Key.of(method.returnType());
+            if (!"".equals(annotation.value())) returnKey = returnKey.name(annotation.value());
 
-            for (final Provider<?> provider : context.hierarchy(key).providers()) {
+            for (final Provider<?> provider : context.hierarchy(returnKey).providers()) {
                 if (provider instanceof ContextDrivenProvider contextDrivenProvider) {
                     final TypeContext<?> typeContext = ((ContextDrivenProvider<?>) provider).context();
 
@@ -70,7 +70,7 @@ public class FactoryServicePreProcessor implements ServicePreProcessor<Service> 
                 }
             }
 
-            throw new IllegalStateException("No matching bound constructor found for " + key + " with parameters: " + method.parameterTypes());
+            throw new IllegalStateException("No matching bound constructor found for " + returnKey + " with parameters: " + method.parameterTypes());
         }
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FunctionalComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FunctionalComponentPostProcessor.java
@@ -17,18 +17,18 @@
 
 package org.dockbox.hartshorn.core.services;
 
-import org.dockbox.hartshorn.core.ComponentType;
-import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.ComponentType;
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
 
 import java.lang.annotation.Annotation;
 
 public abstract class FunctionalComponentPostProcessor<A extends Annotation> implements ComponentPostProcessor<A> {
 
     @Override
-    public <T> boolean preconditions(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        return ComponentPostProcessor.super.preconditions(context, type, instance)
-                && context.locator().container(type).get().componentType() == ComponentType.FUNCTIONAL;
+    public <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return ComponentPostProcessor.super.preconditions(context, key, instance)
+                && context.locator().container(key.type()).get().componentType() == ComponentType.FUNCTIONAL;
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/LifecycleObserverPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/LifecycleObserverPreProcessor.java
@@ -17,11 +17,11 @@
 
 package org.dockbox.hartshorn.core.services;
 
-import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
+import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
 import org.dockbox.hartshorn.core.boot.LifecycleObserver;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 @AutomaticActivation
 public class LifecycleObserverPreProcessor implements ServicePreProcessor<UseBootstrap> {
@@ -32,12 +32,12 @@ public class LifecycleObserverPreProcessor implements ServicePreProcessor<UseBoo
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return type.childOf(LifecycleObserver.class);
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return key.type().childOf(LifecycleObserver.class);
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
-        context.environment().manager().register((LifecycleObserver) context.get(type));
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        context.environment().manager().register((LifecycleObserver) context.get(key));
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProxyDelegationPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProxyDelegationPostProcessor.java
@@ -17,6 +17,8 @@
 
 package org.dockbox.hartshorn.core.services;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.BackingImplementationContext;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
@@ -25,7 +27,6 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -35,8 +36,8 @@ public abstract class ProxyDelegationPostProcessor<P, A extends Annotation> exte
     protected abstract Class<P> parentTarget();
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        return type.childOf(this.parentTarget());
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return key.type().childOf(this.parentTarget());
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodPostProcessor.java
@@ -17,10 +17,11 @@
 
 package org.dockbox.hartshorn.core.services;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -28,8 +29,8 @@ import java.util.Collection;
 public abstract class ServiceAnnotatedMethodPostProcessor<M extends Annotation, A extends Annotation> extends ServiceMethodPostProcessor<A> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        return !type.methods(this.annotation()).isEmpty();
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return !key.type().methods(this.annotation()).isEmpty();
     }
 
     public abstract Class<M> annotation();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceMethodPostProcessor.java
@@ -18,6 +18,7 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.MethodProxyContextImpl;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -33,7 +34,8 @@ import java.util.Collection;
 public abstract class ServiceMethodPostProcessor<A extends Annotation> extends FunctionalComponentPostProcessor<A> {
 
     @Override
-    public <T> T process(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        final TypeContext<T> type = key.type();
         final Collection<MethodContext<?, T>> methods = this.modifiableMethods(type);
 
         // Will reuse existing handler of proxy
@@ -63,8 +65,8 @@ public abstract class ServiceMethodPostProcessor<A extends Annotation> extends F
     }
 
     @Override
-    public <T> boolean preconditions(final ApplicationContext context, final TypeContext<T> type, @Nullable final T instance) {
-        return super.preconditions(context, type, instance) && context.environment().manager().isProxy(instance);
+    public <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return super.preconditions(context, key, instance) && context.environment().manager().isProxy(instance);
     }
 
     protected abstract <T> Collection<MethodContext<?, T>> modifiableMethods(TypeContext<T> type);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServicePreProcessor.java
@@ -17,18 +17,18 @@
 
 package org.dockbox.hartshorn.core.services;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 import java.lang.annotation.Annotation;
 
 public interface ServicePreProcessor<A extends Annotation> extends ComponentPreProcessor<A> {
 
     @Override
-    default boolean modifies(final ApplicationContext context, final TypeContext<?> type) {
-        return type.annotation(Service.class).present() && this.preconditions(context, type);
+    default boolean modifies(final ApplicationContext context, final Key<?> key) {
+        return key.type().annotation(Service.class).present() && this.preconditions(context, key);
     }
 
-    boolean preconditions(ApplicationContext context, TypeContext<?> type);
+    boolean preconditions(ApplicationContext context, Key<?> key);
 }

--- a/hartshorn-core/src/test/java/com/example/application/DemoProcessor.java
+++ b/hartshorn-core/src/test/java/com/example/application/DemoProcessor.java
@@ -1,25 +1,25 @@
 /*
- *  Copyright (C) 2020 Guus Lieben
+ * Copyright (C) 2020 Guus Lieben
  *
- *  This framework is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2.1 of the
- *  License, or (at your option) any later version.
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
- *  the GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
 package com.example.application;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
 
 import javax.inject.Inject;
@@ -45,11 +45,11 @@ public class DemoProcessor implements ComponentPreProcessor<UseDemo> {
     }
 
     @Override
-    public boolean modifies(final ApplicationContext context, final TypeContext<?> type) {
+    public boolean modifies(final ApplicationContext context, final Key<?> type) {
         return false;
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> type) {
     }
 }

--- a/hartshorn-core/src/test/java/com/specific/sub/DemoServicePreProcessor.java
+++ b/hartshorn-core/src/test/java/com/specific/sub/DemoServicePreProcessor.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package com.specific.sub;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServicePreProcessor;
 
 import javax.inject.Singleton;
@@ -17,13 +34,13 @@ public class DemoServicePreProcessor implements ServicePreProcessor<Demo> {
     private int processed = 0;
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return type.is(DemoService.class);
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return key.type().is(DemoService.class);
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
-        context.log().debug("Processing %s".formatted(type.qualifiedName()));
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        context.log().debug("Processing %s".formatted(key));
         this.processed++;
     }
 

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBus.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBus.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.events;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.events.parents.Event;
 
 import java.util.Map;
@@ -28,15 +28,15 @@ import java.util.function.Function;
 
 public interface EventBus {
 
-    void subscribe(TypeContext<?> object);
+    void subscribe(Key<?> object);
 
-    void unsubscribe(TypeContext<?> object);
+    void unsubscribe(Key<?> object);
 
-    void post(Event event, TypeContext<?> target);
+    void post(Event event, Key<?> target);
 
     void post(Event event);
 
-    Map<TypeContext<?>, Set<EventWrapper>> invokers();
+    Map<Key<?>, Set<EventWrapper>> invokers();
 
     void addValidationRule(Function<MethodContext<?, ?>, Exceptional<Boolean>> validator);
 }

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventServicePreProcessor.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventServicePreProcessor.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.events;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServicePreProcessor;
 import org.dockbox.hartshorn.events.annotations.Listener;
 import org.dockbox.hartshorn.events.annotations.UseEvents;
@@ -27,13 +27,13 @@ import org.dockbox.hartshorn.events.annotations.UseEvents;
 @AutomaticActivation
 public class EventServicePreProcessor implements ServicePreProcessor<UseEvents> {
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return !type.methods(Listener.class).isEmpty();
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return !key.type().methods(Listener.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
-        context.get(EventBus.class).subscribe(type);
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
+        context.get(EventBus.class).subscribe(key);
     }
 
     @Override

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
@@ -17,11 +17,12 @@
 
 package org.dockbox.hartshorn.events.handle;
 
+import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.events.EventWrapper;
 import org.dockbox.hartshorn.events.parents.Event;
-import org.dockbox.hartshorn.core.HartshornUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -59,7 +60,7 @@ public class EventHandler {
         if (invoker instanceof EventWrapperImpl) this.invalidateCache(this.invokers.remove(invoker));
     }
 
-    public void post(final Event event, final TypeContext<?> target) {
+    public void post(final Event event, final Key<?> target) {
         EventWrapperImpl<?>[] cache = this.computedInvokerCache;
         if (null == cache) {
             synchronized (this) {

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
@@ -17,8 +17,8 @@
 
 package org.dockbox.hartshorn.events;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.events.annotations.Listener.Priority;
 import org.dockbox.hartshorn.events.listeners.BasicEventListener;
 import org.dockbox.hartshorn.events.listeners.GenericEventListener;
@@ -46,8 +46,8 @@ public class EventBusTests {
     @Test
     public void testTypesCanSubscribe() {
         final EventBus bus = this.bus();
-        bus.subscribe(TypeContext.of(BasicEventListener.class));
-        Assertions.assertTrue(bus.invokers().containsKey(TypeContext.of(BasicEventListener.class)));
+        bus.subscribe(Key.of(BasicEventListener.class));
+        Assertions.assertTrue(bus.invokers().containsKey(Key.of(BasicEventListener.class)));
     }
 
     private EventBus bus() {
@@ -57,7 +57,7 @@ public class EventBusTests {
     @Test
     public void testNonStaticMethodsCanListen() {
         final EventBus bus = this.bus();
-        bus.subscribe(TypeContext.of(BasicEventListener.class));
+        bus.subscribe(Key.of(BasicEventListener.class));
         bus.post(new SampleEvent());
         Assertions.assertTrue(BasicEventListener.fired);
     }
@@ -65,7 +65,7 @@ public class EventBusTests {
     @Test
     public void testStaticMethodsCanListen() {
         final EventBus bus = this.bus();
-        bus.subscribe(TypeContext.of(StaticEventListener.class));
+        bus.subscribe(Key.of(StaticEventListener.class));
         bus.post(new SampleEvent());
         Assertions.assertTrue(StaticEventListener.fired);
     }
@@ -73,7 +73,7 @@ public class EventBusTests {
     @Test
     public void testEventsArePostedInCorrectPriorityOrder() {
         final EventBus bus = this.bus();
-        bus.subscribe(TypeContext.of(PriorityEventListener.class));
+        bus.subscribe(Key.of(PriorityEventListener.class));
         bus.post(new SampleEvent());
         Assertions.assertEquals(Priority.LAST, PriorityEventListener.last());
     }
@@ -81,7 +81,7 @@ public class EventBusTests {
     @Test
     void testGenericEventsAreFiltered() {
         final EventBus bus = this.bus();
-        bus.subscribe(TypeContext.of(GenericEventListener.class));
+        bus.subscribe(Key.of(GenericEventListener.class));
         final Event event = new GenericEvent<>("String") {
         };
         Assertions.assertDoesNotThrow(() -> bus.post(event));
@@ -92,7 +92,7 @@ public class EventBusTests {
         final EventBus bus = this.bus();
         // Ensure the values have not been affected by previous tests
         GenericEventListener.objects().clear();
-        bus.subscribe(TypeContext.of(GenericEventListener.class));
+        bus.subscribe(Key.of(GenericEventListener.class));
         final Event stringEvent = new GenericEvent<>("String") {
         };
         final Event integerEvent = new GenericEvent<>(1) {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/LanguageProviderServicePreProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/LanguageProviderServicePreProcessor.java
@@ -17,10 +17,10 @@
 
 package org.dockbox.hartshorn.i18n.services;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServicePreProcessor;
 import org.dockbox.hartshorn.i18n.Message;
 import org.dockbox.hartshorn.i18n.TranslationBundle;
@@ -37,14 +37,14 @@ public class LanguageProviderServicePreProcessor implements ServicePreProcessor<
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
-        return !type.methods(TranslationProvider.class).isEmpty();
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        return !key.type().methods(TranslationProvider.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
         final TranslationService translationService = context.get(TranslationService.class);
-        for (final MethodContext<?, T> method : type.methods(TranslationProvider.class)) {
+        for (final MethodContext<?, T> method : key.type().methods(TranslationProvider.class)) {
             if (method.returnType().childOf(TranslationBundle.class)) {
                 final TranslationBundle bundle = (TranslationBundle) method.invoke(context).rethrowUnchecked().get();
                 translationService.add(bundle);

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RestControllerPreProcessor.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RestControllerPreProcessor.java
@@ -17,14 +17,15 @@
 
 package org.dockbox.hartshorn.web;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ServicePreProcessor;
 import org.dockbox.hartshorn.web.annotations.RestController;
-import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
 import org.dockbox.hartshorn.web.annotations.UseHttpServer;
+import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
 
 @AutomaticActivation
 public class RestControllerPreProcessor implements ServicePreProcessor<UseHttpServer> {
@@ -34,14 +35,15 @@ public class RestControllerPreProcessor implements ServicePreProcessor<UseHttpSe
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        final TypeContext<?> type = key.type();
         return type.annotation(RestController.class).present() && !type.methods(HttpRequest.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
         final ControllerContext controllerContext = context.first(ControllerContext.class).get();
-        for (final MethodContext<?, T> method : type.methods(HttpRequest.class)) {
+        for (final MethodContext<?, T> method : key.type().methods(HttpRequest.class)) {
             controllerContext.add(new RequestHandlerContext(context, method));
         }
     }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MvcControllerPreProcessor.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MvcControllerPreProcessor.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.web.mvc;
 
+import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -37,14 +38,15 @@ public class MvcControllerPreProcessor implements ServicePreProcessor<UseMvcServ
     }
 
     @Override
-    public boolean preconditions(final ApplicationContext context, final TypeContext<?> type) {
+    public boolean preconditions(final ApplicationContext context, final Key<?> key) {
+        final TypeContext<?> type = key.type();
         return type.annotation(MvcController.class).present() && !type.methods(HttpRequest.class).isEmpty();
     }
 
     @Override
-    public <T> void process(final ApplicationContext context, final TypeContext<T> type) {
+    public <T> void process(final ApplicationContext context, final Key<T> key) {
         final MvcControllerContext controllerContext = context.first(MvcControllerContext.class).get();
-        for (final MethodContext<?, T> method : type.methods(HttpRequest.class)) {
+        for (final MethodContext<?, T> method : key.type().methods(HttpRequest.class)) {
             if (method.returnType().childOf(ViewTemplate.class)) {
                 final RequestHandlerContext handlerContext = new RequestHandlerContext(context, method);
                 controllerContext.add(handlerContext);


### PR DESCRIPTION
# Description
It is not currently possible to get the name of a binding when processing components through `ComponentProcessor` implementations. This limits the ability to perform specific actions on named bindings.  

As `ComponentProcessor` already accepts a `TypeContext` in `process` and `preconditions`, this was relatively easy to swap by replacing the `TypeContext` with a `Key`. This way the type can still be obtained through the `Key`, and the name is exposed correctly as well.  

As this changes the interface for `ComponentProcessor`s, and thus affects all implementations, this is a breaking change.

Fixes #624

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
