### PR TITLE
RC Dependency check

### DIFF
--- a/.github/workflows/hartshorn.yml
+++ b/.github/workflows/hartshorn.yml
@@ -6,19 +6,6 @@ name: Hartshorn
 on: [pull_request]
 
 jobs:
-  javadoc:
-    name: Verify Javadocs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 16
-        uses: actions/setup-java@v1
-        with:
-          java-version: 16
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Verify Javadocs
-        run: ./gradlew aggregateJavadoc
   build:
     name: Build all
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
     dependencies {
         classpath "io.franzbecker:gradle-lombok:$gradleLombokVersion"
-        classpath 'org.owasp:dependency-check-gradle:6.2.2'
+        classpath "org.owasp:dependency-check-gradle:$owaspDependencyCheckVersion"
     }
 }
 
@@ -29,8 +29,7 @@ plugins {
     id 'java'
     id 'java-library'
     id 'org.cadixdev.licenser' version "$licenserVersion"
-    id 'io.freefair.aggregate-javadoc' version "$aggregateJavadocVersion"
-    id 'org.checkerframework' version '0.6.3'
+    id 'org.checkerframework' version "$checkerFrameworkVersion"
 }
 
 apply plugin: 'org.owasp.dependencycheck'

--- a/examples/examples.gradle
+++ b/examples/examples.gradle
@@ -48,10 +48,6 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-toml:$jacksonVersion"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
 
-    implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-
     annotationProcessor "org.projectlombok:lombok:$lombokVersion"
 
     // Only required because this is affected by the global build file, in a real world application you'd use

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,40 +20,39 @@ projectId=hartshorn
 projectName=Hartshorn
 projectVersion=4.2.5
 
-# Dependency versions
-junitVersion=5.3.2
-mockitoVersion=3.10.0
-jetbrainsAnnotationsVersion=19.0.0
-jdaVersion=4.3.0_277
+# Core API versions
+jetbrainsAnnotationsVersion=23.0.0
 slf4jVersion=1.7.32
-reflectionsVersion=0.9.11
-hamcrestVersion=2.0.0.0
-hibernateVersion=5.5.5.Final
-javaxPersistenceVersion=2.2
+logbackVersion=1.2.10
+reflectionsVersion=0.10.2
 jakartaInjectVersion=1.0.5
-javaxJaxbVersion=2.2.4
-lombokVersion=1.18.20
-discordPaginationVersion=2.1.1
-jacksonVersion=2.12.3
-woodstoxVersion=4.4.1
-derbyVersion=10.8.2.2
-imageScalingVersion=0.8.6
-jhlabsFiltersVersion=2.0.235-1
-testContainersVersion=1.16.0
-mySqlConnectorVersion=8.0.26
-postgreSqlVersion=42.2.23
+lombokVersion=1.18.22
+
+# Testing API versions
+junitVersion=5.8.2
+mockitoVersion=4.2.0
+testContainersVersion=1.16.2
+hamcrestVersion=2.0.0.0
+
+# Data API versions
+hibernateVersion=5.6.3.Final
+javaxPersistenceVersion=2.2
+mySqlConnectorVersion=8.0.27
+postgreSqlVersion=42.3.1
 mariaDbClientVersion=2.7.4
-log4jVersion=2.7
-javaxServletVersion=3.1.0
-jettyVersion=9.4.44.v20210927
-mssqlDriverVersion=9.4.0.jre11
-logbackVersion=1.3.0-alpha10
+jacksonVersion=2.13.1
+woodstoxVersion=4.4.1
+derbyVersion=10.14.2.0
+mssqlDriverVersion=9.4.1.jre11
+
+# Web API versions
 freeMarkerVersion=2.3.31
 httpClientVersion=4.5.13
+javaxServletVersion=4.0.1
+jettyVersion=9.4.44.v20210927
 
 # Gradle plugin versions
-licenserVersion=0.5.0
-aggregateJavadocVersion=6.0.0-m2
-
-# Buildscript dependencies
-gradleLombokVersion=1.6
+licenserVersion=0.6.1
+owaspDependencyCheckVersion=6.5.1
+checkerFrameworkVersion=0.6.5
+gradleLombokVersion=5.0.0

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationConfigurator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationConfigurator.java
@@ -21,7 +21,6 @@ import org.dockbox.hartshorn.core.InjectConfiguration;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.exceptions.TypeConversionException;
-import org.reflections.Reflections;
 
 import java.util.Set;
 
@@ -29,7 +28,6 @@ public class HartshornApplicationConfigurator implements ApplicationConfigurator
 
     @Override
     public void configure(final ApplicationManager manager) {
-        Reflections.log = null; // Don't output Reflections
         manager.stacktraces(this.stacktraces(manager));
     }
 

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
@@ -187,6 +187,9 @@ class SqlServiceTest {
 
     @Test
     void hibernateRepositoryUsesPropertiesIfNoConnectionExists() throws ApplicationException {
+        // TestContainers sometimes closes the connection after a test, so we need to make sure we have an active container
+        if (!mySql.isRunning()) mySql.start();
+
         final JpaRepositoryFactory factory = this.applicationContext().get(JpaRepositoryFactory.class);
         final JpaRepository<User, ?> repository = factory.repository(User.class);
         Assertions.assertTrue(repository instanceof HibernateJpaRepository);
@@ -212,6 +215,9 @@ class SqlServiceTest {
 
     @Test
     void testAutomaticConnectionForUserRepository() {
+        // TestContainers sometimes closes the connection after a test, so we need to make sure we have an active container
+        if (!mySql.isRunning()) mySql.start();
+
         // Data API specific
         this.applicationContext().property("hartshorn.data.username", mySql.getUsername());
         this.applicationContext().property("hartshorn.data.password", mySql.getPassword());


### PR DESCRIPTION
# Description
Updates relevant dependencies to the latest compatible version.

## Changes
### Removals
#### Gradle plugins
- FreeFair Javadoc Aggregate plugin, this has not worked correctly for some time now

#### Dependencies
- Removes Log4J dependencies from `examples` module, these were no longer used

### Upgrades
#### Gradle plugins
- Updates CadixDev Licenser from 0.5.0 to 0.6.1
- Updates OWASP Dependency Check from 6.2.2 to 6.5.1
- Updates CheckerFramework from 0.6.3 to 0.6.5
- Updates Gradle Lombok from 1.6 to 5.0.0

#### Dependencies
- Downgrades Logback from 1.3.0-alpha10 to 1.2.10 (due to accidental alpha usage)
- Updates Microsoft SQL Server driver from 9.4.0.jre11 to 9.4.1.jre11
- Updates JavaX Servlet API from 3.1.0 to 4.0.1
- Updates PostgreSQL driver from 42.2.23 to 42.3.1
- Updates MySQL driver from 8.0.26 to 8.0.27
- Updates TestContainers from 1.16.0 to 1.16.2
- Updates Derby driver from 10.8.2.2 to 10.14.2.0
- Updates Jackson Core and data formats from 2.12.3 to 2.13.1
- Updates Lombok from 1.18.20 to 1.18.22
- Updates Hibernate from 5.5.5.Final to 5.6.3.Final
- Updates Reflections from 0.9.11 to 0.10.2
- Updates Jetbrains Annotations from 19.0.0 to 23.0.0
- Updates JUnit from 5.3.2 to 5.8.2
- Updates Mockito from 3.10.0 to 4.2.0

## Type of change
- [x] Chore (changes to the build process or auxiliary tools)

# Checklist:
- [x] I have performed a self-review of my own code
