### PR TITLE
#670 Deprecate `HartshornUtils#emptyMap`

### DIFF
--- a/examples/src/caching/java/org/dockbox/hartshorn/demo/caching/services/CachingService.java
+++ b/examples/src/caching/java/org/dockbox/hartshorn/demo/caching/services/CachingService.java
@@ -20,7 +20,6 @@ package org.dockbox.hartshorn.demo.caching.services;
 import org.dockbox.hartshorn.cache.annotations.CacheService;
 import org.dockbox.hartshorn.cache.annotations.Cached;
 import org.dockbox.hartshorn.cache.annotations.EvictCache;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ApplicationState;
 import org.dockbox.hartshorn.core.boot.ApplicationState.Started;
@@ -33,6 +32,7 @@ import org.dockbox.hartshorn.events.annotations.Listener;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A simple service capable of caching collections. If you only use automatic cache expiration through {@link Cached#expires()},
@@ -43,7 +43,7 @@ import java.util.Map;
 @CacheService("user-cache")
 public abstract class CachingService {
 
-    private final Map<User, Long> lastModified = HartshornUtils.emptyMap();
+    private final Map<User, Long> lastModified = new ConcurrentHashMap<>();
 
     /**
      * Gets a singleton list containing a single {@link User}. The user is always unique, and is stored alongside

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/MethodCommandExecutorContext.java
@@ -27,7 +27,6 @@ import org.dockbox.hartshorn.commands.arguments.CommandParameterLoaderContext;
 import org.dockbox.hartshorn.commands.definition.CommandElement;
 import org.dockbox.hartshorn.commands.events.CommandEvent;
 import org.dockbox.hartshorn.commands.events.CommandEvent.Before;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.DefaultCarrierContext;
@@ -44,6 +43,7 @@ import org.dockbox.hartshorn.i18n.Message;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -106,7 +106,7 @@ public class MethodCommandExecutorContext<T> extends DefaultCarrierContext imple
 
     public Map<String, CommandParameterContext> parameters() {
         if (this.parameters == null) {
-            this.parameters = HartshornUtils.emptyMap();
+            this.parameters = new HashMap<>();
             final LinkedList<ParameterContext<?>> parameters = this.method().parameters();
             for (int i = 0; i < parameters.size(); i++) {
                 final ParameterContext<?> parameter = parameters.get(i);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/HartshornUtils.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/HartshornUtils.java
@@ -75,7 +75,7 @@ public final class HartshornUtils {
 
     /**
      * Constructs a new unique map from a given set of {@link Entry entries}. If no entries are
-     * provided {@link HartshornUtils#emptyMap()} is returned. The constructed map is not concurrent.
+     * provided an empty {@link Map} is returned. The constructed map is not concurrent.
      * Entries can easily be created using {@link org.dockbox.hartshorn.core.domain.tuple.Tuple#of(Object, Object)}
      *
      * @param <K> The (super)type of all keys in the entry set
@@ -89,28 +89,15 @@ public final class HartshornUtils {
     @SafeVarargs
     public static <K, V> Map<K, V> ofEntries(final Entry<? extends K, ? extends V>... entries) {
         if (0 == entries.length) { // implicit null check of entries array
-            return HartshornUtils.emptyMap();
+            return new HashMap<>();
         }
         else {
-            final Map<K, V> map = HartshornUtils.emptyMap();
+            final Map<K, V> map = new HashMap<>();
             for (final Entry<? extends K, ? extends V> entry : entries) {
                 map.put(entry.getKey(), entry.getValue());
             }
             return map;
         }
-    }
-
-    /**
-     * Returns a new empty map. This should be used globally instead of instantiating maps manually.
-     * The returned map is not concurrent.
-     *
-     * @param <K> The (super)type of the map key-set
-     * @param <V> The (super)type of the map value-set
-     *
-     * @return The new map
-     */
-    public static <K, V> Map<K, V> emptyMap() {
-        return new HashMap<>();
     }
 
     public static <T> Set<T> emptyConcurrentSet() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MultiMap.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/MultiMap.java
@@ -20,10 +20,11 @@ package org.dockbox.hartshorn.core;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class MultiMap<K, V> {
 
-    private final Map<K, Collection<V>> map = HartshornUtils.emptyMap();
+    private final Map<K, Collection<V>> map = new ConcurrentHashMap<>();
 
     protected abstract Collection<V> baseCollection();
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -606,7 +607,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
     protected Map<Class<?>, Annotation> validate() {
         if (this.parent().isVoid()) return super.validate();
         else if (this.annotations == null) {
-            final Map<Class<?>, Annotation> annotations = HartshornUtils.emptyMap();
+            final Map<Class<?>, Annotation> annotations = new HashMap<>();
             Class<?> type = this.type();
             while (type != null) {
                 for (final Annotation annotation : type.getDeclaredAnnotations()) {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/HartshornUtilTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/HartshornUtilTests.java
@@ -111,12 +111,6 @@ public class HartshornUtilTests {
         Assertions.assertTrue(map.isEmpty());
     }
 
-    @Test
-    void testEmptyMapIsModifiable() {
-        final Map<Object, Object> map = HartshornUtils.emptyMap();
-        Assertions.assertDoesNotThrow(() -> map.put(1, "two"));
-    }
-
     @ParameterizedTest
     @MethodSource("modifiableCollections")
     void testCollectionCanBeModified(final Collection<String> collection) {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
@@ -34,10 +34,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 
 import org.dockbox.hartshorn.core.GenericType;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
-import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
+import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
@@ -50,6 +49,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -157,7 +157,7 @@ public class JacksonObjectMapper extends DefaultObjectMapper {
     }
 
     private Map<String, Object> flatInternal(final FlatNodeSupplier node) {
-        final Map<String, Object> flat = HartshornUtils.emptyMap();
+        final Map<String, Object> flat = new HashMap<>();
         try {
             final JsonNode jsonNode = node.get();
             this.addKeys("", jsonNode, flat);

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/mapping/ObjectMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/mapping/ObjectMapper.java
@@ -18,7 +18,6 @@
 package org.dockbox.hartshorn.data.mapping;
 
 import org.dockbox.hartshorn.core.GenericType;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.data.FileFormat;
@@ -26,6 +25,7 @@ import org.dockbox.hartshorn.data.FileFormat;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 
 public interface ObjectMapper {
@@ -73,7 +73,7 @@ public interface ObjectMapper {
     Map<String, Object> flat(URL url);
 
     default Map<String, Object> flat(final URI uri) {
-        return Exceptional.of(() -> this.flat(uri.toURL())).or(HartshornUtils.emptyMap());
+        return Exceptional.of(() -> this.flat(uri.toURL())).or(new HashMap<>());
     }
 
     <T> Exceptional<Boolean> write(Path path, T content);

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandlerRegistry.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandlerRegistry.java
@@ -19,15 +19,15 @@ package org.dockbox.hartshorn.events.handle;
 
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.events.parents.Event;
-import org.dockbox.hartshorn.core.HartshornUtils;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.Getter;
 
 public final class EventHandlerRegistry {
 
-    @Getter private final Map<TypeContext<? extends Event>, EventHandler> handlers = HartshornUtils.emptyMap();
+    @Getter private final Map<TypeContext<? extends Event>, EventHandler> handlers = new ConcurrentHashMap<>();
 
     public EventHandler handler(final TypeContext<? extends Event> type) {
         EventHandler handler = this.handlers.get(type);

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/MessageTemplate.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/MessageTemplate.java
@@ -17,8 +17,7 @@
 
 package org.dockbox.hartshorn.i18n;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
-
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -38,10 +37,10 @@ public class MessageTemplate implements Message {
         this.language = language;
         this.key = key;
 
-        this.formattingArgs = HartshornUtils.emptyMap();
+        this.formattingArgs = new HashMap<>();
         this.formattingArgs.put(this.language(), args);
 
-        this.resourceMap = HartshornUtils.emptyMap();
+        this.resourceMap = new HashMap<>();
         this.resourceMap.put(language, value);
 
         this.defaultValue = value;
@@ -103,7 +102,7 @@ public class MessageTemplate implements Message {
         final String temp = this.safeValue();
         final Object[] args = this.formattingArgs.getOrDefault(this.language(), new Object[0]);
         if (0 == args.length) return temp;
-        final Map<String, String> map = HartshornUtils.emptyMap();
+        final Map<String, String> map = new HashMap<>();
 
         for (int i = 0; i < args.length; i++) {
             final String arg = "" + args[i];

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -41,6 +41,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -106,7 +107,7 @@ public final class TranslationBatchGenerator {
         final Properties properties = new Properties();
         properties.load(new StringReader(batch));
 
-        final Map<String, String> files = HartshornUtils.emptyMap();
+        final Map<String, String> files = new HashMap<>();
 
         for (final File file : TranslationBatchGenerator.existingFiles()) {
             final List<String> strings = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
@@ -174,7 +175,7 @@ public final class TranslationBatchGenerator {
     }
 
     public static Map<String, String> collect(final ApplicationContext context) {
-        final Map<String, String> batch = HartshornUtils.emptyMap();
+        final Map<String, String> batch = new HashMap<>();
         for (final ComponentContainer container : context.locator().containers()) {
             final TypeContext<?> type = container.type();
             final List<? extends MethodContext<?, ?>> methods = type.methods(InjectTranslation.class);

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -18,7 +18,6 @@
 package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.config.annotations.Value;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.boot.LifecycleObserver;
@@ -35,6 +34,7 @@ import org.dockbox.hartshorn.web.servlet.WebServlet;
 import org.dockbox.hartshorn.web.servlet.WebServletFactory;
 import org.dockbox.hartshorn.web.servlet.WebServletImpl;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -59,7 +59,7 @@ public class HttpWebServerInitializer implements LifecycleObserver {
 
     @Override
     public void onStarted(final ApplicationContext applicationContext) {
-        final Map<String, Servlet> servlets = HartshornUtils.emptyMap();
+        final Map<String, Servlet> servlets = new HashMap<>();
 
         final ControllerContext controllerContext = applicationContext.first(ControllerContext.class).get();
         for (final RequestHandlerContext context : controllerContext.requestHandlerContexts()) {


### PR DESCRIPTION
# Description
`HartshornUtils#emptyMap` was originally supposed to be deprecated by #659, however it was originally missed when deprecating. This PR removes the utility method, and refactors existing usages.

Fixes #670

## Type of change
- [x] Deprecation

# Checklist:
- [x] Related issue number is linked in pull request title
