### PR TITLE
#691 Add support for wildcards with explicit upper bounds

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -179,6 +179,12 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
         return of((Class<T>) instance.getClass());
     }
 
+    public static <T> TypeContext<T> of(final Type type) {
+        if (type instanceof Class<?>) return of((Class<T>) type);
+        if (type instanceof ParameterizedType parameterizedType) return of((ParameterizedType) type);
+        throw new RuntimeException("Unexpected type " + type);
+    }
+
     public static <T> TypeContext<T> of(final Class<T> type) {
         if (type == null) {
             return (TypeContext<T>) VOID;
@@ -326,7 +332,12 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
                 .filter(type -> type instanceof Class || type instanceof WildcardType || type instanceof ParameterizedType)
                 .map(type -> {
                     if (type instanceof Class clazz) return TypeContext.of(clazz);
-                    else if (type instanceof WildcardType wildcard) return WildcardTypeContext.create();
+                    else if (type instanceof WildcardType wildcard) {
+                        if (wildcard.getUpperBounds() != null && wildcard.getUpperBounds().length > 0) {
+                            return TypeContext.of(wildcard.getUpperBounds()[0]);
+                        }
+                        return WildcardTypeContext.create();
+                    }
                     else if (type instanceof ParameterizedType parameterized) return TypeContext.of(parameterized);
                     else return TypeContext.VOID;
                 })

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -28,6 +28,7 @@ import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.MethodModifier;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.context.element.WildcardTypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.TypeConversionException;
 import org.dockbox.hartshorn.core.types.AnnotatedImpl;
@@ -509,4 +510,22 @@ public class ReflectTests {
 
     public void genericTestMethod(final List<List<String>> nestedGeneric) { }
 
+    public void methodWithWildcardUpperbounds(final List<? extends String> list) { }
+
+    @Test
+    void testWildcardsWithUpperBounds() {
+        final ParameterContext<?> parameter = TypeContext.of(this).method("methodWithWildcardUpperbounds", List.class)
+                .get()
+                .parameters()
+                .get(0);
+
+        final TypeContext<?> first = parameter.genericType();
+
+        Assertions.assertTrue(first.is(List.class));
+        Assertions.assertEquals(1, first.typeParameters().size());
+
+        final TypeContext<?> second = first.typeParameters().get(0);
+        Assertions.assertTrue(second.is(String.class));
+        Assertions.assertFalse(second instanceof WildcardTypeContext);
+    }
 }


### PR DESCRIPTION
# Description
When a wildcard type parameter is encountered, a new `WildcardTypeContext` is returned. While this is valid for wildcards without upper bounds (e.g. `List<?>`) this is not valid for wildcards _with_ upper bounds (e.g. `List<? extends String?`).

This PR adds support for wildcards with upper bounds. This returns a TypeContext of the upper bounds (e.g. `? extends String` becomes `TypeContext<String>`).

Fixes #691

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
