### PR TITLE
#651 Add default `org.slf4j.Logger` binding to `ApplicationLogger` provided logger

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -62,6 +62,7 @@ import org.dockbox.hartshorn.core.services.ComponentPostProcessor;
 import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
 import org.dockbox.hartshorn.core.services.ComponentProcessor;
 import org.dockbox.hartshorn.core.services.ProcessingOrder;
+import org.slf4j.Logger;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -153,6 +154,8 @@ public class HartshornApplicationContext extends DefaultContext implements SelfA
         this.bind(Key.of(ApplicationProxier.class), this.environment().manager());
         this.bind(Key.of(ApplicationManager.class), this.environment().manager());
         this.bind(Key.of(LifecycleObservable.class), this.environment().manager());
+
+        this.bind(Key.of(Logger.class), (Supplier<Logger>) this::log);
     }
 
     @Override

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -42,11 +42,13 @@ import org.dockbox.hartshorn.core.types.TypeWithEnabledInjectField;
 import org.dockbox.hartshorn.core.types.TypeWithFailingConstructor;
 import org.dockbox.hartshorn.core.types.User;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.testsuite.InjectTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
 
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -388,5 +390,10 @@ public class ApplicationContextTests {
         Assertions.assertNotNull(component);
         Assertions.assertNotNull(component.context());
         Assertions.assertSame(sampleContext, component.context());
+    }
+
+    @InjectTest
+    void loggerCanBeInjected(final Logger logger) {
+        Assertions.assertNotNull(logger);
     }
 }


### PR DESCRIPTION
# Description
By default, only the `ApplicationLogger` type is bound, while the `org.slf4j.Logger` it provides is not. This PR adds a default supplier-based binding to the provided logger.

Fixes #651

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
