### PR TITLE
#636 Recursively look for parameterized types in `TypeContext#contextsFromParameterizedType`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -192,7 +192,8 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     }
 
     protected static <T> TypeContext<T> of(final ParameterizedType type) {
-        final TypeContext<T> context = of((Class<T>) type.getRawType());
+        // Use new TypeContext to avoid caching parameterized types.
+        final TypeContext<T> context = new TypeContext<>((Class<T>) type.getRawType());
         context.typeParameters = context.contextsFromParameterizedType(type);
         return context;
     }
@@ -322,10 +323,11 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         final Type[] arguments = parameterizedType.getActualTypeArguments();
 
         return Arrays.stream(arguments)
-                .filter(type -> type instanceof Class || type instanceof WildcardType)
+                .filter(type -> type instanceof Class || type instanceof WildcardType || type instanceof ParameterizedType)
                 .map(type -> {
                     if (type instanceof Class clazz) return TypeContext.of(clazz);
                     else if (type instanceof WildcardType wildcard) return WildcardTypeContext.create();
+                    else if (type instanceof ParameterizedType parameterized) return TypeContext.of(parameterized);
                     else return TypeContext.VOID;
                 })
                 .map(type -> (TypeContext<?>) type)

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -26,6 +26,7 @@ import org.dockbox.hartshorn.core.context.element.ConstructorContext;
 import org.dockbox.hartshorn.core.context.element.FieldContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.MethodModifier;
+import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.TypeConversionException;
@@ -482,4 +483,28 @@ public class ReflectTests {
         Assertions.assertTrue(annotation.present());
         Assertions.assertEquals("impl", annotation.get().value());
     }
+
+    @Test
+    public void genericTypeTests() {
+        final ParameterContext<?> parameter = TypeContext.of(this).method("genericTestMethod", List.class)
+                .get()
+                .parameters()
+                .get(0);
+
+        final TypeContext<?> first = parameter.genericType();
+
+        Assertions.assertTrue(first.is(List.class));
+        Assertions.assertEquals(1, first.typeParameters().size());
+
+        final TypeContext<?> second = first.typeParameters().get(0);
+        Assertions.assertTrue(second.is(List.class));
+        Assertions.assertEquals(1, second.typeParameters().size());
+
+        final TypeContext<?> third = second.typeParameters().get(0);
+        Assertions.assertTrue(third.is(String.class));
+        Assertions.assertEquals(0, third.typeParameters().size());
+    }
+
+    public void genericTestMethod(final List<List<String>> nestedGeneric) { }
+
 }


### PR DESCRIPTION
# Description
`TypeContext#contextsFromParameterizedType` does not look up `ParameterizedType`s, causing e.g. the signature `List<Set<String>>` to have a `TypeContext<List>` without type parameters, as the `Set<String>` is a parameterized type instead of a direct class reference or wildcard. See #636 for further explanation and testing scenario.

Fixes #636

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
