### PR TITLE
#644 Restructure application factories and permit custom prefix context

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.core.boot;
+
+import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.InjectConfiguration;
+import org.dockbox.hartshorn.core.annotations.activate.Activator;
+import org.dockbox.hartshorn.core.annotations.inject.InjectConfig;
+import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
+import org.dockbox.hartshorn.core.context.ModifiableContextCarrier;
+import org.dockbox.hartshorn.core.context.PrefixContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.services.ServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+
+public abstract class AbstractActivatingApplicationFactory<
+        Self extends ApplicationFactory<Self, C>,
+        C extends SelfActivatingApplicationContext,
+        M extends ObservableApplicationManager & ModifiableContextCarrier
+        > extends AbstractApplicationFactory<Self, C> {
+
+    private enum FactoryState {
+        WAITING, CREATING
+    }
+
+    private FactoryState state = FactoryState.WAITING;
+    @Getter(AccessLevel.PROTECTED)
+    private Logger logger;
+
+    @Override
+    public C create() {
+        if (this.state == FactoryState.CREATING) {
+            throw new IllegalStateException("Application factory is already creating a new application context");
+        }
+        this.state = FactoryState.CREATING;
+        this.validate();
+
+        this.logger = LoggerFactory.getLogger(this.activator.type());
+        final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+
+        // Alternative to InetAddress.getLocalHost().getHostName()
+        final String host = runtimeMXBean.getName().split("@")[1];
+
+        this.logger().info("Starting application " + this.activator.name() + " on " + host + " using Java " + runtimeMXBean.getVmVersion() + " with PID " + runtimeMXBean.getPid());
+
+        final long applicationStartTimestamp = System.currentTimeMillis();
+        final M manager = this.createManager();
+
+        final PrefixContext prefixContext = this.prefixContext.apply(manager);
+        this.prefixes.forEach(prefixContext::prefix);
+        final ApplicationEnvironment environment = this.applicationEnvironment.apply(prefixContext, manager);
+
+        final C applicationContext = this.createContext(environment);
+
+        manager.applicationContext(applicationContext);
+
+        applicationContext.addActivator(new ServiceImpl());
+
+        final ApplicationConfigurator configurator = this.applicationConfigurator;
+        configurator.configure(manager);
+
+        for (final Annotation serviceActivator : this.serviceActivators)
+            applicationContext.addActivator(serviceActivator);
+
+        // Always load Hartshorn internals first
+        configurator.bind(manager, Hartshorn.PACKAGE_PREFIX);
+
+        final Activator activator = this.activatorAnnotation();
+        final Set<String> scanPackages = Set.of(activator.scanPackages());
+        final Collection<String> scanPrefixes = HartshornUtils.merge(this.prefixes, scanPackages);
+
+        if (activator.includeBasePackage())
+            scanPrefixes.add(this.activator.type().getPackageName());
+
+        final Set<InjectConfiguration> configurations = Arrays.stream(activator.configs())
+                .map(InjectConfig::value)
+                .map(TypeContext::of)
+                .map(applicationContext::get)
+                .collect(Collectors.toSet());
+
+        configurator.apply(manager, configurations);
+        configurator.apply(manager, this.injectConfigurations);
+
+        for (final String prefix : scanPrefixes)
+            configurator.bind(manager, prefix);
+
+        applicationContext.processPrefixQueue();
+        applicationContext.lookupActivatables();
+
+        this.componentPreProcessors.forEach(applicationContext::add);
+        applicationContext.process();
+
+        this.componentPostProcessors.forEach(applicationContext::add);
+
+        for (final LifecycleObserver observer : manager.observers())
+            observer.onStarted(applicationContext);
+
+        final long applicationStartedTimestamp = System.currentTimeMillis();
+
+
+
+        final double startupTime = ((double) (applicationStartedTimestamp - applicationStartTimestamp)) / 1000;
+        final double jvmUptime = ((double) runtimeMXBean.getUptime()) / 1000;
+
+        this.logger().info("Started " + Hartshorn.PROJECT_NAME + " in " + startupTime + " seconds (JVM running for " + jvmUptime + ")");
+
+        this.state = FactoryState.WAITING;
+
+        return applicationContext;
+    }
+
+    protected void validate() {
+        if (this.applicationConfigurator == null) throw new IllegalArgumentException("Application configurator is not set");
+        if (this.applicationProxier == null) throw new IllegalArgumentException("Application proxier is not set");
+        if (this.applicationLogger == null) throw new IllegalArgumentException("Application logger is not set");
+        if (this.activator == null) throw new IllegalArgumentException("Application activator is not set");
+        if (this.exceptionHandler == null) throw new IllegalArgumentException("Exception handler is not set");
+        if (this.componentLocator == null) throw new IllegalArgumentException("Component locator is not set");
+        if (this.resourceLocator == null) throw new IllegalArgumentException("Resource locator is not set");
+        if (this.metaProvider == null) throw new IllegalArgumentException("Meta provider is not set");
+    }
+
+    protected void registerHooks(final C applicationContext, final M manager) {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            this.logger().info("Runtime shutting down, notifying observers");
+            for (final LifecycleObserver observer : manager.observers()) {
+                this.logger().debug("Notifying " + observer.getClass().getSimpleName() + " of shutdown");
+                observer.onExit(applicationContext);
+            }
+        }));
+    }
+
+    public abstract Self loadDefaults();
+
+    protected abstract M createManager();
+
+    protected abstract C createContext(final ApplicationEnvironment environment);
+
+    protected abstract Activator activatorAnnotation();
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractApplicationFactory.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
+package org.dockbox.hartshorn.core.boot;
+
+import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.InjectConfiguration;
+import org.dockbox.hartshorn.core.MetaProvider;
+import org.dockbox.hartshorn.core.Modifiers;
+import org.dockbox.hartshorn.core.annotations.activate.Activator;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
+import org.dockbox.hartshorn.core.context.PrefixContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.services.ComponentLocator;
+import org.dockbox.hartshorn.core.services.ComponentPostProcessor;
+import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Getter(AccessLevel.PROTECTED)
+public abstract class AbstractApplicationFactory<Self extends ApplicationFactory<Self, C>, C extends ApplicationContext> implements ApplicationFactory<Self, C> {
+
+    protected ApplicationConfigurator applicationConfigurator;
+    protected ApplicationProxier applicationProxier;
+    protected ApplicationFSProvider applicationFSProvider;
+    protected ApplicationLogger applicationLogger;
+    protected ExceptionHandler exceptionHandler;
+    protected BiFunction<PrefixContext, ApplicationManager, ApplicationEnvironment> applicationEnvironment;
+    protected Function<ApplicationContext, ComponentLocator> componentLocator;
+    protected Function<ApplicationContext, ClasspathResourceLocator> resourceLocator;
+    protected Function<ApplicationContext, MetaProvider> metaProvider;
+    protected Function<ApplicationManager, PrefixContext> prefixContext;
+
+    protected TypeContext<?> activator;
+
+    protected final Set<InjectConfiguration> injectConfigurations = HartshornUtils.emptyConcurrentSet();
+    protected final Set<Annotation> serviceActivators = HartshornUtils.emptyConcurrentSet();
+    protected final Set<Modifiers> modifiers = HartshornUtils.emptyConcurrentSet();
+    protected final Set<String> arguments = HartshornUtils.emptyConcurrentSet();
+    protected final Set<String> prefixes = HartshornUtils.emptyConcurrentSet();
+    protected final Set<ComponentPostProcessor<?>> componentPostProcessors = HartshornUtils.emptyConcurrentSet();
+    protected final Set<ComponentPreProcessor<?>> componentPreProcessors = HartshornUtils.emptyConcurrentSet();
+
+    @Override
+    public Self modifiers(final Modifiers... modifiers) {
+        this.modifiers.addAll(Set.of(modifiers));
+        return this.self();
+    }
+
+    @Override
+    public Self modifier(final Modifiers modifier) {
+        this.modifiers.add(modifier);
+        return this.self();
+    }
+
+    @Override
+    public Self activator(final TypeContext<?> activator) {
+        final Exceptional<Activator> annotation = activator.annotation(Activator.class);
+        if (annotation.absent())
+            throw new IllegalArgumentException("Application type should be decorated with @Activator");
+
+        if (activator.isAbstract())
+            throw new IllegalArgumentException("Bootstrap type cannot be abstract, got " + activator.name());
+
+        this.activator = activator;
+        return this.self();
+    }
+
+    @Override
+    public Self argument(final String argument) {
+        this.arguments.add(argument);
+        return this.self();
+    }
+
+    @Override
+    public Self arguments(final String... args) {
+        this.arguments.addAll(Set.of(args));
+        return this.self();
+    }
+
+    @Override
+    public Self serviceActivators(final Set<Annotation> annotations) {
+        this.serviceActivators.addAll(annotations);
+        return this.self();
+    }
+
+    @Override
+    public Self postProcessor(final ComponentPostProcessor<?> modifier) {
+        this.componentPostProcessors.add(modifier);
+        return this.self();
+    }
+
+    @Override
+    public Self preProcessor(final ComponentPreProcessor<?> processor) {
+        this.componentPreProcessors.add(processor);
+        return this.self();
+    }
+
+    @Override
+    public Self serviceActivator(final Annotation annotation) {
+        this.serviceActivators.add(annotation);
+        return this.self();
+    }
+
+    @Override
+    public Self prefix(final String prefix) {
+        this.prefixes.add(prefix);
+        return this.self();
+    }
+
+    @Override
+    public Self prefixes(final Set<String> prefixes) {
+        this.prefixes.addAll(prefixes);
+        return this.self();
+    }
+
+    @Override
+    public Self prefixes(final String... prefixes) {
+        this.prefixes.addAll(Set.of(prefixes));
+        return this.self();
+    }
+
+    @Override
+    public Self configuration(final InjectConfiguration injectConfiguration) {
+        this.injectConfigurations.add(injectConfiguration);
+        return this.self();
+    }
+
+    @Override
+    public Self applicationConfigurator(final ApplicationConfigurator applicationConfigurator) {
+        this.applicationConfigurator = applicationConfigurator;
+        return this.self();
+    }
+
+    @Override
+    public Self applicationProxier(final ApplicationProxier applicationProxier) {
+        this.applicationProxier = applicationProxier;
+        return this.self();
+    }
+
+    @Override
+    public Self applicationLogger(final ApplicationLogger applicationLogger) {
+        this.applicationLogger = applicationLogger;
+        return this.self();
+    }
+
+    @Override
+    public Self applicationFSProvider(final ApplicationFSProvider applicationFSProvider) {
+        this.applicationFSProvider = applicationFSProvider;
+        return this.self();
+    }
+
+    @Override
+    public Self applicationEnvironment(final BiFunction<PrefixContext, ApplicationManager, ApplicationEnvironment> applicationEnvironment) {
+        this.applicationEnvironment = applicationEnvironment;
+        return this.self();
+    }
+
+    @Override
+    public Self componentLocator(final Function<ApplicationContext, ComponentLocator> componentLocator) {
+        this.componentLocator = componentLocator;
+        return this.self();
+    }
+
+    @Override
+    public Self metaProvider(final Function<ApplicationContext, MetaProvider> metaProvider) {
+        this.metaProvider = metaProvider;
+        return this.self();
+    }
+
+    @Override
+    public Self resourceLocator(final Function<ApplicationContext, ClasspathResourceLocator> resourceLocator) {
+        this.resourceLocator = resourceLocator;
+        return this.self();
+    }
+
+    @Override
+    public Self exceptionHandler(final ExceptionHandler exceptionHandler) {
+        this.exceptionHandler = exceptionHandler;
+        return this.self();
+    }
+
+    @Override
+    public Self prefixContext(final Function<ApplicationManager, PrefixContext> prefixContext) {
+        this.prefixContext = prefixContext;
+        return this.self();
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationFactory.java
@@ -22,6 +22,7 @@ import org.dockbox.hartshorn.core.Modifiers;
 import org.dockbox.hartshorn.core.InjectConfiguration;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
+import org.dockbox.hartshorn.core.context.PrefixContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.services.ComponentLocator;
 import org.dockbox.hartshorn.core.services.ComponentPostProcessor;
@@ -29,6 +30,7 @@ import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public interface ApplicationFactory<Self extends ApplicationFactory<Self, C>, C extends ApplicationContext> {
@@ -55,7 +57,7 @@ public interface ApplicationFactory<Self extends ApplicationFactory<Self, C>, C 
 
     Self applicationFSProvider(ApplicationFSProvider applicationFSProvider);
 
-    Self applicationEnvironment(Function<ApplicationManager, ApplicationEnvironment> applicationEnvironment);
+    Self applicationEnvironment(BiFunction<PrefixContext, ApplicationManager, ApplicationEnvironment> applicationEnvironment);
 
     Self componentLocator(Function<ApplicationContext, ComponentLocator> componentLocator);
 
@@ -66,6 +68,10 @@ public interface ApplicationFactory<Self extends ApplicationFactory<Self, C>, C 
     Self metaProvider(Function<ApplicationContext, MetaProvider> metaProvider);
 
     Self resourceLocator(Function<ApplicationContext, ClasspathResourceLocator> resourceLocator);
+
+    Self exceptionHandler(ExceptionHandler exceptionHandler);
+
+    Self prefixContext(Function<ApplicationManager, PrefixContext> prefixContext);
 
     Self prefix(String prefix);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ClasspathResourceLocator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ClasspathResourceLocator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.boot;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationFactory.java
@@ -17,274 +17,34 @@
 
 package org.dockbox.hartshorn.core.boot;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.core.InjectConfiguration;
 import org.dockbox.hartshorn.core.InjectorMetaProvider;
-import org.dockbox.hartshorn.core.MetaProvider;
-import org.dockbox.hartshorn.core.Modifiers;
-import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
 import org.dockbox.hartshorn.core.annotations.activate.Activator;
-import org.dockbox.hartshorn.core.annotations.inject.InjectConfig;
+import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
 import org.dockbox.hartshorn.core.annotations.activate.UseProxying;
-import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
 import org.dockbox.hartshorn.core.context.HartshornApplicationContext;
 import org.dockbox.hartshorn.core.context.HartshornApplicationEnvironment;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.services.ComponentLocator;
+import org.dockbox.hartshorn.core.context.ReflectionsPrefixContext;
 import org.dockbox.hartshorn.core.services.ComponentLocatorImpl;
-import org.dockbox.hartshorn.core.services.ComponentPostProcessor;
-import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
-import org.dockbox.hartshorn.core.services.ServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import lombok.Getter;
-import lombok.Setter;
 
-public class HartshornApplicationFactory implements ApplicationFactory<HartshornApplicationFactory, HartshornApplicationContext> {
+public class HartshornApplicationFactory extends AbstractActivatingApplicationFactory<HartshornApplicationFactory, HartshornApplicationContext, HartshornApplicationManager> {
 
     @Getter
     private final HartshornApplicationFactory self = this;
 
-    @Setter
-    private ApplicationConfigurator applicationConfigurator;
-    @Setter
-    private ApplicationProxier applicationProxier;
-    @Setter
-    private ApplicationFSProvider applicationFSProvider;
-    @Setter
-    private ApplicationLogger applicationLogger;
-    @Setter
-    private ExceptionHandler exceptionHandler;
-    @Setter
-    private Function<ApplicationManager, ApplicationEnvironment> applicationEnvironment;
-    @Setter
-    private Function<ApplicationContext, ComponentLocator> componentLocator;
-    @Setter
-    private Function<ApplicationContext, ClasspathResourceLocator> resourceLocator;
-    @Setter
-    private Function<ApplicationContext, MetaProvider> metaProvider;
-
-    private TypeContext<?> activator;
-
-    private final Set<InjectConfiguration> injectConfigurations = HartshornUtils.emptyConcurrentSet();
-    private final Set<Annotation> serviceActivators = HartshornUtils.emptyConcurrentSet();
-    private final Set<Modifiers> modifiers = HartshornUtils.emptyConcurrentSet();
-    private final Set<String> arguments = HartshornUtils.emptyConcurrentSet();
-    private final Set<String> prefixes = HartshornUtils.emptyConcurrentSet();
-    private final Set<ComponentPostProcessor<?>> componentPostProcessors = HartshornUtils.emptyConcurrentSet();
-    private final Set<ComponentPreProcessor<?>> componentPreProcessors = HartshornUtils.emptyConcurrentSet();
-
     @Override
-    public HartshornApplicationFactory modifiers(final Modifiers... modifiers) {
-        this.modifiers.addAll(Set.of(modifiers));
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory modifier(final Modifiers modifier) {
-        this.modifiers.add(modifier);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory activator(final TypeContext<?> activator) {
-        final Exceptional<Activator> annotation = activator.annotation(Activator.class);
-        if (annotation.absent())
-            throw new IllegalArgumentException("Application type should be decorated with @Activator");
-
-        if (activator.isAbstract())
-            throw new IllegalArgumentException("Bootstrap type cannot be abstract, got " + activator.name());
-
-        this.activator = activator;
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory argument(final String argument) {
-        this.arguments.add(argument);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory arguments(final String... args) {
-        this.arguments.addAll(Set.of(args));
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory serviceActivators(final Set<Annotation> annotations) {
-        this.serviceActivators.addAll(annotations);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory postProcessor(final ComponentPostProcessor<?> modifier) {
-        this.componentPostProcessors.add(modifier);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory preProcessor(final ComponentPreProcessor<?> processor) {
-        this.componentPreProcessors.add(processor);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory serviceActivator(final Annotation annotation) {
-        this.serviceActivators.add(annotation);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory prefix(final String prefix) {
-        this.prefixes.add(prefix);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory prefixes(final Set<String> prefixes) {
-        this.prefixes.addAll(prefixes);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory prefixes(final String... prefixes) {
-        this.prefixes.addAll(Set.of(prefixes));
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationFactory configuration(final InjectConfiguration injectConfiguration) {
-        this.injectConfigurations.add(injectConfiguration);
-        return this.self();
-    }
-
-    @Override
-    public HartshornApplicationContext create() {
-        this.validate();
-
-        final Logger logger = LoggerFactory.getLogger(this.activator.type());
-        final RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
-
-        // Alternative to InetAddress.getLocalHost().getHostName()
-        final String host = runtimeMXBean.getName().split("@")[1];
-
-        logger.info("Starting application " + this.activator.name() + " on " + host + " using Java " + runtimeMXBean.getVmVersion() + " with PID " + runtimeMXBean.getPid());
-
-        final long applicationStartTimestamp = System.currentTimeMillis();
-        final HartshornApplicationManager manager = new HartshornApplicationManager(
-                this.activator,
-                this.applicationLogger,
-                this.applicationProxier,
-                this.applicationFSProvider,
-                this.exceptionHandler
-        );
-        final ApplicationEnvironment environment = this.applicationEnvironment.apply(manager);
-
-        final HartshornApplicationContext applicationContext = new HartshornApplicationContext(
-                environment,
-                this.componentLocator,
-                this.resourceLocator,
-                this.metaProvider,
-                this.activator,
-                this.arguments,
-                this.modifiers
-        );
-        manager.applicationContext(applicationContext);
-
-        applicationContext.addActivator(new ServiceImpl());
-
-        final ApplicationConfigurator configurator = this.applicationConfigurator;
-        configurator.configure(manager);
-
-        for (final Annotation serviceActivator : this.serviceActivators)
-            applicationContext.addActivator(serviceActivator);
-
-        // Always load Hartshorn internals first
-        configurator.bind(manager, Hartshorn.PACKAGE_PREFIX);
-
-        final Activator activator = this.activatorAnnotation();
-        final Set<String> scanPackages = Set.of(activator.scanPackages());
-        final Collection<String> scanPrefixes = HartshornUtils.merge(this.prefixes, scanPackages);
-
-        if (activator.includeBasePackage())
-            scanPrefixes.add(this.activator.type().getPackageName());
-
-        final Set<InjectConfiguration> configurations = Arrays.stream(activator.configs())
-                .map(InjectConfig::value)
-                .map(TypeContext::of)
-                .map(applicationContext::get)
-                .collect(Collectors.toSet());
-
-        configurator.apply(manager, configurations);
-        configurator.apply(manager, this.injectConfigurations);
-
-        for (final String prefix : scanPrefixes)
-            configurator.bind(manager, prefix);
-
-        applicationContext.processPrefixQueue();
-        applicationContext.lookupActivatables();
-
-        this.componentPreProcessors.forEach(applicationContext::add);
-        applicationContext.process();
-
-        this.componentPostProcessors.forEach(applicationContext::add);
-
-        for (final LifecycleObserver observer : manager.observers())
-            observer.onStarted(applicationContext);
-
-        final long applicationStartedTimestamp = System.currentTimeMillis();
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            logger.info("Runtime shutting down, notifying observers");
-            for (final LifecycleObserver observer : manager.observers()) {
-                logger.debug("Notifying " + observer.getClass().getSimpleName() + " of shutdown");
-                observer.onExit(applicationContext);
-            }
-        }));
-
-        final double startupTime = ((double) (applicationStartedTimestamp - applicationStartTimestamp)) / 1000;
-        final double jvmUptime = ((double) runtimeMXBean.getUptime()) / 1000;
-
-        logger.info("Started " + Hartshorn.PROJECT_NAME + " in " + startupTime + " seconds (JVM running for " + jvmUptime + ")");
-
-        return applicationContext;
-    }
-
-    private Activator activatorAnnotation() {
-        return this.activator.annotation(Activator.class).get();
-    }
-
-    private void validate() {
-        if (this.applicationConfigurator == null) throw new IllegalArgumentException("Application configurator is not set");
-        if (this.applicationProxier == null) throw new IllegalArgumentException("Application proxier is not set");
-        if (this.applicationLogger == null) throw new IllegalArgumentException("Application logger is not set");
-        if (this.activator == null) throw new IllegalArgumentException("Application activator is not set");
-        if (this.exceptionHandler == null) throw new IllegalArgumentException("Exception handler is not set");
-        if (this.componentLocator == null) throw new IllegalArgumentException("Component locator is not set");
-        if (this.resourceLocator == null) throw new IllegalArgumentException("Resource locator is not set");
-        if (this.metaProvider == null) throw new IllegalArgumentException("Meta provider is not set");
-    }
-
     public HartshornApplicationFactory loadDefaults() {
         return this.applicationLogger(new HartshornApplicationLogger())
                 .applicationConfigurator(new HartshornApplicationConfigurator())
                 .applicationProxier(new JavassistApplicationProxier())
                 .applicationFSProvider(new HartshornApplicationFSProvider())
-                .applicationEnvironment(manager -> new HartshornApplicationEnvironment(this.prefixes, manager))
+                .applicationEnvironment(HartshornApplicationEnvironment::new)
                 .exceptionHandler(new HartshornExceptionHandler())
+                .prefixContext(ReflectionsPrefixContext::new)
                 .componentLocator(ComponentLocatorImpl::new)
                 .resourceLocator(HartshornClasspathResourceLocator::new)
                 .metaProvider(InjectorMetaProvider::new)
@@ -299,5 +59,34 @@ public class HartshornApplicationFactory implements ApplicationFactory<Hartshorn
                         return UseProxying.class;
                     }
                 });
+    }
+
+    @Override
+    protected Activator activatorAnnotation() {
+        return this.activator.annotation(Activator.class).get();
+    }
+
+    @Override
+    protected HartshornApplicationManager createManager() {
+        return new HartshornApplicationManager(
+                this.activator,
+                this.applicationLogger,
+                this.applicationProxier,
+                this.applicationFSProvider,
+                this.exceptionHandler
+        );
+    }
+
+    @Override
+    protected HartshornApplicationContext createContext(final ApplicationEnvironment environment) {
+        return new HartshornApplicationContext(
+                environment,
+                this.componentLocator,
+                this.resourceLocator,
+                this.metaProvider,
+                this.activator,
+                this.arguments,
+                this.modifiers
+        );
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornApplicationManager.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core.boot;
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.context.LogExclude;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.ModifiableContextCarrier;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
@@ -34,7 +35,7 @@ import lombok.Setter;
 
 @LogExclude
 @Getter
-public class HartshornApplicationManager implements ApplicationManager {
+public class HartshornApplicationManager implements ObservableApplicationManager, ModifiableContextCarrier {
 
     private static final String BANNER = """
                  _   _            _       _                     \s
@@ -132,9 +133,10 @@ public class HartshornApplicationManager implements ApplicationManager {
         return this.applicationProxier.handler(instance);
     }
 
-    public void applicationContext(final ApplicationContext applicationContext) {
+    public HartshornApplicationManager applicationContext(final ApplicationContext applicationContext) {
         if (this.applicationContext == null) this.applicationContext = applicationContext;
         else throw new IllegalArgumentException("Application context has already been configured");
+        return this;
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornClasspathResourceLocator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/HartshornClasspathResourceLocator.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.boot;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ObservableApplicationManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ObservableApplicationManager.java
@@ -15,16 +15,10 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.core.context;
+package org.dockbox.hartshorn.core.boot;
 
-import java.lang.annotation.Annotation;
 import java.util.Set;
 
-public interface ActivatorSource {
-
-    Set<Annotation> activators();
-
-    boolean hasActivator(Class<? extends Annotation> activator);
-
-    <A> A activator(Class<A> activator);
+public interface ObservableApplicationManager extends ApplicationManager {
+    Set<LifecycleObserver> observers();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/SelfActivatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/SelfActivatingApplicationContext.java
@@ -15,16 +15,18 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.core.context;
+package org.dockbox.hartshorn.core.boot;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
 
 import java.lang.annotation.Annotation;
-import java.util.Set;
 
-public interface ActivatorSource {
+public interface SelfActivatingApplicationContext extends ApplicationContext {
+    void addActivator(Annotation annotation);
 
-    Set<Annotation> activators();
+    void processPrefixQueue();
 
-    boolean hasActivator(Class<? extends Annotation> activator);
+    void process();
 
-    <A> A activator(Class<A> activator);
+    void lookupActivatables();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/AbstractPrefixContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/AbstractPrefixContext.java
@@ -1,18 +1,18 @@
 /*
- *  Copyright (C) 2020 Guus Lieben
+ * Copyright (C) 2020 Guus Lieben
  *
- *  This framework is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2.1 of the
- *  License, or (at your option) any later version.
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
- *  the GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
 package org.dockbox.hartshorn.core.context;
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core.context;
 import org.dockbox.hartshorn.core.AnnotationHelper;
 import org.dockbox.hartshorn.core.CustomMultiMap;
 import org.dockbox.hartshorn.core.MultiMap;
+import org.dockbox.hartshorn.core.boot.ApplicationManager;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 import java.lang.annotation.Annotation;
@@ -36,16 +37,13 @@ import lombok.Getter;
 public abstract class AbstractPrefixContext<S> extends DefaultContext implements PrefixContext {
 
     @Getter(AccessLevel.PROTECTED)
-    private final ApplicationEnvironment environment;
+    private final ApplicationManager manager;
 
     private final Map<String, S> prefixes = new ConcurrentHashMap<>();
     private final MultiMap<Class<? extends Annotation>, Class<? extends Annotation>> annotationHierarchy = new CustomMultiMap<>(CopyOnWriteArrayList::new);
 
-    protected AbstractPrefixContext(final ApplicationEnvironment environment, final Iterable<String> initialPrefixes) {
-        this.environment = environment;
-        for (final String initialPrefix : initialPrefixes) {
-            this.prefix(initialPrefix);
-        }
+    protected AbstractPrefixContext(final ApplicationManager manager) {
+        this.manager = manager;
     }
 
     protected abstract S process(String prefix);
@@ -61,7 +59,7 @@ public abstract class AbstractPrefixContext<S> extends DefaultContext implements
     @Override
     public void prefix(final String prefix) {
         if (!this.prefixes.containsKey(prefix)) {
-            this.environment.manager().log().debug("Registering and caching prefix '%s'".formatted(prefix));
+            this.manager().log().debug("Registering and caching prefix '%s'".formatted(prefix));
             this.prefixes.put(prefix, this.process(prefix));
         }
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -48,6 +48,7 @@ import org.dockbox.hartshorn.core.boot.ApplicationProxier;
 import org.dockbox.hartshorn.core.boot.ClasspathResourceLocator;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.boot.LifecycleObservable;
+import org.dockbox.hartshorn.core.boot.SelfActivatingApplicationContext;
 import org.dockbox.hartshorn.core.context.element.FieldContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -88,7 +89,7 @@ import javax.inject.Named;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-public class HartshornApplicationContext extends DefaultContext implements ApplicationContext {
+public class HartshornApplicationContext extends DefaultContext implements SelfActivatingApplicationContext {
 
     private static final Pattern ARGUMENTS = Pattern.compile("-H([a-zA-Z0-9\\.]+)=(.+)");
 
@@ -155,6 +156,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         this.bind(Key.of(LifecycleObservable.class), this.environment().manager());
     }
 
+    @Override
     public void addActivator(final Annotation annotation) {
         if (this.activators.contains(annotation)) return;
         final TypeContext<? extends Annotation> annotationType = TypeContext.of(annotation.annotationType());
@@ -235,6 +237,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         return (A) this.activators.stream().filter(a -> a.annotationType().equals(activator)).findFirst().orElse(null);
     }
 
+    @Override
     public void processPrefixQueue() {
         String scan;
         while ((scan = this.prefixQueue.poll()) != null) {
@@ -257,6 +260,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         }
     }
 
+    @Override
     public void process() {
         this.processPrefixQueue();
         final Collection<ComponentContainer> containers = this.locator().containers(ComponentType.FUNCTIONAL);
@@ -635,6 +639,7 @@ public class HartshornApplicationContext extends DefaultContext implements Appli
         this.inHierarchy(contract, hierarchy -> hierarchy.add(Providers.of(instance)));
     }
 
+    @Override
     public void lookupActivatables() {
         final Collection<TypeContext<? extends ComponentProcessor>> children = this.environment().children(ComponentProcessor.class);
         for (final TypeContext<? extends ComponentProcessor> processor : children) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationEnvironment.java
@@ -34,10 +34,10 @@ public class HartshornApplicationEnvironment implements ApplicationEnvironment {
     @Getter private final boolean isCI;
     @Getter private final ApplicationManager manager;
 
-    public HartshornApplicationEnvironment(final Collection<String> prefixes, final ApplicationManager manager) {
+    public HartshornApplicationEnvironment(final PrefixContext prefixContext, final ApplicationManager manager) {
         this.manager = manager;
         this.isCI = HartshornUtils.isCI();
-        this.prefixContext = new ReflectionsPrefixContext(this, prefixes);
+        this.prefixContext = prefixContext;
         this.manager().log().debug("Created new application environment (isCI: %s, prefixCount: %d)".formatted(this.isCI(), this.prefixContext().prefixes().size()));
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ModifiableContextCarrier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ModifiableContextCarrier.java
@@ -17,14 +17,6 @@
 
 package org.dockbox.hartshorn.core.context;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
-
-public interface ActivatorSource {
-
-    Set<Annotation> activators();
-
-    boolean hasActivator(Class<? extends Annotation> activator);
-
-    <A> A activator(Class<A> activator);
+public interface ModifiableContextCarrier extends ContextCarrier {
+    public ModifiableContextCarrier applicationContext(ApplicationContext context);
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/PrefixContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/PrefixContext.java
@@ -1,18 +1,18 @@
 /*
- *  Copyright (C) 2020 Guus Lieben
+ * Copyright (C) 2020 Guus Lieben
  *
- *  This framework is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU Lesser General Public License as
- *  published by the Free Software Foundation, either version 2.1 of the
- *  License, or (at your option) any later version.
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
- *  the GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public License
- *  along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
 package org.dockbox.hartshorn.core.context;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -18,8 +18,9 @@
 package org.dockbox.hartshorn.core;
 
 import org.dockbox.hartshorn.core.annotations.Base;
+import org.dockbox.hartshorn.core.boot.ApplicationManager;
 import org.dockbox.hartshorn.core.bridge.BridgeImpl;
-import org.dockbox.hartshorn.core.context.ApplicationEnvironment;
+import org.dockbox.hartshorn.core.context.PrefixContext;
 import org.dockbox.hartshorn.core.context.ReflectionsPrefixContext;
 import org.dockbox.hartshorn.core.context.element.AnnotatedElementModifier;
 import org.dockbox.hartshorn.core.context.element.ConstructorContext;
@@ -182,16 +183,18 @@ public class ReflectTests {
     }
 
     @InjectTest
-    void testAnnotatedTypesReturnsAllInPrefix(final ApplicationEnvironment environment) {
-        final ReflectionsPrefixContext context = new ReflectionsPrefixContext(environment, HartshornUtils.asList("org.dockbox.hartshorn.core.types"));
+    void testAnnotatedTypesReturnsAllInPrefix(final ApplicationManager manager) {
+        final PrefixContext context = new ReflectionsPrefixContext(manager);
+        context.prefix("org.dockbox.hartshorn.core.types");
         final Collection<TypeContext<?>> types = context.types(Demo.class);
         Assertions.assertEquals(1, types.size());
         Assertions.assertEquals(ReflectTestType.class, types.iterator().next().type());
     }
 
     @InjectTest
-    void testSubTypesReturnsAllSubTypes(final ApplicationEnvironment environment) {
-        final ReflectionsPrefixContext context = new ReflectionsPrefixContext(environment, HartshornUtils.asList("org.dockbox.hartshorn.core.types"));
+    void testSubTypesReturnsAllSubTypes(final ApplicationManager manager) {
+        final PrefixContext context = new ReflectionsPrefixContext(manager);
+        context.prefix("org.dockbox.hartshorn.core.types");
         final Collection<TypeContext<? extends ParentTestType>> types = context.children(ParentTestType.class);
         Assertions.assertEquals(1, types.size());
         Assertions.assertEquals(ReflectTestType.class, types.iterator().next().type());

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/testsuite/HartshornFactoryTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/testsuite/HartshornFactoryTests.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.testsuite;
 
 import org.dockbox.hartshorn.core.boot.ApplicationFactory;


### PR DESCRIPTION
# Description
Currently the active `PrefixContext` of a given `ApplicationEnvironment` can not be configured at all. The existing implementation, `ReflectionsPrefixContext` is hardcoded into the `HartshornApplicationEnvironment`.

https://github.com/GuusLieben/Hartshorn/blob/7c321cda4b2b4c07de8ed477bc184add17f57447/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationEnvironment.java#L40

This PR adds the option to configure a custom prefix context, using the `ReflectionsPrefixContext` as the default implementation.  

Additionally, the existing `HartshornApplicationFactory` has been split into dedicated abstract factories, to allow for easier custom implementations.

Fixes #644

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
