### PR TITLE
#662 Resolve components being processed twice on partial prefixes

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MultiMap.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MultiMap.java
@@ -27,6 +27,10 @@ public abstract class MultiMap<K, V> {
 
     protected abstract Collection<V> baseCollection();
 
+    public Collection<V> allValues() {
+        return this.values().stream().flatMap(Collection::stream).toList();
+    }
+
     public void putAll(final K key, final Collection<V> values) {
         values.forEach(v -> this.put(key, v));
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
@@ -52,6 +52,7 @@ public class ComponentLocatorImpl implements ComponentLocator {
         final List<ComponentContainer> containers = this.applicationContext().environment()
                 .types(prefix, Component.class, false)
                 .stream()
+                .filter(type -> this.cache.allValues().stream().noneMatch(container -> container.type().equals(type)))
                 .map(type -> new ComponentContainerImpl(this.applicationContext(), type))
                 .filter(container -> !container.type().isAnnotation()) // Exclude extended annotations
                 .map(ComponentContainer.class::cast)


### PR DESCRIPTION
# Description
#662 reports that components may be processed twice if they are on two partial prefix matches. In this case that meant that any prefix that matched both `nz.pumbas.*` and `nz.pumbas.halpbot.*` would be processed twice.  

The direct solution is relatively easy, which is to filter the incoming components in the `ComponentLocator` implementation. However @pumbas600's logs indicated a second issue; the locating order was completely incorrect.
```java
11:53:25.960 [ main           ] @ 18284 -> o.d.h.c.s.ComponentLocatorImpl         INFO  - Located 46 components with prefix nz.pumbas.halpbot in 145ms 
11:53:26.001 [ main           ] @ 18284 -> o.d.h.c.s.ComponentLocatorImpl         INFO  - Located 21 components with prefix org.dockbox.hartshorn in 12ms 
11:53:26.024 [ main           ] @ 18284 -> o.d.h.c.s.ComponentLocatorImpl         INFO  - Located 48 components with prefix nz.pumbas in 3ms 
```
While the location of `o.d.h.*` is not relevant in this example, it is not intended that `nz.pumbas.halpbot` would be processed before `nz.pumbas` when these are both known beforehand. This was originally resolved by partially matching prefixes, but that change got lost when I refactored a large part of the core bootstrapping process.  
To resolve this, the prefix queue in the application context needed to be changed to a `PriorityQueue`. To allow external parties to modify this queue, the `Comparator` of the queue has been made public.

Fixes #662

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Integration testing (with Halpbot FW)
- [x] Manual testing

**Test Configuration**:
@pumbas600 tested a snapshot build of this solution with his setup of Halpbot. The issue is confirmed to have been resolved.

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
