### PR TITLE
#635 Resolve `#equals` failing on native proxy objects

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/Unproxy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/Unproxy.java
@@ -1,0 +1,12 @@
+package org.dockbox.hartshorn.core.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.PARAMETER})
+public @interface Unproxy {
+    boolean fallbackToProxy() default false;
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/JavassistApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/JavassistApplicationProxier.java
@@ -56,7 +56,7 @@ public class JavassistApplicationProxier implements ApplicationProxier, Applicat
 
     @Override
     public <T> Exceptional<T> proxy(final TypeContext<T> type, final T instance) {
-        return Exceptional.of(() -> this.handler(type, instance).proxy(this.applicationManager().applicationContext(), instance));
+        return Exceptional.of(() -> this.handler(type, instance).proxy(instance));
     }
 
     @Override
@@ -96,10 +96,10 @@ public class JavassistApplicationProxier implements ApplicationProxier, Applicat
                     return Exceptional.of(proxyInterfaceHandler.handler());
                 }
                 else if (invocationHandler instanceof AnnotationInvocationHandler annotationInvocationHandler) {
-                    return Exceptional.of(() -> new JavassistProxyHandler<>((T) annotationInvocationHandler.annotation()));
+                    return Exceptional.of(() -> new JavassistProxyHandler<>(this.applicationManager().applicationContext(), (T) annotationInvocationHandler.annotation()));
                 }
                 else if (instance instanceof Annotation annotation) {
-                    return Exceptional.of(() -> new JavassistProxyHandler<>(instance, (Class<T>) annotation.annotationType()));
+                    return Exceptional.of(() -> new JavassistProxyHandler<>(this.applicationManager().applicationContext(), instance, (Class<T>) annotation.annotationType()));
                 }
             }
         }
@@ -132,7 +132,7 @@ public class JavassistApplicationProxier implements ApplicationProxier, Applicat
 
     protected <T> ProxyHandler<T> handler(final Class<T> type, final T instance) {
         final Exceptional<ProxyHandler<T>> handler = this.handler(instance);
-        return handler.orElse(() -> new JavassistProxyHandler<>(instance, type)).get();
+        return handler.orElse(() -> new JavassistProxyHandler<>(this.applicationManager().applicationContext(), instance, type)).get();
     }
 
     public void registerProxyLookup(final ProxyLookup lookup) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/ProxyHandler.java
@@ -17,13 +17,13 @@
 
 package org.dockbox.hartshorn.core.proxy;
 
