### PR TITLE
#678 Implement `Closeable` in `ApplicationContext`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java
@@ -30,6 +30,7 @@ import org.dockbox.hartshorn.core.services.ServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -154,10 +155,10 @@ public abstract class AbstractActivatingApplicationFactory<
 
     protected void registerHooks(final C applicationContext, final M manager) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            this.logger().info("Runtime shutting down, notifying observers");
-            for (final LifecycleObserver observer : manager.observers()) {
-                this.logger().debug("Notifying " + observer.getClass().getSimpleName() + " of shutdown");
-                observer.onExit(applicationContext);
+            try {
+                applicationContext.close();
+            } catch (final IOException e) {
+                this.logger().error("Failed to close application context", e);
             }
         }, "ShutdownHook"));
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ApplicationContext.java
@@ -29,6 +29,8 @@ import org.dockbox.hartshorn.core.services.ComponentLocator;
 import org.dockbox.hartshorn.core.services.ComponentProcessor;
 import org.slf4j.Logger;
 
+import java.io.Closeable;
+
 @LogExclude
 public interface ApplicationContext extends
         ApplicationBinder,
@@ -36,7 +38,8 @@ public interface ApplicationContext extends
         ApplicationPropertyHolder,
         ExceptionHandler,
         ApplicationLogger,
-        ActivatorSource
+        ActivatorSource,
+        Closeable
 {
 
     <T> T populate(T type);


### PR DESCRIPTION
# Description
Currently the type responsible for closing an active `ApplicationContext` is the `ApplicationFactory`. In implementation details, this would be the `AbstractActivatingApplicationFactory` specifically. This leads to two issues:
1. The responsibility shifts to a non-managed component
2. The application context is only closed when the runtime shuts down

Both these issues are especially relevant in applications where the application lifecycle may end long before the runtime exits. An example of this is contexts activated through JUnit.

To allow environments to close an application context manually, before the runtime exits, this PR implements `Closeable` in the `ApplicationContext` interface. The concrete implementation mimicks the current implementation in the `AbstractActivatingApplicationFactory` as can be seen below.
https://github.com/GuusLieben/Hartshorn/blob/97ae8f7bdbd7b957a6be98066d98163e2aa50e9f/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java#L157-L161

Fixes #678

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [ ] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
