### PR TITLE
#693 Add support for non-required factory validation

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/Factory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/Factory.java
@@ -66,4 +66,11 @@ public @interface Factory {
      * @return The name of the {@link org.dockbox.hartshorn.core.Key} to use.
      */
     String value() default "";
+
+    /**
+     * Indicate whether the factory method should fail if there is no binding for the bound type. If
+     * this is set to {@code true}, the factory method will throw an exception if there is no binding
+     * for the bound type. If this is set to {@code false}, the factory method will return {@code null}.
+     */
+    boolean required() default true;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/FactoryContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/FactoryContext.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.core.context;
 import org.dockbox.hartshorn.core.annotations.context.AutoCreating;
 import org.dockbox.hartshorn.core.context.element.ConstructorContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.services.FactoryServicePostProcessor;
 import org.dockbox.hartshorn.core.services.FactoryServicePreProcessor;
 
@@ -56,9 +57,8 @@ public class FactoryContext extends DefaultContext {
      * @return The constructor associated with the given method.
      * @throws NoSuchElementException If no constructor is associated with the method.
      */
-    public <T> ConstructorContext<T> get(final MethodContext<T, ?> method) {
+    public <T> Exceptional<ConstructorContext<T>> get(final MethodContext<T, ?> method) {
         final ConstructorContext<?> constructor = this.bounds.get(method);
-        if (constructor == null) throw new NoSuchElementException("No bound constructor present for method " + method.qualifiedName());
-        return (ConstructorContext<T>) constructor;
+        return Exceptional.of((ConstructorContext<T>) constructor);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/FactoryServicePreProcessor.java
@@ -69,7 +69,8 @@ public class FactoryServicePreProcessor implements ServicePreProcessor<Service> 
                 }
             }
 
-            throw new IllegalStateException("No matching bound constructor found for " + returnKey + " with parameters: " + method.parameterTypes());
+            if (annotation.required())
+                throw new IllegalStateException("No matching bound constructor found for " + returnKey + " with parameters: " + method.parameterTypes());
         }
     }
 


### PR DESCRIPTION
# Description
Currently, all `@Factory` methods are validated on startup. This ensures every factory method has an appropriate bound constructor on the target type. However sometimes it may be preferred to make this binding optional.

This PR adds an option to make factory bindings optional. If a factory binding is optional, and no bound constructor is found, it will then ignore this instead of throwing an exception.  

When post-processing, this is also correctly handled. If no bound constructor is available, the processor will fall back to returning `null`. If the factory is required the post processor will always yield an exception.

By default all factory methods are required unless specifically marked as non-required.

Fixes #693

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Integration testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
