### PR TITLE
#679 Replace explicit `Thread` creation with managed service executor and refactor `CommandListener`

### DIFF
--- a/examples/src/commands/java/org/dockbox/hartshorn/demo/commands/services/CommandCLIStarterService.java
+++ b/examples/src/commands/java/org/dockbox/hartshorn/demo/commands/services/CommandCLIStarterService.java
@@ -16,7 +16,8 @@
 
 package org.dockbox.hartshorn.demo.commands.services;
 
-import org.dockbox.hartshorn.commands.CommandCLI;
+import org.dockbox.hartshorn.commands.CommandListener;
+import org.dockbox.hartshorn.commands.CommandListenerImpl;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ApplicationState;
 import org.dockbox.hartshorn.core.boot.ApplicationState.Started;
@@ -37,9 +38,9 @@ public class CommandCLIStarterService {
      * The method activated when the engine is done starting, this is done automatically when the application
      * was bootstrapped through {@link HartshornApplication}.
      *
-     * <p>In this example we wish to use the {@link CommandCLI} to be able to the file {@code commands.txt} to
-     * enter commands. This can be done by overriding the default {@link InputStream} of the {@link CommandCLI}.
-     * In this case the default implementation is {@link org.dockbox.hartshorn.commands.cli.SimpleCommandCLI}, which
+     * <p>In this example we wish to use the {@link CommandListener} to be able to the file {@code commands.txt} to
+     * enter commands. This can be done by overriding the default {@link InputStream} of the {@link CommandListener}.
+     * In this case the default implementation is {@link CommandListenerImpl}, which
      * uses {@link System#in}.
      *
      * <p>Note the use of the generic type parameter {@link Started} in the event. This causes this method to
@@ -53,7 +54,7 @@ public class CommandCLIStarterService {
         final Exceptional<Path> commands = event.applicationContext().resourceLocator().resource("commands.txt");
         if (commands.present()) {
             final InputStream inputStream = Files.newInputStream(commands.get());
-            event.applicationContext().get(CommandCLI.class).input(inputStream).open();
+            event.applicationContext().get(CommandListener.class).input(inputStream).open();
         }
     }
 }

--- a/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/EventListenerService.java
+++ b/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/EventListenerService.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.demo.persistence.services;
 import org.dockbox.hartshorn.demo.persistence.domain.User;
 import org.dockbox.hartshorn.demo.persistence.events.UserCreatedEvent;
 
-import org.dockbox.hartshorn.commands.CommandCLI;
+import org.dockbox.hartshorn.commands.CommandListener;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ApplicationState;
 import org.dockbox.hartshorn.core.boot.ApplicationState.Started;
@@ -50,7 +50,7 @@ public class EventListenerService {
      * The method activated when the engine is done starting, this is done automatically when the application
      * was bootstrapped through {@link HartshornApplication}.
      *
-     * <p>In this example we wish to use the {@link CommandCLI} to be able to use the command line to enter commands.
+     * <p>In this example we wish to use the {@link CommandListener} to be able to use the command line to enter commands.
      * An example command has been provided by {@link UserCommandService}.
      *
      * <p>Note the use of the generic type parameter {@link Started} in the event. This causes this method to
@@ -61,7 +61,7 @@ public class EventListenerService {
      */
     @Listener
     public void on(final EngineChangedState<Started> event) {
-        event.applicationContext().get(CommandCLI.class).async(true).open();
+        event.applicationContext().get(CommandListener.class).async(true).open();
     }
 
 }

--- a/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/UserCommandService.java
+++ b/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/UserCommandService.java
@@ -16,6 +16,7 @@
 
 package org.dockbox.hartshorn.demo.persistence.services;
 
+import org.dockbox.hartshorn.commands.CommandListener;
 import org.dockbox.hartshorn.commands.annotations.Command;
 import org.dockbox.hartshorn.commands.context.CommandContext;
 import org.dockbox.hartshorn.commands.context.CommandDefinitionContextImpl;
@@ -37,7 +38,7 @@ public class UserCommandService {
 
     /**
      * The method activated when the command {@code create <name> <age>} is correctly entered by a user
-     * (or other {@link java.io.InputStream}, depending on the {@link org.dockbox.hartshorn.commands.CommandCLI}).
+     * (or other {@link java.io.InputStream}, depending on the {@link CommandListener}).
      *
      * <p>The {@link Command#value()} indicates the command itself, excluding arguments. {@link Command#arguments()}
      * indicates the arguments which are expected to be present. The way these are defined depends on the {@link org.dockbox.hartshorn.commands.CommandParser}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListener.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListener.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.events.EngineChangedState;
 import java.io.InputStream;
 
 /**
- * Represents a constant CLI which is capable of listening to command inputs. Commands may be entered through
+ * Represents a constant listener which is capable of listening to command inputs. Commands may be entered through
  * any mean, like a command line, external event bus, or similar solutions. Should be activated after the engine
  * started, typically this can be done by listening for {@link EngineChangedState} with
  * {@link ApplicationState.Started} as its parameter.
@@ -35,10 +35,10 @@ import java.io.InputStream;
  * }
  * }</pre>
  */
-public interface CommandCLI {
+public interface CommandListener {
     void open();
 
-    CommandCLI async(boolean async);
-    CommandCLI input(InputStream stream);
-    CommandCLI source(CommandSource source);
+    CommandListener async(boolean async);
+    CommandListener input(InputStream stream);
+    CommandListener source(CommandSource source);
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
@@ -1,0 +1,14 @@
+package org.dockbox.hartshorn.commands;
+
+import org.dockbox.hartshorn.commands.annotations.UseCommands;
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+
+@Service(activators = UseCommands.class)
+public class CommandProviders {
+
+    @Provider
+    public CommandListener listener() {
+        return new CommandListenerImpl();
+    }
+}


### PR DESCRIPTION
# Description
The `SimpleCommandCLI` currently uses an explicitly created `Thread` to run in asynchronous mode. This means the thread the action is performed on is unmanaged.

https://github.com/GuusLieben/Hartshorn/blob/97ae8f7bdbd7b957a6be98066d98163e2aa50e9f/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/cli/SimpleCommandCLI.java#L76

This PR migrates this explicit call to a `ExecutorService` through a simple `Executors.newSingleThreadExecutor()`. This ensures the thread is correctly destroyed after the CLI exits.  

Additionally, as I suggested in #679, I moved the implementation out of the `cli` package so it is at the same level as its interface. These have also both been renamed to be `CommandListener` instead of `CommandCLI`.

Fixes #679 

## Type of change
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
