### PR TITLE
#681 Clean up ordered processing in `HartshornApplicationContext`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -353,34 +353,32 @@ public class HartshornApplicationContext extends DefaultContext implements SelfA
 
         // Modify the instance during phase 1. This allows discarding the existing instance and replacing it with a new instance.
         // See ServiceOrder#PHASE_1
-        if (doProcess) {
-            for (final ProcessingOrder order : ProcessingOrder.PHASE_1) {
-                for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
-                    if (postProcessor.preconditions(this, key, instance))
-                        instance = postProcessor.process(this, key, instance);
-                }
-            }
-        }
+        if (doProcess) instance = this.process(key, instance, ProcessingOrder.PHASE_1, true);
 
         this.populateAndStore(key, instance);
 
         // Modify the instance during phase 2. This does not allow discarding the existing instance.
         // See ServiceOrder#PHASE_2
-        if (doProcess) {
-            for (final ProcessingOrder order : ProcessingOrder.PHASE_2) {
-                for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
-                    if (postProcessor.preconditions(this, key, instance)) {
-                        final T modified = postProcessor.process(this, key, instance);
-                        if (modified != instance) {
-                            throw new IllegalStateException(("Component %s was modified during phase %s (Phase 2) by %s. " +
-                                    "Component processors are only able to discard existing instances in phases: %s").formatted(key.type().name(), order.name(), TypeContext.of(postProcessor).name(), Arrays.toString(ProcessingOrder.PHASE_2)));
-                        }
+        if (doProcess) this.process(key, instance, ProcessingOrder.PHASE_2, false);
+
+        return instance;
+    }
+
+    protected <T> T process(final Key<T> key, final T instance, final ProcessingOrder[] orders, final boolean modifiable) {
+        T result = instance;
+        for (final ProcessingOrder order : orders) {
+            for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
+                if (postProcessor.preconditions(this, key, instance)) {
+                    final T modified = postProcessor.process(this, key, instance);
+                    if (modifiable) result = modified;
+                    else if (!modifiable && modified != instance) {
+                        throw new IllegalStateException(("Component %s was modified during phase %s by %s. " +
+                                "Component processors are only able to discard existing instances in phases: %s").formatted(key.type().name(), order.name(), TypeContext.of(postProcessor).name(), Arrays.toString(ProcessingOrder.PHASE_2)));
                     }
                 }
             }
         }
-
-        return instance;
+        return result;
     }
 
     protected <T> T populateAndStore(final Key<T> key, final T instance) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java
@@ -368,8 +368,8 @@ public class HartshornApplicationContext extends DefaultContext implements SelfA
         T result = instance;
         for (final ProcessingOrder order : orders) {
             for (final ComponentPostProcessor<?> postProcessor : this.postProcessors.get(order)) {
-                if (postProcessor.preconditions(this, key, instance)) {
-                    final T modified = postProcessor.process(this, key, instance);
+                if (postProcessor.preconditions(this, key, result)) {
+                    final T modified = postProcessor.process(this, key, result);
                     if (modifiable) result = modified;
                     else if (!modifiable && modified != instance) {
                         throw new IllegalStateException(("Component %s was modified during phase %s by %s. " +

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyHandler.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/javassist/JavassistProxyHandler.java
@@ -201,20 +201,20 @@ public class JavassistProxyHandler<T> extends DefaultContext implements ProxyHan
             // If the proxy associated with this handler has a delegate, use it.
             if (this.instance != null) return this.invokeDelegate(target, args);
 
-                // If the method is default inside an interface, we cannot invoke it directly using a proxy instance. Instead we
-                // need to lookup the method on the class and invoke it through the method handle directly.
+            // If the method is default inside an interface, we cannot invoke it directly using a proxy instance. Instead we
+            // need to lookup the method on the class and invoke it through the method handle directly.
             else if (thisMethod.isDefault()) return this.invokeDefault(declaringType, thisMethod, self, args);
 
-                // If the current target instance (self) is not a proxy, we can invoke the method directly using reflections.
+            // If the current target instance (self) is not a proxy, we can invoke the method directly using reflections.
             else if (!(self instanceof Proxy || ProxyFactory.isProxyClass(self.getClass()))) return this.invokeSelf(self, target, args);
 
-                // If the target method is concrete in an abstract class, we cannot invoke the method directly using reflections.
-                // This solution uses private lookups to invoke the method, unreflecting the method first so it can be invoked using
-                // proxy instances.
+            // If the target method is concrete in an abstract class, we cannot invoke the method directly using reflections.
+            // This solution uses private lookups to invoke the method, unreflecting the method first so it can be invoked using
+            // proxy instances.
             else if (this.type().isAbstract() && !MethodContext.of(thisMethod).isAbstract()) return this.invokePrivate(declaringType, thisMethod, self, args);
 
-                // If none of the above conditions are met, we have no way to handle the method.
-            else throw new IllegalArgumentException("Cannot invoke method " + thisMethod.getName() + " on proxy " + self.getClass().getName());
+            // If none of the above conditions are met, we have no way to handle the method.
+            else throw new IllegalArgumentException("Cannot invoke method " + thisMethod.getName() + " on proxy " + this.type().qualifiedName());
         }
         catch (final InvocationTargetException e) {
             throw e.getCause();


### PR DESCRIPTION
# Description
Currently the processing part of components created by the `HartshornApplicationContext` is implemented as follows:
https://github.com/GuusLieben/Hartshorn/blob/97ae8f7bdbd7b957a6be98066d98163e2aa50e9f/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L356-L381

Especially both phases are almost 100% identical, with the one difference being that phase 1 permits mutable instances, while phase 2 does not.

Phase 1:
https://github.com/GuusLieben/Hartshorn/blob/97ae8f7bdbd7b957a6be98066d98163e2aa50e9f/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L356-L363

Phase 2:
https://github.com/GuusLieben/Hartshorn/blob/97ae8f7bdbd7b957a6be98066d98163e2aa50e9f/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HartshornApplicationContext.java#L369-L381

The proposed changes refactor this into a separate method, where a single boolean indicates whether the instance should be considered mutable or immutable. This does not affect functionality or any API-related issues, and is only a readability enhancement.

Fixes #681

## Type of change
- [x] Refactor (code changes that do not affect the behavior of the code)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
