### PR TITLE
#680 Ensure `ApplicationFactory` modifiers are accessible during unit tests

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ReflectionMethodInvoker.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ReflectionMethodInvoker.java
@@ -18,11 +18,16 @@ package org.dockbox.hartshorn.core.context.element;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
+import java.lang.reflect.Method;
+
 public class ReflectionMethodInvoker<T, P> implements MethodInvoker<T, P> {
 
     @Override
     public Exceptional<T> invoke(final MethodContext<T, P> method, final P instance, final Object[] args) {
-        final Exceptional<T> result = Exceptional.of(() -> (T) method.method().invoke(instance, args));
+        final Exceptional<T> result = Exceptional.of(() -> {
+            final Method jlrMethod = method.method();
+            return (T) jlrMethod.invoke(instance, args);
+        });
         if (result.caught()) {
             Throwable cause = result.error();
             if (result.error().getCause() != null) cause = result.error().getCause();

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornExtension.java
@@ -149,6 +149,10 @@ public class HartshornExtension implements BeforeEachCallback, AfterEachCallback
                     throw new IllegalStateException("Factory modifiers must be static");
                 }
                 if (factoryModifier.returnType().childOf(ApplicationFactory.class)) {
+
+                    final Method jlrMethod = factoryModifier.method();
+                    if (!jlrMethod.canAccess(null)) jlrMethod.setAccessible(true);
+
                     final LinkedList<TypeContext<?>> parameters = factoryModifier.parameterTypes();
                     if (parameters.isEmpty()) {
                         applicationFactory = (ApplicationFactory<?, ?>) factoryModifier.invokeStatic().rethrowUnchecked().orNull();
@@ -159,6 +163,8 @@ public class HartshornExtension implements BeforeEachCallback, AfterEachCallback
                     else {
                         throw new IllegalStateException("Invalid parameters for @HartshornFactory modifier, expected " + ApplicationFactory.class.getSimpleName() + " but got " + parameters.get(0).name());
                     }
+
+                    jlrMethod.setAccessible(false);
                 }
                 else {
                     throw new IllegalStateException("Invalid return type for @HartshornFactory modifier, expected " + ApplicationFactory.class.getSimpleName() + " but got " + factoryModifier.returnType().name());


### PR DESCRIPTION
# Description
Methods are not made accessible by default in a new `MethodContext`. Because of this, protected and private methods cannot be invoked by default. This leads to `HartshornExtension` being unable to invoke protected and static factory modification methods (annotated with `@HartshornFactory`).

This PR ensures the invoked method is accessible before making any attempts to invoke it. This is handled by the `HartshornExtension`, and _not_ the invoker itself to follow proper invocation conventions.

Fixes #680

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
