### PR TITLE
#672 Rename ambiguous `ServiceMethodPostProcessor` and `ServiceAnnotatedMethodPostProcessor`

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheEvictionMethodPostProcessor.java
@@ -24,12 +24,12 @@ import org.dockbox.hartshorn.cache.context.CacheContext;
 import org.dockbox.hartshorn.cache.context.CacheMethodContext;
 import org.dockbox.hartshorn.cache.context.CacheMethodContextImpl;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 
 /**
- * The {@link ServiceAnnotatedMethodPostProcessor} responsible for {@link EvictCache}
+ * The {@link ServiceAnnotatedMethodInterceptorPostProcessor} responsible for {@link EvictCache}
  * decorated methods. This delegates functionality to the underlying {@link org.dockbox.hartshorn.cache.CacheManager}
  * to evict specific {@link org.dockbox.hartshorn.cache.Cache caches}.
  */

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
@@ -30,17 +30,17 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.services.ComponentContainer;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 
 import java.lang.annotation.Annotation;
 import java.util.function.Supplier;
 
 /**
- * Common functionality for cache related {@link ServiceAnnotatedMethodPostProcessor modifiers}.
+ * Common functionality for cache related {@link ServiceAnnotatedMethodInterceptorPostProcessor modifiers}.
  *
  * @param <A> The cache-related annotation
  */
