### PR TITLE
#666 Lazy-loading components and add required service activators to internal services

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheFactory.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheFactory.java
@@ -17,11 +17,12 @@
 
 package org.dockbox.hartshorn.cache;
 
+import org.dockbox.hartshorn.cache.annotations.UseCaching;
 import org.dockbox.hartshorn.core.annotations.Factory;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 
 @FunctionalInterface
-@Service
+@Service(activators = UseCaching.class)
 public interface CacheFactory {
     @Factory
     Cache<?> cache(Expiration expiration);

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/annotations/CacheService.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/annotations/CacheService.java
@@ -44,4 +44,9 @@ public @interface CacheService {
      */
     @AliasFor("id")
     String value();
+
+    /**
+     * @see Service#lazy()
+     */
+    boolean lazy() default false;
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/annotations/Command.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/annotations/Command.java
@@ -56,4 +56,9 @@ public @interface Command {
      */
     @AliasFor("owner")
     Class<?> parent() default Void.class;
+
+    /**
+     * @see Service#lazy()
+     */
+    boolean lazy() default false;
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.commands.arguments;
 
+import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.definition.ArgumentConverter;
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.adapter.BuiltInStringTypeAdapters;
@@ -33,7 +34,7 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
 
-@Service
+@Service(activators = UseCommands.class)
 public final class DefaultArgumentConverters {
 
     public static final ArgumentConverter<String> STRING = ArgumentConverterImpl.builder(String.class, "string")

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
@@ -34,7 +34,7 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
 
-@Service(activators = UseCommands.class)
+@Service(activators = UseCommands.class, permitProxying = false)
 public final class DefaultArgumentConverters {
 
     public static final ArgumentConverter<String> STRING = ArgumentConverterImpl.builder(String.class, "string")

--- a/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
+++ b/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
@@ -192,5 +192,10 @@ public class CommandDefinitionContextTests {
         public Class<?> parent() {
             return Void.class;
         }
+
+        @Override
+        public boolean lazy() {
+            return false;
+        }
     }
 }

--- a/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/annotations/Configuration.java
+++ b/hartshorn-config/src/main/java/org/dockbox/hartshorn/config/annotations/Configuration.java
@@ -56,6 +56,13 @@ import java.lang.annotation.Target;
 @Extends(Service.class)
 public @interface Configuration {
     String source();
+
     Class<?> owner() default Hartshorn.class;
+
     FileFormats filetype() default FileFormats.YAML;
+
+    /**
+     * @see Service#lazy()
+     */
+    boolean lazy() default false;
 }

--- a/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/DemoFSConfiguration.java
+++ b/hartshorn-config/src/test/java/org/dockbox/hartshorn/config/DemoFSConfiguration.java
@@ -26,11 +26,10 @@ import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@Configuration(source = "junit")
+@Configuration(source = "junit", lazy = true)
 public class DemoFSConfiguration {
 
     @Value("junit.fs")
     @Getter
     private String fileSystemValue;
-
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/ComponentBinding.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/inject/ComponentBinding.java
@@ -49,6 +49,7 @@ import javax.inject.Named;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Extends(Component.class)
+@Component(lazy = true)
 public @interface ComponentBinding {
 
     /**

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
@@ -107,6 +107,17 @@ public @interface Component {
     boolean singleton() default false;
 
     /**
+     * Indicates whether a component should be created after the application context has been initialized.
+     * When this is {@code true} the component will be created after the application context has been
+     * initialized, as long as {@link #singleton()} is {@code true}. If {@link #singleton()} is {@code false},
+     * the component will always be lazy-loaded.
+     *
+     * @return {@code true} if the component should be created after the application context has been initialized
+     * @see ComponentContainer#lazy()
+     */
+    boolean lazy() default true;
+
+    /**
      * The type of the component. This is used to indicate whether the component is a functional
      * component, and thus modifiable, or if it should only be injected into.
      *

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Service.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Service.java
@@ -73,6 +73,12 @@ public @interface Service {
     boolean singleton() default true;
 
     /**
+     * @see Component#lazy()
+     * @return Whether the service is lazy.
+     */
+    boolean lazy() default false;
+
+    /**
      * The activators required for this service to become active by default. If one or more activators are not present,
      * the service will not be loaded.
      *

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationProviders.java
@@ -17,6 +17,7 @@
 
 package org.dockbox.hartshorn.core.boot;
 
+import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
 import org.dockbox.hartshorn.core.annotations.context.LogExclude;
 import org.dockbox.hartshorn.core.annotations.inject.Provider;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
@@ -30,7 +31,7 @@ import org.slf4j.Logger;
  * @author Guus Lieben
  * @since 21.7
  */
-@Service
+@Service(activators = UseBootstrap.class)
 @LogExclude
 public class ApplicationProviders {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -433,7 +433,7 @@ public class HartshornApplicationContext extends DefaultContext implements SelfA
                 .flatMap(hierarchy -> {
                     // Will continue going through each provider until a provider was successful or no other providers remain
                     for (final Provider<T> provider : hierarchy.providers()) {
-                        final Exceptional<T> provided = provider.provide(this);
+                        final Exceptional<T> provided = provider.provide(this).rethrowUnchecked();
                         if (provided.present()) return provided;
                     }
                     return Exceptional.empty();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/AccessorFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/AccessorFactory.java
@@ -18,11 +18,12 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.annotations.Factory;
+import org.dockbox.hartshorn.core.annotations.activate.UseProxying;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.proxy.DelegatorAccessor;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 
-@Service
+@Service(activators = UseProxying.class)
 interface AccessorFactory {
     @Factory
     <T> DelegatorAccessor<T> delegatorAccessor(ProxyHandler<T> handler);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
@@ -41,6 +41,8 @@ public interface ComponentContainer {
 
     boolean singleton();
 
+    boolean lazy();
+
     ComponentType componentType();
 
     boolean permitsProxying();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
@@ -90,6 +90,11 @@ public class ComponentContainerImpl implements ComponentContainer {
     }
 
     @Override
+    public boolean lazy() {
+        return this.annotation.lazy();
+    }
+
+    @Override
     public ComponentType componentType() {
         return this.annotation.type();
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceImpl.java
@@ -43,6 +43,11 @@ public class ServiceImpl implements Service {
     }
 
     @Override
+    public boolean lazy() {
+        return false;
+    }
+
+    @Override
     public Class<? extends Annotation>[] activators() {
         return new Class[0];
     }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/TransactionFactory.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/TransactionFactory.java
@@ -19,10 +19,11 @@ package org.dockbox.hartshorn.data;
 
 import org.dockbox.hartshorn.core.annotations.Factory;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
 
 import javax.persistence.EntityManager;
 
-@Service
+@Service(activators = UsePersistence.class)
 public interface TransactionFactory {
     @Factory
     TransactionManager manager(EntityManager entityManager);

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/JpaRepositoryFactory.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/JpaRepositoryFactory.java
@@ -20,9 +20,10 @@ package org.dockbox.hartshorn.data.service;
 import org.dockbox.hartshorn.core.annotations.Factory;
 import org.dockbox.hartshorn.core.annotations.inject.Enable;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.jpa.JpaRepository;
 
-@Service
+@Service(activators = UsePersistence.class)
 public interface JpaRepositoryFactory {
     @Factory
     @Enable(false)

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletFactory.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletFactory.java
@@ -20,8 +20,9 @@ package org.dockbox.hartshorn.web;
 import org.dockbox.hartshorn.core.annotations.Factory;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.web.annotations.UseHttpServer;
 
-@Service
+@Service(activators = UseHttpServer.class)
 @FunctionalInterface
 public interface ServletFactory {
     @Factory

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/MvcController.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/MvcController.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.web.annotations;
 
 import org.dockbox.hartshorn.core.annotations.AliasFor;
 import org.dockbox.hartshorn.core.annotations.Extends;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,4 +32,9 @@ import java.lang.annotation.Target;
 public @interface MvcController {
     @AliasFor("pathSpec")
     String value() default "";
+
+    /**
+     * @see Service#lazy()
+     */
+    boolean lazy() default false;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/PathSpec.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/PathSpec.java
@@ -27,4 +27,9 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PathSpec {
     String pathSpec() default "";
+
+    /**
+     * @see Service#lazy()
+     */
+    boolean lazy() default false;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/RestController.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/RestController.java
@@ -18,7 +18,6 @@
 package org.dockbox.hartshorn.web.annotations;
 
 import org.dockbox.hartshorn.core.annotations.AliasFor;
-import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.annotations.Extends;
 
 import java.lang.annotation.ElementType;
@@ -28,7 +27,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Extends(Service.class)
+@Extends(PathSpec.class)
 public @interface RestController {
     @AliasFor("pathSpec")
     String value() default "";

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/RestController.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/annotations/RestController.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.web.annotations;
 
 import org.dockbox.hartshorn.core.annotations.AliasFor;
 import org.dockbox.hartshorn.core.annotations.Extends;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,4 +32,9 @@ import java.lang.annotation.Target;
 public @interface RestController {
     @AliasFor("pathSpec")
     String value() default "";
+
+    /**
+     * @see Service#lazy()
+     */
+    boolean lazy() default false;
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletFactory.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletFactory.java
@@ -22,9 +22,10 @@ import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.web.HttpWebServer;
 import org.dockbox.hartshorn.web.RequestHandlerContext;
+import org.dockbox.hartshorn.web.annotations.UseHttpServer;
 import org.dockbox.hartshorn.web.mvc.ViewTemplate;
 
-@Service
+@Service(activators = UseHttpServer.class)
 public interface WebServletFactory {
     @Factory
     WebServletImpl webServlet(final HttpWebServer starter, final RequestHandlerContext context);


### PR DESCRIPTION
# Description
Currently most internal services are not explicitely marked with service activators, causing them to always be active. This specifically targets `Service#activators`. This PR adds required service activators to all internal services to prevent them from being activated when they shouldn't be activated. Services which are already marked correctly have been ignored.  

In addition to this, I also made sure services are now correctly activated directly after the application context is created. This ensures services can start processes where needed. This can be toggled on/off by changing the `lazy` attribute on applicable services. All service stereotypes can be lazy-loaded, however they will always be pre-processed as long as the appropriate activators are present.

Fixes #666

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
