### PR TITLE
#674 Update CLI pattern for readability

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -92,7 +92,7 @@ import lombok.Getter;
 public class HartshornApplicationContext extends DefaultContext implements SelfActivatingApplicationContext {
 
     public static Comparator<String> PREFIX_PRIORITY_COMPARATOR = Comparator.naturalOrder();
-    private static final Pattern ARGUMENTS = Pattern.compile("-H([a-zA-Z0-9\\.]+)=(.+)");
+    private static final Pattern ARGUMENTS = Pattern.compile("--([a-zA-Z0-9\\.]+)=(.+)");
 
     protected final transient Set<InjectionPoint<?>> injectionPoints = HartshornUtils.emptyConcurrentSet();
     protected final transient MultiMap<ProcessingOrder, ComponentPostProcessor<?>> postProcessors = new CustomMultiMap<>(HartshornUtils::emptyConcurrentSet);

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/testsuite/HartshornFactoryTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/testsuite/HartshornFactoryTests.java
@@ -27,7 +27,7 @@ public class HartshornFactoryTests {
 
     @HartshornFactory
     public static ApplicationFactory<?, ?> factory(final ApplicationFactory<?, ?> factory) {
-        return factory.argument("-Hfactory.modified=true");
+        return factory.argument("--factory.modified=true");
     }
 
     @InjectTest


### PR DESCRIPTION
# Description
Currently the CLI argument pattern is `-Hproperty=value`, which was originally chosen as the `-H` prefix would indicate the argument is used by Hartshorn. However this often leads to properties such as `-Hhartshorn.data.url` which becomes hard to read.  

This PR replaces the pattern with `--property=value`, so properties will be more readable. Considering these are passed as application arguments, it is to be expected that these will be used within Hartshorn either way.

Fixes #674

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have ~~added~~ updated tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