-import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.Context;
+import org.dockbox.hartshorn.core.context.ContextCarrier;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
-public interface ProxyHandler<T> extends Context {
+public interface ProxyHandler<T> extends Context, ContextCarrier {
 
     Exceptional<T> proxyInstance();
 
@@ -33,7 +33,7 @@ public interface ProxyHandler<T> extends Context {
 
     void delegate(final MethodProxyContext<T, ?> property);
 
-    T proxy(ApplicationContext context) throws ApplicationException;
+    T proxy() throws ApplicationException;
 
-    T proxy(ApplicationContext context, T existing) throws ApplicationException;
+    T proxy(T existing) throws ApplicationException;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistInterfaceHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistInterfaceHandler.java
@@ -45,7 +45,7 @@ public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHan
         return this.handler().invoke(proxy, method, null, args);
     }
 
-    public T proxy(final ApplicationContext context) {
+    public T proxy() {
         final T proxy = (T) Proxy.newProxyInstance(this.getClass().getClassLoader(), new Class[]{
                 this.handler().type().type()
         }, this);
@@ -54,8 +54,8 @@ public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHan
     }
 
     @Override
-    public T proxy(final ApplicationContext context, final T existing) throws ApplicationException {
-        return this.handler().proxy(context, existing);
+    public T proxy(final T existing) throws ApplicationException {
+        return this.handler().proxy(existing);
     }
 
     @Override
@@ -85,5 +85,10 @@ public class JavassistInterfaceHandler<T> implements InvocationHandler, ProxyHan
 
     public Object invoke(final Object self, final Method thisMethod, final Method proceed, final Object[] args) throws Throwable {
         return this.handler().invoke(self, thisMethod, proceed, args);
+    }
+
+    @Override
+    public ApplicationContext applicationContext() {
+        return this.handler().applicationContext();
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/ObjectEqualsParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/ObjectEqualsParameterLoaderRule.java
@@ -1,0 +1,21 @@
+package org.dockbox.hartshorn.core.proxy.javassist;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.proxy.ProxyHandler;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+
+public class ObjectEqualsParameterLoaderRule implements ParameterLoaderRule<ParameterLoaderContext> {
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        return parameter.declaredBy().parent().is(Object.class) && parameter.declaredBy().name().equals("equals");
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        final Object argument = args[index];
+        final Exceptional<ProxyHandler<Object>> handler = context.applicationContext().environment().manager().handler(argument);
+        return handler.flatMap(ProxyHandler::instance).orElse(() -> argument).map(a -> (T) a);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/UnproxyParameterLoaderRule.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/UnproxyParameterLoaderRule.java
@@ -1,0 +1,26 @@
+package org.dockbox.hartshorn.core.proxy.javassist;
+
+import org.dockbox.hartshorn.core.annotations.Unproxy;
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.proxy.ProxyHandler;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoaderRule;
+
+public class UnproxyParameterLoaderRule implements ParameterLoaderRule<ParameterLoaderContext> {
+    @Override
+    public boolean accepts(final ParameterContext<?> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        return parameter.annotation(Unproxy.class).present() || parameter.declaredBy().annotation(Unproxy.class).present();
+    }
+
+    @Override
+    public <T> Exceptional<T> load(final ParameterContext<T> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        final Object argument = args[index];
+        final Exceptional<ProxyHandler<Object>> handler = context.applicationContext().environment().manager().handler(argument);
+        return handler.flatMap(ProxyHandler::instance).orElse(() -> {
+            final Unproxy unproxy = parameter.annotation(Unproxy.class).orElse(() -> parameter.declaredBy().annotation(Unproxy.class).orNull()).get();
+            if (unproxy.fallbackToProxy()) return argument;
+            else return null;
+        }).map(a -> (T) a);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/UnproxyingParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/UnproxyingParameterLoader.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.core.proxy.javassist;
+
+import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
+import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
+
+public class UnproxyingParameterLoader extends RuleBasedParameterLoader<ParameterLoaderContext> {
+
+    public UnproxyingParameterLoader() {
+        this.add(new UnproxyParameterLoaderRule());
+        this.add(new ObjectEqualsParameterLoaderRule());
+    }
+
+    @Override
+    protected <T> T loadDefault(final ParameterContext<T> parameter, final int index, final ParameterLoaderContext context, final Object... args) {
+        return (T) args[index];
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProxyPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentProxyPostProcessor.java
@@ -39,7 +39,7 @@ public class ComponentProxyPostProcessor implements ComponentPostProcessor<Servi
     public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
         try {
             final ProxyHandler<T> handler = context.environment().manager().handler(key.type(), instance);
-            return handler.proxy(context, instance);
+            return handler.proxy(instance);
         } catch (final ApplicationException e) {
             return ExceptionHandler.unchecked(e);
         }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -50,9 +50,9 @@ public class ProxyTests {
                 ConcreteProxyTarget.class,
                 ConcreteProxyTarget.class.getMethod("name"),
                 (instance, args, proxyContext) -> "Hartshorn");
-        final ProxyHandler<ConcreteProxyTarget> handler = new JavassistProxyHandler<>(new ConcreteProxyTarget());
+        final ProxyHandler<ConcreteProxyTarget> handler = new JavassistProxyHandler<>(this.applicationContext(), new ConcreteProxyTarget());
         handler.delegate(property);
-        final ConcreteProxyTarget proxy = handler.proxy(this.applicationContext());
+        final ConcreteProxyTarget proxy = handler.proxy();
 
         Assertions.assertNotNull(proxy);
         Assertions.assertNotNull(proxy.name());
@@ -65,11 +65,11 @@ public class ProxyTests {
                 FinalProxyTarget.class,
                 FinalProxyTarget.class.getMethod("name"),
                 (instance, args, proxyContext) -> "Hartshorn");
-        final ProxyHandler<FinalProxyTarget> handler = new JavassistProxyHandler<>(new FinalProxyTarget());
+        final ProxyHandler<FinalProxyTarget> handler = new JavassistProxyHandler<>(this.applicationContext(), new FinalProxyTarget());
         Assertions.assertThrows(ApplicationException.class, () -> handler.delegate(property));
 
         // Ensure the exception isn't thrown after registration
-        final FinalProxyTarget proxy = handler.proxy(this.applicationContext());
+        final FinalProxyTarget proxy = handler.proxy();
 
         Assertions.assertNotNull(proxy);
         Assertions.assertNotNull(proxy.name());
@@ -86,7 +86,7 @@ public class ProxyTests {
         final ConcreteProxyTarget concrete = this.applicationContext().get(ConcreteProxyTarget.class);
         final ProxyHandler<ConcreteProxyTarget> handler = this.applicationContext().environment().manager().handler(TypeContext.of(ConcreteProxyTarget.class), concrete);
         handler.delegate(methodProxyContext);
-        final ConcreteProxyTarget proxy = handler.proxy(this.applicationContext());
+        final ConcreteProxyTarget proxy = handler.proxy();
 
         Assertions.assertNotNull(proxy);
         Assertions.assertNotNull(proxy.name());
@@ -98,7 +98,7 @@ public class ProxyTests {
         final ConcreteProxyTarget concrete = this.applicationContext().get(ConcreteProxyTarget.class);
         final ProxyHandler<ConcreteProxyTarget> handler = this.applicationContext().environment().manager().handler(TypeContext.of(ConcreteProxyTarget.class), concrete);
         Assertions.assertTrue(handler.proxyInstance().absent());
-        handler.proxy(this.applicationContext());
+        handler.proxy();
         Assertions.assertTrue(handler.proxyInstance().present());
     }
 

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -17,8 +17,9 @@
 
 package org.dockbox.hartshorn.core.proxy;
 
-import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.annotations.activate.UseProxying;
+import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
@@ -28,6 +29,7 @@ import org.dockbox.hartshorn.core.proxy.types.FinalProxyTarget;
 import org.dockbox.hartshorn.core.proxy.types.ProviderService;
 import org.dockbox.hartshorn.core.proxy.types.SampleType;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -108,4 +110,31 @@ public class ProxyTests {
         final SampleType type = service.get();
         Assertions.assertNotNull(type);
     }
+
+    @InjectTest
+    public void proxyEqualityTest(final ApplicationContext applicationContext) {
+        final DemoServiceA serviceA1 = applicationContext.get(DemoServiceA.class);
+        final DemoServiceA serviceA2 = applicationContext.get(DemoServiceA.class);
+
+        Assertions.assertEquals(serviceA1, serviceA2);
+
+        final DemoServiceB serviceB1 = applicationContext.get(DemoServiceB.class);
+        final DemoServiceB serviceB2 = applicationContext.get(DemoServiceB.class);
+
+        Assertions.assertEquals(serviceB1, serviceB2);
+
+        final DemoServiceC serviceC1 = applicationContext.get(DemoServiceC.class);
+        final DemoServiceC serviceC2 = applicationContext.get(DemoServiceC.class);
+
+        Assertions.assertEquals(serviceC1, serviceC2);
+    }
+
+    @Service
+    public static interface DemoServiceA { }
+
+    @Service
+    public static class DemoServiceB { }
+
+    @Service
+    public static abstract class DemoServiceC { }
 }


### PR DESCRIPTION
# Description
When `#equals` was called on a proxy object, the method call would be handled as follows:
`proxyA.equals(proxyA)` -> `proxyHandler.invoke(method = #equals, args = [proxyA])` -> `delegate.equals(proxyA)`
As there is no explicit implementation of `#equals` in `proxyA`, this would redirect to the native implementation defined in `Object`, which performs a sameness check `this/delegate == proxyA`, which is `false`.  

To resolve this, the incoming argument should be unproxied, so the argument becomes `delegate` when it is received by `delegate#equals`. However, this leaves one final issue: interface proxies have no delegate instances, so there is no explicit `#equals` method to fall back to. This too has been resolved by performing the equality check inside the proxy handler, checking the proxy instance for sameness, `proxyA == proxyA`. Additional support has been added to this equality check to also support delegate instance equality checks, though this is currently not used by any internal implementations.  

Finally, to support other similar situations from occurring, I added the `@Unproxy` parameter and method annotation. This allows parameters to be unproxied before they are passed into the real or proxied method. 

```java
@Service
public class ServiceA {
    public void doSomething(@Unproxy ServiceB b) {
        // ... b will be the real instance, instead of a proxy
    }
}
```

If there is no instance behind a proxy, the default behavior is to return `null`, so no proxies are accidentally passed while this is not expected. This can be disabled by setting `fallbackToProxy` to `true`, in which case the parameter value will fall back to the proxy instance, if no underlying instance exists.

Fixes #635 

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
