### PR TITLE
#649 Don't attempt to access types from closed module(s)

### DIFF
--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -396,4 +396,12 @@ public class ApplicationContextTests {
     void loggerCanBeInjected(final Logger logger) {
         Assertions.assertNotNull(logger);
     }
+
+    @Test
+    void testStringProvision() {
+        final Key<String> key = Key.of(String.class, "license");
+        this.applicationContext.bind(key, "MIT");
+        final String license = this.applicationContext.get(key);
+        Assertions.assertEquals("MIT", license);
+    }
 }


### PR DESCRIPTION
# Description
In specific cases, such as providing license keys or other similar values, it can be useful to define the following component provider:
```java
@Service
public class LicenseService {
    @Provider("license")
    public String license() {
        return "MyLicenseKey";
    }
}
```
However, this yields an exception when obtaining the component (applicationContext.get(Key.of(String.class, "license"))) as fields are attempted to be populated on a closed module.
```java
Unable to make field private final byte[] java.lang.String.value accessible: module java.base does not "opens java.lang" to unnamed module @44e81672
```

As this is caused by the `setAccessible(true)` statement (see below), this can be resolved by replacing said statement with `trySetAccessible()`. As this only affects get/set actions on hidden fields, it is safe to silently fail get/set actions on these fields. To still provide some feedback, `#get` will return `Exceptional(-, ApplicationException(Field $field is not accessible!))` when the field is not accessible. Field metadata can still be accessed, though its value cannot be changed.

https://github.com/GuusLieben/Hartshorn/blob/e5c6d1fad7e0555d529c86e6892a03297a6bccb2/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/FieldContext.java#L48

Fixes #649

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
