### PR TITLE
#639 Add `permitProcessing` to component stereotype

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
@@ -137,4 +137,12 @@ public @interface Component {
      * @see ComponentContainer#permitsProxying()
      */
     boolean permitProxying() default true;
+
+    /**
+     * Indicates whether the component should be allowed to be processed by {@link org.dockbox.hartshorn.core.services.ComponentProcessor}s.
+     * Processed components may be modified by changing the behavior or content of the component.
+     *
+     * @return {@code true} if the component should be processed
+     */
+    boolean permitProcessing() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
@@ -53,6 +53,8 @@ public interface ComponentContainer {
 
     boolean permitsProxying();
 
+    boolean permitsProcessing();
+
     static String id(final ApplicationContext context, final TypeContext<?> type) {
         return id(context, type, false);
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
@@ -119,6 +119,11 @@ public class ComponentContainerImpl implements ComponentContainer {
     }
 
     @Override
+    public boolean permitsProcessing() {
+        return this.annotation.permitProcessing();
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || this.getClass() != o.getClass()) return false;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -32,6 +32,7 @@ import org.dockbox.hartshorn.core.types.CircularDependencyB;
 import org.dockbox.hartshorn.core.types.ComponentType;
 import org.dockbox.hartshorn.core.types.ContextInjectedType;
 import org.dockbox.hartshorn.core.types.NonComponentType;
+import org.dockbox.hartshorn.core.types.NonProcessableType;
 import org.dockbox.hartshorn.core.types.NonProxyComponentType;
 import org.dockbox.hartshorn.core.types.Person;
 import org.dockbox.hartshorn.core.types.SampleContext;
@@ -403,5 +404,12 @@ public class ApplicationContextTests {
         this.applicationContext.bind(key, "MIT");
         final String license = this.applicationContext.get(key);
         Assertions.assertEquals("MIT", license);
+    }
+
+    @Test
+    void testNonProcessableComponent() {
+        final NonProcessableType nonProcessableType = this.applicationContext().get(NonProcessableType.class);
+        Assertions.assertNotNull(nonProcessableType);
+        Assertions.assertNull(nonProcessableType.nonNullIfProcessed());
     }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableType.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableType.java
@@ -1,0 +1,11 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.dockbox.hartshorn.core.annotations.stereotype.Component;
+
+import lombok.Getter;
+
+@Component(permitProcessing = false, permitProxying = false)
+public class NonProcessableType {
+    @Getter
+    private String nonNullIfProcessed;
+}

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
@@ -1,0 +1,29 @@
+package org.dockbox.hartshorn.core.types;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.services.ComponentPostProcessor;
+
+@AutomaticActivation
+public class NonProcessableTypeProcessor implements ComponentPostProcessor<Service> {
+    @Override
+    public Class<Service> activator() {
+        return Service.class;
+    }
+
+    @Override
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        final TypeContext<T> type = key.type();
+        type.field("nonNullIfProcessed").get().set(instance, "processed");
+        return instance;
+    }
+
+    @Override
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        return instance instanceof NonProcessableType;
+    }
+}


### PR DESCRIPTION
# Description
Currently all components are automatically processed when it passes any `ComponentProcessor`'s preconditions. However, it may not always be desired that a component is processed. This may be to circumvent specific modifications, for testing purposes, or other specific use-cases.  

This PR adds a new attribute to the component stereotype: `permitProcessing`. Like `permitProxying`, this indicates specifically how the component should be treated during post-processing. While `permitProxying` targets specific processors, `permitProcessing` will target the proccessing job itself. If it is set to `false`, the component will not be processed by any processor.

Fixes #639

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
