### PR TITLE
#661 Add field-support to `@Provider`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/InjectorMetaProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/InjectorMetaProvider.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.core;
 
 import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.AnnotatedElementContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.TypedOwner;
@@ -66,8 +66,8 @@ public class InjectorMetaProvider implements MetaProvider {
     }
 
     @Override
-    public boolean singleton(final MethodContext<?, ?> method) {
-        return method.annotation(Singleton.class).present();
+    public boolean singleton(final AnnotatedElementContext<?> element) {
+        return element.annotation(Singleton.class).present();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MetaProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MetaProvider.java
@@ -17,9 +17,9 @@
 
 package org.dockbox.hartshorn.core;
 
-import org.dockbox.hartshorn.core.domain.TypedOwner;
-import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.AnnotatedElementContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.TypedOwner;
 
 /**
  * The type responsible for providing metadata on given types.
@@ -44,7 +44,7 @@ public interface MetaProvider {
      * @return <code>true</code> if the type is a singleton, or <code>false</code>
      */
     boolean singleton(TypeContext<?> type);
-    boolean singleton(MethodContext<?, ?> method);
+    boolean singleton(AnnotatedElementContext<?> element);
 
     /**
      * Looks up whether the given type is a component-like type. This only applies if

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Provider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/Provider.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  * @since 21.2
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 public @interface Provider {
     String value() default "";
     int priority() default -1;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServicePreProcessor.java
@@ -18,40 +18,55 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.Key;
+import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
 import org.dockbox.hartshorn.core.annotations.inject.Provider;
-import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.AnnotatedElementContext;
+import org.dockbox.hartshorn.core.context.element.FieldContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.inject.ProviderContext;
 
 import java.util.List;
+import java.util.function.Function;
 
 @AutomaticActivation
 public final class ProviderServicePreProcessor implements ServicePreProcessor<UseServiceProvision> {
 
     @Override
     public boolean preconditions(final ApplicationContext context, final Key<?> key) {
-        return !key.type().methods(Provider.class).isEmpty();
+        return !(key.type().methods(Provider.class).isEmpty() && key.type().fields(Provider.class).isEmpty());
     }
 
     @Override
     public <T> void process(final ApplicationContext context, final Key<T> key) {
         final TypeContext<T> type = key.type();
         final List<MethodContext<?, T>> methods = type.methods(Provider.class);
-        context.log().debug("Found " + methods.size() + " providers in " + type.name());
+        final List<FieldContext<?>> fields = type.fields(Provider.class);
+
+        context.log().debug("Found " + (methods.size() + fields.size()) + " method providers in " + type.name());
+
         for (final MethodContext<?, T> method : methods) {
-            final boolean singleton = context.meta().singleton(method);
-            final Provider annotation = method.annotation(Provider.class).get();
-
-            final Key<?> providerKey = "".equals(annotation.value())
-                    ? Key.of(method.returnType())
-                    : Key.of(method.returnType(), annotation.value());
-
-            final ProviderContext<?> providerContext = new ProviderContext<>(((Key<Object>) providerKey), singleton, annotation.priority(), () -> method.invoke(context).rethrowUnchecked().orNull());
-            context.add(providerContext);
+            this.process(context, method, MethodContext::returnType, m -> m.invoke(context));
         }
+
+        for (final FieldContext<?> field : fields) {
+            this.process(context, field, FieldContext::type, f -> f.get(context.get(key)));
+        }
+    }
+
+    private <T extends AnnotatedElementContext<?>> void process(final ApplicationContext context, final T element, final Function<T, TypeContext<?>> type, final Function<T, Exceptional<?>> getter) {
+        final boolean singleton = context.meta().singleton(element);
+        final Provider annotation = element.annotation(Provider.class).get();
+
+        final Key<?> providerKey = "".equals(annotation.value())
+                ? Key.of(type.apply(element).type())
+                : Key.of(type.apply(element).type(), annotation.value());
+
+        final ProviderContext<?> providerContext = new ProviderContext<>(((Key<Object>) providerKey), singleton, annotation.priority(), () -> getter.apply(element).rethrowUnchecked().orNull());
+        context.add(providerContext);
     }
 
     @Override

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -63,6 +63,7 @@ import test.types.SampleFieldImplementation;
 import test.types.SampleImplementation;
 import test.types.SampleInterface;
 import test.types.meta.SampleMetaAnnotatedImplementation;
+import test.types.provision.FieldProviderService;
 import test.types.provision.ProvidedInterface;
 import test.types.scan.SampleAnnotatedImplementation;
 
@@ -78,8 +79,8 @@ public class ApplicationContextTests {
         return Stream.of(
                 Arguments.of(null, "Provision", false, null, false),
                 Arguments.of("named", "NamedProvision", false, null, false),
-                Arguments.of("field", "FieldProvision", true, null, false),
-                Arguments.of("namedField", "NamedFieldProvision", true, "named", false),
+                Arguments.of("parameter", "ParameterProvision", true, null, false),
+                Arguments.of("namedParameter", "NamedParameterProvision", true, "named", false),
                 Arguments.of("singleton", "SingletonProvision", false, null, true)
         );
     }
@@ -280,6 +281,29 @@ public class ApplicationContextTests {
             Assertions.assertNotNull(second);
             Assertions.assertSame(provided, second);
         }
+    }
+
+    @Test
+    void testFieldProviders() {
+        this.applicationContext().bind("test.types.provision");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+        final ProvidedInterface field = this.applicationContext().get(Key.of(ProvidedInterface.class, "field"));
+        Assertions.assertNotNull(field);
+        Assertions.assertEquals("Field", field.name());
+    }
+
+    @Test
+    void testSingletonFieldProviders() {
+        this.applicationContext().bind("test.types.provision");
+        ((HartshornApplicationContext) this.applicationContext()).process();
+        this.applicationContext().get(FieldProviderService.class);
+        final ProvidedInterface field = this.applicationContext().get(Key.of(ProvidedInterface.class, "singletonField"));
+        Assertions.assertNotNull(field);
+
+        final ProvidedInterface field2 = this.applicationContext().get(Key.of(ProvidedInterface.class, "singletonField"));
+        Assertions.assertNotNull(field2);
+
+        Assertions.assertSame(field, field2);
     }
 
     @Test

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 Guus Lieben
+ *
+ * This framework is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
+ */
+
 package org.dockbox.hartshorn.core.types;
 
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/hartshorn-core/src/test/java/test/types/provision/FieldProviderService.java
+++ b/hartshorn-core/src/test/java/test/types/provision/FieldProviderService.java
@@ -15,14 +15,20 @@
  * along with this library. If not, see {@literal<http://www.gnu.org/licenses/>}.
  */
 
-package org.dockbox.hartshorn.core.types;
+package test.types.provision;
 
-import org.dockbox.hartshorn.core.annotations.stereotype.Component;
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 
-import lombok.Getter;
+import javax.inject.Singleton;
 
-@Component(permitProcessing = false, permitProxying = false)
-public class NonProcessableType {
-    @Getter
-    private String nonNullIfProcessed;
+@Service
+public class FieldProviderService {
+
+    @Provider("field")
+    private final ProvidedInterface field = () -> "Field";
+
+    @Singleton
+    @Provider("singletonField")
+    private final ProvidedInterface singletonField = () -> "Field";
 }

--- a/hartshorn-core/src/test/java/test/types/provision/SampleProviderService.java
+++ b/hartshorn-core/src/test/java/test/types/provision/SampleProviderService.java
@@ -38,14 +38,14 @@ public class SampleProviderService {
         return () -> "NamedProvision";
     }
 
-    @Provider("field")
-    public ProvidedInterface withField(final SampleField field) {
-        return () -> "FieldProvision";
+    @Provider("parameter")
+    public ProvidedInterface withParameter(final SampleField field) {
+        return () -> "ParameterProvision";
     }
 
-    @Provider("namedField")
+    @Provider("namedParameter")
     public ProvidedInterface withNamedField(@Named("named") final SampleField field) {
-        return () -> "NamedFieldProvision";
+        return () -> "NamedParameterProvision";
     }
 
     @Singleton


### PR DESCRIPTION
# Description
Currently when a field value is injected, for example through `@Value`, the only way to turn this into a provider is by creating a getter for the field and annotating the getter with `@Provider`. For example:
```java
@Configuration(source = "classpath:license", filetype = FileFormats.PROPERTIES)
public class MyLicense {

    @Value("license.key")
    private String licenseKey;

    @Singleton
    @Provider("license")
    public String get() {
        return this.licenseKey;
    }
}
```

This PR adds the ability to mark fields with `@Provider`, which allows you to directly create a binding of that field. For example:
```java
@Configuration(source = "classpath:license", filetype = FileFormats.PROPERTIES)
public class MyLicense {
    @Singleton
    @Provider("license")
    @Value("license.key")
    private String licenseKey;
}
```

Fixes #661

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
