### PR TITLE
#667 Deprecate Tasks API

### DIFF
--- a/hartshorn-cache/hartshorn-cache.gradle
+++ b/hartshorn-cache/hartshorn-cache.gradle
@@ -19,5 +19,4 @@ apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
     implementation 'org.dockbox.hartshorn:hartshorn-core'
-    implementation 'org.dockbox.hartshorn:hartshorn-tasks'
 }

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java
@@ -22,9 +22,10 @@ import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.Enableable;
-import org.dockbox.hartshorn.core.task.TaskRunner;
 
 import java.util.Locale;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import javax.inject.Inject;
 
@@ -69,7 +70,8 @@ public class CacheImpl<T> implements Cache<T>, Enableable {
     private void scheduleEviction() {
         // Negative amounts are considered non-expiring
         if (this.expiration.amount() > 0) {
-            TaskRunner.create(this.applicationContext).acceptDelayed(this::evict, this.expiration.amount(), this.expiration.unit());
+            final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
+            executor.schedule(this::evict, this.expiration.amount(), this.expiration.unit());
             this.applicationContext.log().debug("Scheduled eviction after %d %s".formatted(this.expiration.amount(), this.expiration.unit().name().toLowerCase(Locale.ROOT)));
         }
     }

--- a/hartshorn-commands/hartshorn-commands.gradle
+++ b/hartshorn-commands/hartshorn-commands.gradle
@@ -20,6 +20,5 @@ apply from: "$project.rootDir/gradle/publications.gradle"
 dependencies {
     implementation 'org.dockbox.hartshorn:hartshorn-core'
     implementation 'org.dockbox.hartshorn:hartshorn-i18n'
-    implementation 'org.dockbox.hartshorn:hartshorn-tasks'
     implementation 'org.dockbox.hartshorn:hartshorn-events'
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/cli/SimpleCommandCLI.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/cli/SimpleCommandCLI.java
@@ -24,7 +24,6 @@ import org.dockbox.hartshorn.commands.SystemSubject;
 import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.task.ThreadUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,8 +41,6 @@ public class SimpleCommandCLI implements CommandCLI {
     private ApplicationContext context;
     @Inject
     private CommandGateway gateway;
-    @Inject
-    private ThreadUtils threads;
 
     @Getter
     @Setter

--- a/hartshorn-events/hartshorn-events.gradle
+++ b/hartshorn-events/hartshorn-events.gradle
@@ -19,5 +19,4 @@ apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
     api 'org.dockbox.hartshorn:hartshorn-core'
-    implementation 'org.dockbox.hartshorn:hartshorn-tasks'
 }

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/AbstractTask.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/AbstractTask.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core.task;
 
+@Deprecated(forRemoval = true, since = "22.2")
 public abstract class AbstractTask implements Task {
 
     protected abstract void perform();

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/PipelineTask.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/PipelineTask.java
@@ -20,6 +20,7 @@ package org.dockbox.hartshorn.core.task;
 import org.dockbox.hartshorn.core.task.pipeline.pipelines.Pipeline;
 import org.dockbox.hartshorn.core.task.pipeline.pipes.EqualPipe;
 
+@Deprecated(forRemoval = true, since = "22.2")
 public abstract class PipelineTask extends AbstractTask {
 
     private final Pipeline<Void> pipeline;

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/SimpleTaskRunner.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/SimpleTaskRunner.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+@Deprecated(forRemoval = true, since = "22.2")
 @ComponentBinding(TaskRunner.class)
 public class SimpleTaskRunner extends TaskRunner {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/Task.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/Task.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core.task;
 
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface Task {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/TaskRunner.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/TaskRunner.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 
 import java.util.concurrent.TimeUnit;
 
+@Deprecated(forRemoval = true, since = "22.2")
 public abstract class TaskRunner {
 
     public static TaskRunner create(final ApplicationContext context) {

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/ThreadUtils.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/ThreadUtils.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 /**
  * A low-level interface for easy thread-based actions.
  */
+@Deprecated(forRemoval = true, since = "22.2")
 public interface ThreadUtils {
 
     /**

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/ThreadUtilsImpl.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/ThreadUtilsImpl.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+@Deprecated(forRemoval = true, since = "22.2")
 @ComponentBinding(ThreadUtils.class)
 public class ThreadUtilsImpl implements ThreadUtils {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/CancelBehaviour.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/CancelBehaviour.java
@@ -25,6 +25,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public enum CancelBehaviour {
     NON_CANCELLABLE,
     DISCARD(output -> null),

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/PipelineDirection.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/PipelineDirection.java
@@ -17,6 +17,10 @@
 
 package org.dockbox.hartshorn.core.task.pipeline;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public enum PipelineDirection {
     FORWARD,
     BACKWARD,

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/exceptions/IllegalPipeException.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/exceptions/IllegalPipeException.java
@@ -17,6 +17,10 @@
 
 package org.dockbox.hartshorn.core.task.pipeline.exceptions;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public class IllegalPipeException extends RuntimeException {
 
     public IllegalPipeException(final String errorMessage, final Throwable throwable) {

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/exceptions/IllegalPipelineException.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/exceptions/IllegalPipelineException.java
@@ -17,6 +17,10 @@
 
 package org.dockbox.hartshorn.core.task.pipeline.exceptions;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public class IllegalPipelineException extends RuntimeException {
 
     public IllegalPipelineException(final String errorMessage, final Throwable throwable) {

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/AbstractPipeline.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/AbstractPipeline.java
@@ -43,7 +43,9 @@ import lombok.Getter;
  * nullable.
  * @param <P> The input type of the pipeline.
  * @param <I> The input type of the first pipe.
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
  */
+@Deprecated(forRemoval = true, since = "22.2")
 public abstract class AbstractPipeline<P, I> {
 
     private final List<IPipe<I, I>> pipes = new CopyOnWriteArrayList<>();

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/ConvertiblePipeline.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/ConvertiblePipeline.java
@@ -29,6 +29,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.function.Function;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public class ConvertiblePipeline<P, I> extends AbstractPipeline<P, I> {
 
     private final TypeContext<I> inputClass;

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/ConvertiblePipelineSource.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/ConvertiblePipelineSource.java
@@ -21,6 +21,10 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public class ConvertiblePipelineSource<I> extends ConvertiblePipeline<I, I> {
 
     /**

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/Pipeline.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipelines/Pipeline.java
@@ -22,6 +22,10 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.task.pipeline.pipes.IPipe;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 public class Pipeline<I> extends AbstractPipeline<I, I> {
 
     /**

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/CancellablePipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/CancellablePipe.java
@@ -21,6 +21,10 @@ import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.task.pipeline.pipelines.AbstractPipeline;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface CancellablePipe<I, O> extends ComplexPipe<I, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ComplexPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ComplexPipe.java
@@ -21,6 +21,10 @@ import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.task.pipeline.pipelines.AbstractPipeline;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface ComplexPipe<I, O> extends IPipe<I, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/EqualPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/EqualPipe.java
@@ -19,6 +19,10 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface EqualPipe<O> extends StandardPipe<O, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/IPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/IPipe.java
@@ -25,7 +25,9 @@ import org.dockbox.hartshorn.core.task.pipeline.pipelines.AbstractPipeline;
  * of a {@link AbstractPipeline pipeline}.
  * @param <I> The input type of the pipe.
  * @param <O> The output type of the pipe.
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
  */
+@Deprecated(forRemoval = true, since = "22.2")
 public interface IPipe<I, O> {
 
     /**

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/InputPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/InputPipe.java
@@ -20,6 +20,10 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface InputPipe<I, O> extends StandardPipe<I, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ListenerPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/ListenerPipe.java
@@ -20,6 +20,10 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface ListenerPipe<I> extends StandardPipe<I, I> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/OutputPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/OutputPipe.java
@@ -20,6 +20,10 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface OutputPipe<O> extends StandardPipe<O, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/Pipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/Pipe.java
@@ -20,6 +20,10 @@ package org.dockbox.hartshorn.core.task.pipeline.pipes;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface Pipe<I, O> extends StandardPipe<I, O> {
 

--- a/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/StandardPipe.java
+++ b/hartshorn-tasks/src/main/java/org/dockbox/hartshorn/core/task/pipeline/pipes/StandardPipe.java
@@ -21,6 +21,10 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
+/**
+ * @deprecated Moved to https://github.com/GuusLieben/JPipelines
+ */
+@Deprecated(forRemoval = true, since = "22.2")
 @FunctionalInterface
 public interface StandardPipe<I, O> extends IPipe<I, O> {
 


### PR DESCRIPTION
# Description
The Tasks API has gone largely unused, the only reference to `ThreadUtils` being an unused reference in the `SimpleCommandCLI` (to be removed), and the `TaskRunner` being used once in the `CacheImpl` (to be replaced).

https://github.com/GuusLieben/Hartshorn/blob/21a262a874a430ff190f9152a40a5f3fd22f2a95/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/cli/SimpleCommandCLI.java#L46

https://github.com/GuusLieben/Hartshorn/blob/21a262a874a430ff190f9152a40a5f3fd22f2a95/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java#L72

All types of the Tasks API have been marked for removal. The Pipeline API has been marked for removal from Hartshorn, and has been moved to a separate repository at https://github.com/GuusLieben/JPipelines

Fixes #667

## Type of change
- [x] Deprecation

# Checklist:
- [x] Related issue number is linked in pull request title