-public abstract class CacheServicePostProcessor<A extends Annotation> extends ServiceAnnotatedMethodPostProcessor<A, UseCaching> {
+public abstract class CacheServicePostProcessor<A extends Annotation> extends ServiceAnnotatedMethodInterceptorPostProcessor<A, UseCaching> {
 
     @Override
     public <T, R> ProxyFunction<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext) {

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheUpdateMethodPostProcessor.java
@@ -26,10 +26,10 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 
 /**
- * The {@link ServiceAnnotatedMethodPostProcessor} responsible for {@link UpdateCache}
+ * The {@link ServiceAnnotatedMethodInterceptorPostProcessor} responsible for {@link UpdateCache}
  * decorated methods. This delegates functionality to the underlying {@link org.dockbox.hartshorn.cache.CacheManager}
  * to update specific {@link org.dockbox.hartshorn.cache.Cache caches}.
  */

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodPostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CachedMethodPostProcessor.java
@@ -27,12 +27,12 @@ import org.dockbox.hartshorn.cache.context.CacheContext;
 import org.dockbox.hartshorn.cache.context.CacheMethodContext;
 import org.dockbox.hartshorn.cache.context.CacheMethodContextImpl;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 
 /**
- * The {@link ServiceAnnotatedMethodPostProcessor} responsible for {@link Cached}
+ * The {@link ServiceAnnotatedMethodInterceptorPostProcessor} responsible for {@link Cached}
  * decorated methods. This delegates functionality to the underlying {@link org.dockbox.hartshorn.cache.CacheManager}
  * to store or obtain {@link Cache} entries.
  */

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ContextMethodPostProcessor.java
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 
 @AutomaticActivation
-public class ContextMethodPostProcessor extends ServiceAnnotatedMethodPostProcessor<Provided, UseProxying> {
+public class ContextMethodPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<Provided, UseProxying> {
 
     @Override
     public Class<UseProxying> activator() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServicePostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServicePostProcessor.java
@@ -31,7 +31,7 @@ import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 
 @AutomaticActivation
-public class FactoryServicePostProcessor extends ServiceAnnotatedMethodPostProcessor<Factory, Service> {
+public class FactoryServicePostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<Factory, Service> {
 
     @Override
     public Class<Service> activator() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProxyDelegationPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProxyDelegationPostProcessor.java
@@ -31,7 +31,7 @@ import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 
-public abstract class ProxyDelegationPostProcessor<P, A extends Annotation> extends ServiceMethodPostProcessor<A> {
+public abstract class ProxyDelegationPostProcessor<P, A extends Annotation> extends ServiceMethodInterceptorPostProcessor<A> {
 
     protected abstract Class<P> parentTarget();
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodInterceptorPostProcessor.java
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 
-public abstract class ServiceAnnotatedMethodPostProcessor<M extends Annotation, A extends Annotation> extends FunctionalComponentPostProcessor<A> {
+public abstract class ServiceAnnotatedMethodInterceptorPostProcessor<M extends Annotation, A extends Annotation> extends ServiceMethodInterceptorPostProcessor<A> {
 
     @Override
     public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
@@ -36,18 +36,6 @@ public abstract class ServiceAnnotatedMethodPostProcessor<M extends Annotation, 
     public abstract Class<M> annotation();
 
     @Override
-    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
-        final TypeContext<T> type = key.type();
-        final Collection<MethodContext<?, T>> methods = this.modifiableMethods(type);
-
-        for (final MethodContext<?, T> method : methods) {
-            this.process(context, key, instance, method);
-        }
-        return instance;
-    }
-
-    protected abstract <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final MethodContext<?, T> method);
-
     protected <T> Collection<MethodContext<?, T>> modifiableMethods(final TypeContext<T> type) {
         return type.methods(this.annotation());
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodPostProcessor.java
@@ -46,7 +46,7 @@ public abstract class ServiceAnnotatedMethodPostProcessor<M extends Annotation, 
         return instance;
     }
 
-    protected abstract <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final MethodContext<?, T> method);
+    protected abstract <T> void process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final MethodContext<?, T> method);
 
     protected <T> Collection<MethodContext<?, T>> modifiableMethods(final TypeContext<T> type) {
         return type.methods(this.annotation());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceMethodInterceptorPostProcessor.java
@@ -31,7 +31,7 @@ import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 
-public abstract class ServiceMethodPostProcessor<A extends Annotation> extends FunctionalComponentPostProcessor<A> {
+public abstract class ServiceMethodInterceptorPostProcessor<A extends Annotation> extends FunctionalComponentPostProcessor<A> {
 
     @Override
     public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/AbstractPersistenceServicePostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/AbstractPersistenceServicePostProcessor.java
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.core.domain.TypedOwner;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.services.ComponentContainer;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 import org.dockbox.hartshorn.data.FileFormats;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.context.PersistenceAnnotationContext;
@@ -38,7 +38,7 @@ import java.lang.annotation.Annotation;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public abstract class AbstractPersistenceServicePostProcessor<M extends Annotation, C extends SerialisationContext> extends ServiceAnnotatedMethodPostProcessor<M, UsePersistence> {
+public abstract class AbstractPersistenceServicePostProcessor<M extends Annotation, C extends SerialisationContext> extends ServiceAnnotatedMethodInterceptorPostProcessor<M, UsePersistence> {
 
     @Override
     public Class<UsePersistence> activator() {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/QueryPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/QueryPostProcessor.java
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.proxy.ProxyContext;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.services.ProcessingOrder;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 import org.dockbox.hartshorn.data.QueryFunction;
 import org.dockbox.hartshorn.data.annotations.EntityModifier;
 import org.dockbox.hartshorn.data.annotations.Query;
@@ -39,7 +39,7 @@ import java.util.Collection;
 import java.util.List;
 
 @AutomaticActivation
-public class QueryPostProcessor extends ServiceAnnotatedMethodPostProcessor<Query, UsePersistence> {
+public class QueryPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<Query, UsePersistence> {
 
     @Override
     public Class<UsePersistence> activator() {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
@@ -31,10 +31,10 @@ import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodPostProcessor;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 
 @AutomaticActivation
-public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodPostProcessor<InjectTranslation, UseTranslations> {
+public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<InjectTranslation, UseTranslations> {
 
     @Override
     public <T, R> ProxyFunction<T, R> process(final ApplicationContext context, final MethodProxyContext<T> methodContext) {


### PR DESCRIPTION
# Description
The names `ServiceMethodPostProcessor` and `ServiceAnnotatedMethodPostProcessor` suggest the method is processed, which is correct, but does not disclose the fact that methods will be intercepted as proxy methods. 

https://github.com/GuusLieben/Hartshorn/blob/21a262a874a430ff190f9152a40a5f3fd22f2a95/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceAnnotatedMethodPostProcessor.java

https://github.com/GuusLieben/Hartshorn/blob/21a262a874a430ff190f9152a40a5f3fd22f2a95/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceMethodPostProcessor.java

This PR renames these processors to `ServiceMethodInterceptorPostProcessor` and `ServiceAnnotatedMethodInterceptorPostProcessor`, respectively. This way the processors clearly disclose their purpose.  

For ease of extension, it also adds a `ServiceAnnotatedMethodPostProcessor` which _processes_ an annotated method, but does not modify or intercept it.

Fixes #672

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
