### PR TITLE
#697 Service-based static `@Provider` binding and component binding migration

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java
@@ -16,11 +16,10 @@
 
 package org.dockbox.hartshorn.cache;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
+import org.dockbox.hartshorn.core.Enableable;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.Enableable;
 
 import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,7 +32,6 @@ import javax.inject.Inject;
  *
  * @see Cache
  */
-@ComponentBinding(Cache.class)
 public class CacheImpl<T> implements Cache<T>, Enableable {
 
     private final Expiration expiration;

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheManagerImpl.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheManagerImpl.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.cache;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
@@ -25,13 +24,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Default implementation of {@link CacheManager}.
  *
  * @see CacheManager
  */
-@ComponentBinding(value = CacheManager.class, singleton = true)
+@Singleton
 public class CacheManagerImpl implements CacheManager {
 
     protected final Map<String, Cache<?>> caches = new ConcurrentHashMap<>();

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheProviders.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheProviders.java
@@ -1,0 +1,22 @@
+package org.dockbox.hartshorn.cache;
+
+import org.dockbox.hartshorn.cache.annotations.UseCaching;
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+
+import javax.inject.Singleton;
+
+@Service(activators = UseCaching.class)
+public class CacheProviders {
+
+    @Provider
+    public Class<? extends Cache> cache() {
+        return CacheImpl.class;
+    }
+
+    @Provider
+    @Singleton
+    public Class<? extends CacheManager> cacheManager() {
+        return CacheManagerImpl.class;
+    }
+}

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/ApplicationSystemSubject.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/ApplicationSystemSubject.java
@@ -16,15 +16,12 @@
 
 package org.dockbox.hartshorn.commands;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.i18n.Message;
 
-@ComponentBinding(SystemSubject.class)
 public class ApplicationSystemSubject extends SystemSubject {
 
     @Override
     public void send(final Message text) {
         this.applicationContext().log().info("-> %s".formatted(text.string()));
     }
-
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -28,7 +28,6 @@ import org.dockbox.hartshorn.core.ArrayListMultiMap;
 import org.dockbox.hartshorn.core.Enableable;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MultiMap;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -48,7 +47,6 @@ import lombok.Getter;
 /**
  * Simple implementation of {@link CommandGateway}.
  */
-@ComponentBinding(value = CommandGateway.class, singleton = true)
 public class CommandGatewayImpl implements CommandGateway, Enableable {
 
     @Getter(AccessLevel.PROTECTED)

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
@@ -28,7 +28,6 @@ import org.dockbox.hartshorn.commands.definition.GroupCommandElement;
 import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.commands.service.CommandParameter;
 import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.i18n.Message;
@@ -46,7 +45,6 @@ import javax.inject.Inject;
 /**
  * Simple implementation of {@link CommandParser}.
  */
-@ComponentBinding(CommandParser.class)
 public class CommandParserImpl implements CommandParser {
 
     // Note the difference between this and SimpleCommandContainerContext.FLAG, here a space is expected before the flag

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
@@ -17,14 +17,40 @@
 package org.dockbox.hartshorn.commands;
 
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
+import org.dockbox.hartshorn.commands.arguments.CommandParameterLoader;
 import org.dockbox.hartshorn.core.annotations.inject.Provider;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+
+import javax.inject.Singleton;
 
 @Service(activators = UseCommands.class)
 public class CommandProviders {
 
     @Provider
-    public CommandListener listener() {
-        return new CommandListenerImpl();
+    public Class<? extends CommandListener> listener() {
+        return CommandListenerImpl.class;
+    }
+
+    @Provider
+    @Singleton
+    public SystemSubject systemSubject() {
+        return new ApplicationSystemSubject();
+    }
+
+    @Provider
+    @Singleton
+    public Class<? extends CommandGateway> commandGateway() {
+        return CommandGatewayImpl.class;
+    }
+
+    @Provider
+    public Class<? extends CommandParser> commandParser() {
+        return CommandParserImpl.class;
+    }
+
+    @Provider("command_loader")
+    public ParameterLoader parameterLoader() {
+        return new CommandParameterLoader();
     }
 }

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoader.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/CommandParameterLoader.java
@@ -17,16 +17,11 @@
 package org.dockbox.hartshorn.commands.arguments;
 
 import org.dockbox.hartshorn.commands.context.CommandParameterContext;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
-import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 
 import java.util.ArrayList;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = ParameterLoader.class, named = @Named("command_loader"))
 public class CommandParameterLoader extends RuleBasedParameterLoader<CommandParameterLoaderContext> {
 
     public CommandParameterLoader() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/DefaultProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/DefaultProviders.java
@@ -1,0 +1,27 @@
+package org.dockbox.hartshorn.core;
+
+import org.dockbox.hartshorn.core.annotations.activate.UseBootstrap;
+import org.dockbox.hartshorn.core.annotations.activate.UseServiceProvision;
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.context.ConcreteContextCarrier;
+import org.dockbox.hartshorn.core.context.ContextCarrier;
+import org.dockbox.hartshorn.core.proxy.DelegatorAccessor;
+import org.dockbox.hartshorn.core.proxy.DelegatorAccessorImpl;
+
+import javax.inject.Singleton;
+
+@Service(activators = { UseBootstrap.class, UseServiceProvision.class })
+public class DefaultProviders {
+
+    @Provider
+    @Singleton
+    public Class<? extends ContextCarrier> contextCarrier() {
+        return ConcreteContextCarrier.class;
+    }
+
+    @Provider
+    public Class<? extends DelegatorAccessor> delegatorAccessor() {
+        return DelegatorAccessorImpl.class;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ConcreteContextCarrier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ConcreteContextCarrier.java
@@ -16,8 +16,6 @@
 
 package org.dockbox.hartshorn.core.context;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
-
 import javax.inject.Inject;
 
 import lombok.Getter;
@@ -25,7 +23,6 @@ import lombok.Getter;
 /**
  * A concrete implementation of {@link ContextCarrier}.
  */
-@ComponentBinding(value = ContextCarrier.class, singleton = true)
 public class ConcreteContextCarrier implements ContextCarrier {
     @Inject
     @Getter

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ConstructorContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ConstructorContext.java
@@ -111,6 +111,11 @@ public final class ConstructorContext<T> extends ExecutableElementContext<Constr
     }
 
     @Override
+    public TypeContext<T> genericType() {
+        return this.type();
+    }
+
+    @Override
     public String name() {
         return this.qualifiedName();
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/MethodContext.java
@@ -32,7 +32,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-public class MethodContext<T, P> extends ExecutableElementContext<Method, P> {
+public class MethodContext<T, P> extends ExecutableElementContext<Method, P> implements ObtainableElement<T>, TypedElementContext<T> {
 
     private static final Map<Method, MethodContext<?, ?>> cache = new ConcurrentHashMap<>();
 
@@ -73,7 +73,7 @@ public class MethodContext<T, P> extends ExecutableElementContext<Method, P> {
         final Object[] args = this.arguments(context);
         return this.invoke(instance, args);
     }
-    
+
     public Exceptional<T> invoke(final ApplicationContext context, final Collection<Object> arguments) {
         return this.invoke(context.get(this.parent()), arguments);
     }
@@ -141,5 +141,20 @@ public class MethodContext<T, P> extends ExecutableElementContext<Method, P> {
 
     public boolean isProtected() {
         return this.has(AccessModifier.PROTECTED);
+    }
+
+    @Override
+    public Exceptional<T> obtain(final ApplicationContext applicationContext) {
+        return this.invoke(applicationContext);
+    }
+
+    @Override
+    public TypeContext<T> type() {
+        return this.returnType();
+    }
+
+    @Override
+    public TypeContext<T> genericType() {
+        return this.genericReturnType();
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ObtainableElement.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ObtainableElement.java
@@ -1,0 +1,8 @@
+package org.dockbox.hartshorn.core.context.element;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+public interface ObtainableElement<R> {
+    Exceptional<R> obtain(ApplicationContext applicationContext);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ParameterContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/ParameterContext.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 
-// skipcq: JAVA-W0100
 public final class ParameterContext<T> extends AnnotatedElementContext<Parameter> implements TypedElementContext<T> {
 
     private final Parameter parameter;
@@ -77,6 +76,7 @@ public final class ParameterContext<T> extends AnnotatedElementContext<Parameter
         );
     }
 
+    @Override
     public TypeContext<T> type() {
         if (this.type == null) {
             this.type = TypeContext.of((Class<T>) this.element().getType());
@@ -84,6 +84,7 @@ public final class ParameterContext<T> extends AnnotatedElementContext<Parameter
         return this.type;
     }
 
+    @Override
     public TypeContext<T> genericType() {
         if (this.genericType == null) {
             final Type genericType = this.element().getParameterizedType();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -57,7 +57,6 @@ import javax.inject.Inject;
 import javassist.util.proxy.ProxyFactory;
 import lombok.Getter;
 
-// skipcq: JAVA-W0100
 public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
 
     private static final Map<Class<?>, TypeContext<?>> CACHE = new ConcurrentHashMap<>();

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypedElementContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypedElementContext.java
@@ -20,4 +20,5 @@ import org.dockbox.hartshorn.core.domain.Named;
 
 public interface TypedElementContext<T> extends QualifiedElement, Named {
     TypeContext<T> type();
+    TypeContext<T> genericType();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/DelegatorAccessorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/proxy/DelegatorAccessorImpl.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.core.proxy;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
+import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 
 import lombok.RequiredArgsConstructor;
 
-@ComponentBinding(value = DelegatorAccessor.class, permitProxying = false)
+@Component(permitProxying = false)
 @RequiredArgsConstructor(onConstructor_ = @Bound)
 public class DelegatorAccessorImpl<T> implements DelegatorAccessor<T> {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ProviderServicePreProcessor.java
@@ -24,8 +24,9 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.AnnotatedElementContext;
 import org.dockbox.hartshorn.core.context.element.FieldContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
+import org.dockbox.hartshorn.core.context.element.ObtainableElement;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.core.context.element.TypedElementContext;
 import org.dockbox.hartshorn.core.inject.ProviderContext;
 
 import java.util.List;
@@ -47,25 +48,45 @@ public final class ProviderServicePreProcessor implements ServicePreProcessor<Us
 
         context.log().debug("Found " + (methods.size() + fields.size()) + " method providers in " + type.name());
 
-        for (final MethodContext<?, T> method : methods) {
-            this.process(context, method, MethodContext::returnType, m -> m.invoke(context));
-        }
+        for (final MethodContext<?, T> method : methods)
+            this.processContext(context, method);
 
-        for (final FieldContext<?> field : fields) {
-            this.process(context, field, FieldContext::type, f -> f.get(context.get(key)));
-        }
+        for (final FieldContext<?> field : fields)
+            this.processContext(context, field);
     }
 
-    private <T extends AnnotatedElementContext<?>> void process(final ApplicationContext context, final T element, final Function<T, TypeContext<?>> type, final Function<T, Exceptional<?>> getter) {
+    private <E extends AnnotatedElementContext<?> & ObtainableElement<?> & TypedElementContext<?>> void processContext(final ApplicationContext context, final E element) {
+        if (element.type().is(Class.class))
+            this.processClassBinding(context, element.genericType(), (AnnotatedElementContext<?> & ObtainableElement<Class<Object>>) element);
+        else if (element.type().is(TypeContext.class))
+            this.processTypeBinding(context, element.genericType(), (AnnotatedElementContext<?> & ObtainableElement<TypeContext<Object>>) element);
+        else
+            this.processInstanceBinding(context, element, E::type);
+    }
+
+    private <T extends AnnotatedElementContext<?> & ObtainableElement<?>> void processInstanceBinding(final ApplicationContext context, final T element, final Function<T, TypeContext<?>> type) {
         final boolean singleton = context.meta().singleton(element);
         final Provider annotation = element.annotation(Provider.class).get();
+        final Key<?> providerKey = Key.of(type.apply(element), annotation.value());
+        final ProviderContext<?> providerContext = new ProviderContext<>(((Key<Object>) providerKey), singleton, annotation.priority(), () -> element.obtain(context).rethrowUnchecked().orNull());
 
-        final Key<?> providerKey = "".equals(annotation.value())
-                ? Key.of(type.apply(element).type())
-                : Key.of(type.apply(element).type(), annotation.value());
-
-        final ProviderContext<?> providerContext = new ProviderContext<>(((Key<Object>) providerKey), singleton, annotation.priority(), () -> getter.apply(element).rethrowUnchecked().orNull());
         context.add(providerContext);
+    }
+
+    private <R, C extends Class<R>, E extends AnnotatedElementContext<?> & ObtainableElement<C>> void processClassBinding(final ApplicationContext context, final TypeContext<?> generic, final E element) {
+        final TypeContext<R> typeContext = (TypeContext<R>) generic.typeParameters().get(0);
+        final Provider annotation = element.annotation(Provider.class).get();
+        final Key<R> key = Key.of(typeContext, annotation.value());
+
+        context.bind(key, element.obtain(context).get());
+    }
+
+    private <R, C extends TypeContext<R>, E extends AnnotatedElementContext<?> & ObtainableElement<C>> void processTypeBinding(final ApplicationContext context, final TypeContext<?> generic, final E element) {
+        final TypeContext<R> typeContext = (TypeContext<R>) generic.typeParameters().get(0);
+        final Provider annotation = element.annotation(Provider.class).get();
+        final Key<R> key = Key.of(typeContext, annotation.value());
+
+        context.bind(key, element.obtain(context).get().type());
     }
 
     @Override

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/PersistenceProviders.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/PersistenceProviders.java
@@ -1,0 +1,17 @@
+package org.dockbox.hartshorn.data;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
+import org.dockbox.hartshorn.data.jpa.JpaParameterLoader;
+
+@Service(activators = UsePersistence.class)
+public class PersistenceProviders {
+
+    @Provider("jpa_query")
+    public ParameterLoader jpaParameterLoader() {
+        return new JpaParameterLoader();
+    }
+
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -18,7 +18,6 @@ package org.dockbox.hartshorn.data.hibernate;
 
 import org.dockbox.hartshorn.core.Enableable;
 import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -62,7 +61,6 @@ import javax.persistence.criteria.CriteriaQuery;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-@ComponentBinding(JpaRepository.class)
 public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enableable, Closeable {
 
     private final Map<Class<? extends Remote<?>>, String> dialects = new ConcurrentHashMap<>();

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateProviders.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateProviders.java
@@ -1,0 +1,32 @@
+package org.dockbox.hartshorn.data.hibernate;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.data.QueryFunction;
+import org.dockbox.hartshorn.data.TransactionManager;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
+import org.dockbox.hartshorn.data.jpa.JpaRepository;
+
+@Service(activators = UsePersistence.class)
+public class HibernateProviders {
+
+    @Provider
+    public Class<? extends JpaRepository> jpaRepository() {
+        return HibernateJpaRepository.class;
+    }
+
+    @Provider
+    public Class<? extends TransactionManager> transactionManager() {
+        return HibernateTransactionManager.class;
+    }
+
+    @Provider
+    public QueryFunction queryFunction() {
+        return new HibernateQueryFunction();
+    }
+
+    @Provider
+    public Class<? extends HibernateRemote> remote() {
+        return HibernateRemoteImpl.class;
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateQueryFunction.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateQueryFunction.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.data.hibernate;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.data.QueryFunction;
 import org.dockbox.hartshorn.data.context.QueryContext;
 import org.hibernate.Session;
@@ -25,7 +24,6 @@ import java.util.function.Function;
 
 import javax.persistence.Query;
 
-@ComponentBinding(QueryFunction.class)
 public class HibernateQueryFunction implements QueryFunction {
 
     @Override

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.data.hibernate;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.data.remote.PersistenceConnection;
@@ -27,7 +26,6 @@ import javax.inject.Inject;
 import lombok.Getter;
 
 @Getter
-@ComponentBinding(HibernateRemote.class)
 public class HibernateRemoteImpl implements HibernateRemote {
 
     private final String driver;

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateTransactionManager.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateTransactionManager.java
@@ -16,14 +16,12 @@
 
 package org.dockbox.hartshorn.data.hibernate;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.data.TransactionManager;
 import org.hibernate.Session;
 
 import javax.persistence.EntityManager;
 
-@ComponentBinding(TransactionManager.class)
 public class HibernateTransactionManager implements TransactionManager {
 
     private final Session session;

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
@@ -34,7 +34,6 @@ import com.fasterxml.jackson.databind.node.ValueNode;
 
 import org.dockbox.hartshorn.core.GenericType;
 import org.dockbox.hartshorn.core.Key;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -55,7 +54,6 @@ import java.util.Map.Entry;
 
 import javax.inject.Inject;
 
-@ComponentBinding(org.dockbox.hartshorn.data.mapping.ObjectMapper.class)
 public class JacksonObjectMapper extends DefaultObjectMapper {
 
     private Include include = Include.ALWAYS;

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonProviders.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonProviders.java
@@ -1,0 +1,32 @@
+package org.dockbox.hartshorn.data.jackson;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
+import org.dockbox.hartshorn.data.mapping.ObjectMapper;
+
+@Service(activators = UsePersistence.class)
+public class JacksonProviders {
+
+    @Provider("properties")
+    private final JacksonDataMapper properties = new JavaPropsDataMapper();
+
+    @Provider("json")
+    private final JacksonDataMapper json = new JsonDataMapper();
+
+    @Provider("toml")
+    private final JacksonDataMapper toml = new TomlDataMapper();
+
+    @Provider("xml")
+    private final JacksonDataMapper xml = new XmlDataMapper();
+
+    @Provider("yml")
+    private final JacksonDataMapper yml = new YamlDataMapper();
+
+    @Provider
+    public ObjectMapper objectMapper() {
+        if (TypeContext.lookup("com.fasterxml.jackson.databind.ObjectMapper").isVoid()) throw new IllegalStateException("Jackson is not available");
+        return new JacksonObjectMapper();
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JavaPropsDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JavaPropsDataMapper.java
@@ -19,13 +19,9 @@ package org.dockbox.hartshorn.data.jackson;
 import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 import com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.data.FileFormat;
 import org.dockbox.hartshorn.data.FileFormats;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = JacksonDataMapper.class, named = @Named("properties"))
 public class JavaPropsDataMapper implements JacksonDataMapper {
     @Override
     public FileFormat fileFormat() {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JsonDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JsonDataMapper.java
@@ -19,13 +19,9 @@ package org.dockbox.hartshorn.data.jackson;
 import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.data.FileFormat;
 import org.dockbox.hartshorn.data.FileFormats;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = JacksonDataMapper.class, named = @Named("json"))
 public class JsonDataMapper implements JacksonDataMapper{
 
     @Override

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/TomlDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/TomlDataMapper.java
@@ -19,13 +19,9 @@ package org.dockbox.hartshorn.data.jackson;
 import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 import com.fasterxml.jackson.dataformat.toml.TomlMapper;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.data.FileFormat;
 import org.dockbox.hartshorn.data.FileFormats;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = JacksonDataMapper.class, named = @Named("toml"))
 public class TomlDataMapper implements JacksonDataMapper {
     @Override
     public FileFormat fileFormat() {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/XmlDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/XmlDataMapper.java
@@ -19,13 +19,9 @@ package org.dockbox.hartshorn.data.jackson;
 import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.data.FileFormat;
 import org.dockbox.hartshorn.data.FileFormats;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = JacksonDataMapper.class, named = @Named("xml"))
 public class XmlDataMapper implements JacksonDataMapper {
     @Override
     public FileFormat fileFormat() {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/YamlDataMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/YamlDataMapper.java
@@ -22,13 +22,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.data.FileFormat;
 import org.dockbox.hartshorn.data.FileFormats;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = JacksonDataMapper.class, named = @Named("yml"))
 public class YamlDataMapper implements JacksonDataMapper {
     @Override
     public FileFormat fileFormat() {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jpa/JpaParameterLoader.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jpa/JpaParameterLoader.java
@@ -16,15 +16,10 @@
 
 package org.dockbox.hartshorn.data.jpa;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
-import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 import org.dockbox.hartshorn.data.context.JpaParameterLoaderContext;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = ParameterLoader.class, named = @Named("jpa_query"))
 public class JpaParameterLoader extends RuleBasedParameterLoader<JpaParameterLoaderContext> {
 
     public JpaParameterLoader() {

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DataStructuresSerializersTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DataStructuresSerializersTests.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.data;
 import org.dockbox.hartshorn.core.GenericType;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
 import org.dockbox.hartshorn.data.registry.Registry;
 import org.dockbox.hartshorn.data.registry.RegistryColumn;
@@ -35,6 +36,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 
 @HartshornTest
+@UsePersistence
 public class DataStructuresSerializersTests {
 
     @Inject

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/ObjectMappingTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/ObjectMappingTests.java
@@ -25,6 +25,7 @@ import org.dockbox.hartshorn.data.FileFormats;
 import org.dockbox.hartshorn.data.MultiElement;
 import org.dockbox.hartshorn.data.NestedElement;
 import org.dockbox.hartshorn.data.PersistentElement;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.jackson.JacksonObjectMapper;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +40,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 
 @HartshornTest
+@UsePersistence
 public class ObjectMappingTests {
 
     @Inject

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/PersistenceModifiersTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/PersistenceModifiersTests.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.data.mapping;
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 
 @HartshornTest
+@UsePersistence
 public class PersistenceModifiersTests {
 
     @Inject

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -19,7 +19,6 @@ package org.dockbox.hartshorn.events;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -36,12 +35,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * A simple default implementation of {@link EventBus}, used for internal event posting and
  * handling.
  */
-@ComponentBinding(value = EventBus.class, singleton = true)
+@Singleton
 public class EventBusImpl implements EventBus {
 
     protected final Set<Function<MethodContext<?, ?>, Exceptional<Boolean>>> validators = HartshornUtils.emptyConcurrentSet();

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
@@ -1,0 +1,24 @@
+package org.dockbox.hartshorn.events;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.events.annotations.UseEvents;
+import org.dockbox.hartshorn.events.handle.EventParameterLoader;
+
+import javax.inject.Singleton;
+
+@Service(activators = UseEvents.class)
+public class EventProviders {
+
+    @Singleton
+    @Provider
+    public EventBus eventBus() {
+        return new EventBusImpl();
+    }
+
+    @Provider("event_loader")
+    public ParameterLoader eventParameterLoader() {
+        return new EventParameterLoader();
+    }
+}

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoader.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventParameterLoader.java
@@ -16,13 +16,8 @@
 
 package org.dockbox.hartshorn.events.handle;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
-import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = ParameterLoader.class, named = @Named("event_loader"))
 public class EventParameterLoader extends RuleBasedParameterLoader<EventParameterLoaderContext> {
     public EventParameterLoader() {
         this.add(new EventParameterRule());

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.events;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.events.annotations.Listener.Priority;
+import org.dockbox.hartshorn.events.annotations.UseEvents;
 import org.dockbox.hartshorn.events.listeners.BasicEventListener;
 import org.dockbox.hartshorn.events.listeners.GenericEventListener;
 import org.dockbox.hartshorn.events.listeners.PriorityEventListener;
@@ -36,6 +37,7 @@ import javax.inject.Inject;
 import lombok.Getter;
 
 @HartshornTest
+@UseEvents
 public class EventBusTests {
 
     @Inject

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/BundledTranslationService.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/BundledTranslationService.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.i18n;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
@@ -24,7 +23,6 @@ import javax.inject.Inject;
 
 import lombok.Getter;
 
-@ComponentBinding(TranslationService.class)
 public class BundledTranslationService implements TranslationService {
 
     @Inject

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.i18n;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.data.FileFormats;
@@ -37,7 +36,6 @@ import javax.inject.Inject;
 import lombok.Getter;
 import lombok.Setter;
 
-@ComponentBinding(TranslationBundle.class)
 public class DefaultTranslationBundle implements TranslationBundle {
 
     @Inject

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationProviders.java
@@ -1,0 +1,19 @@
+package org.dockbox.hartshorn.i18n;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
+
+@Service(activators = UseTranslations.class)
+public class TranslationProviders {
+
+    @Provider
+    public TranslationService translationService() {
+        return new BundledTranslationService();
+    }
+
+    @Provider
+    public TranslationBundle translationBundle() {
+        return new DefaultTranslationBundle();
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ErrorServletImpl.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ErrorServletImpl.java
@@ -16,10 +16,8 @@
 
 package org.dockbox.hartshorn.web;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.web.servlet.ErrorServlet;
 
-@ComponentBinding(ErrorServlet.class)
 public class ErrorServletImpl implements ErrorServlet {
     @Override
     public void handle(final RequestError error) {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpServerProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpServerProviders.java
@@ -1,0 +1,39 @@
+package org.dockbox.hartshorn.web;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.web.annotations.UseHttpServer;
+import org.dockbox.hartshorn.web.processing.HttpServletParameterLoader;
+import org.dockbox.hartshorn.web.servlet.ErrorServlet;
+import org.dockbox.hartshorn.web.servlet.WebServlet;
+import org.dockbox.hartshorn.web.servlet.WebServletImpl;
+
+@Service(activators = UseHttpServer.class)
+public abstract class HttpServerProviders {
+
+    @Provider
+    public ErrorServlet errorServlet() {
+        return new ErrorServletImpl();
+    }
+
+    @Provider
+    public Class<? extends WebServlet> webServlet() {
+        return WebServletImpl.class;
+    }
+
+    @Provider
+    public Class<WebServletImpl> webServletImpl() {
+        return WebServletImpl.class;
+    }
+
+    @Provider
+    public Class<ServletHandler> servletHandler() {
+        return ServletHandler.class;
+    }
+
+    @Provider("http_webserver")
+    public ParameterLoader parameterLoader() {
+        return new HttpServletParameterLoader();
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -16,16 +16,15 @@
 
 package org.dockbox.hartshorn.web;
 
-import org.dockbox.hartshorn.data.annotations.Value;
 import org.dockbox.hartshorn.core.Enableable;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.boot.Hartshorn;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.data.annotations.Value;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
 import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
 import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
@@ -39,7 +38,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.Getter;
 
-@ComponentBinding(ServletHandler.class)
 public class ServletHandler implements Enableable {
 
     private final HttpWebServer starter;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.web.jetty;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.web.HttpStatus;
 import org.dockbox.hartshorn.web.HttpWebServer;
@@ -31,7 +30,6 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@ComponentBinding(DirectoryServlet.class)
 public class JettyDirectoryServlet implements DirectoryServlet {
 
     @Inject

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.web.jetty;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.boot.Hartshorn;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
@@ -44,7 +43,6 @@ import javax.servlet.Servlet;
 import lombok.Getter;
 import lombok.Setter;
 
-@ComponentBinding(HttpWebServer.class)
 public class JettyHttpWebServer extends DefaultHttpWebServer {
 
     @Inject @Getter

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyProviders.java
@@ -1,0 +1,21 @@
+package org.dockbox.hartshorn.web.jetty;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.web.HttpWebServer;
+import org.dockbox.hartshorn.web.annotations.UseHttpServer;
+import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
+
+@Service(activators = UseHttpServer.class)
+public class JettyProviders {
+
+    @Provider
+    public DirectoryServlet directoryServlet() {
+        return new JettyDirectoryServlet();
+    }
+
+    @Provider
+    public HttpWebServer httpWebServer(final JettyResourceService resourceService) {
+        return new JettyHttpWebServer(resourceService);
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MVCProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/MVCProviders.java
@@ -1,0 +1,22 @@
+package org.dockbox.hartshorn.web.mvc;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
+import org.dockbox.hartshorn.web.annotations.UseMvcServer;
+import org.dockbox.hartshorn.web.processing.MvcParameterLoader;
+import org.dockbox.hartshorn.web.servlet.MvcServlet;
+
+@Service(activators = UseMvcServer.class)
+public class MVCProviders {
+
+    @Provider("mvc_webserver")
+    public ParameterLoader mvcParameterLoader() {
+        return new MvcParameterLoader();
+    }
+
+    @Provider
+    public Class<MvcServlet> mvcServlet() {
+        return MvcServlet.class;
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
@@ -17,7 +17,6 @@
 package org.dockbox.hartshorn.web.mvc.freemarker;
 
 import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.boot.Hartshorn;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -35,13 +34,15 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
+import javax.inject.Singleton;
+
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import freemarker.template.TemplateModelException;
 
-@ComponentBinding(value = MVCInitializer.class, singleton = true)
+@Singleton
 public class FreeMarkerMVCInitializer implements MVCInitializer {
 
     private Configuration configuration;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.web.mvc.freemarker;
+
+import org.dockbox.hartshorn.core.annotations.inject.Provider;
+import org.dockbox.hartshorn.core.annotations.stereotype.Service;
+import org.dockbox.hartshorn.web.annotations.UseMvcServer;
+import org.dockbox.hartshorn.web.mvc.MVCInitializer;
+
+import javax.inject.Singleton;
+
+@Service(activators = UseMvcServer.class)
+public class FreeMarkerProviders {
+
+    @Provider
+    @Singleton
+    public MVCInitializer mvcInitializer() {
+        return new FreeMarkerMVCInitializer();
+    }
+}

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpServletParameterLoader.java
@@ -16,9 +16,7 @@
 
 package org.dockbox.hartshorn.web.processing;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
-import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.HeaderRequestParameterRule;
@@ -26,9 +24,6 @@ import org.dockbox.hartshorn.web.processing.rules.RequestQueryParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.ServletRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.ServletResponseParameterRule;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = ParameterLoader.class, named = @Named("http_webserver"))
 public class HttpServletParameterLoader extends RuleBasedParameterLoader<HttpRequestParameterLoaderContext> {
 
     public HttpServletParameterLoader() {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoader.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoader.java
@@ -16,9 +16,7 @@
 
 package org.dockbox.hartshorn.web.processing;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
-import org.dockbox.hartshorn.core.services.parameter.ParameterLoader;
 import org.dockbox.hartshorn.core.services.parameter.RuleBasedParameterLoader;
 import org.dockbox.hartshorn.web.processing.rules.BodyRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.HeaderRequestParameterRule;
@@ -26,9 +24,6 @@ import org.dockbox.hartshorn.web.processing.rules.RequestQueryParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.ServletRequestParameterRule;
 import org.dockbox.hartshorn.web.processing.rules.ServletResponseParameterRule;
 
-import javax.inject.Named;
-
-@ComponentBinding(value = ParameterLoader.class, named = @Named("mvc_webserver"))
 public class MvcParameterLoader extends RuleBasedParameterLoader<MvcParameterLoaderContext> {
 
     public MvcParameterLoader() {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/MvcServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/MvcServlet.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.web.servlet;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -38,7 +37,6 @@ import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@ComponentBinding(MvcServlet.class)
 public class MvcServlet implements WebServlet {
 
     private final MethodContext<ViewTemplate, ?> methodContext;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletFactory.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletFactory.java
@@ -29,6 +29,6 @@ public interface WebServletFactory {
     @Factory
     WebServletImpl webServlet(final HttpWebServer starter, final RequestHandlerContext context);
 
-    @Factory
+    @Factory(required = false)
     MvcServlet mvc(final MethodContext<ViewTemplate, ?> methodContext);
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletImpl.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletImpl.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.web.servlet;
 
-import org.dockbox.hartshorn.core.annotations.inject.ComponentBinding;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.dockbox.hartshorn.web.HttpAction;
@@ -31,7 +30,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.Getter;
 
-@ComponentBinding(WebServletImpl.class)
 public class WebServletImpl implements WebServlet {
 
     @Getter

--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.core.context.element.ExecutableElementContext;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
+import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.dockbox.hartshorn.web.annotations.RequestHeader;
 import org.dockbox.hartshorn.web.annotations.http.HttpRequest;
@@ -47,6 +48,7 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.Getter;
 
 @HartshornTest
+@UsePersistence
 public class RequestArgumentProcessorTests {
 
     @Inject


### PR DESCRIPTION
# Description
Currently, `@Provider` only permits binding types to a supplier (lazy) or instance (singleton) through methods and fields. However, it is currently not possible to create static bindings.  

Static binding requires the binding of a type `C` to a type `T extends C`. So, this will require the use of either `Class` or `TypeContext` to indicate which implementation type should bind to the contract type `C`.  

#692 introduces the required support for this feature; making it possible to use wildcard upper bounds in return types so we can bind to a specific type. This would look as follows:
```java
@Provider
public Class<? extends C> someStaticBinding() {
    return T.class;
}
```

This is also how this has been implemented. This supports both `Class<T>` and `TypeContext<T>`  as long as the return type has a type parameter with upper bounds available (so anything that isn't a plain wildcard).  

This supports both methods and fields, and singleton providers. Singleton providers are translated to the following pseudo-code:
```java
// given
Type<C> contract;
Provider provider;
// perform
Type<T :: C> binding = provider.obtain()
Supplier<C> supplier = () -> ApplicationContext.get(binding)
ApplicationContext.bind(contract, supplier)
```
Important to note is that this is lazy-loaded, depending on the underlying `ApplicationContext` implementation, due to the use of suppliers instead of direct instance binding.  

Internal usages of `ComponentBinding` have been migrated to support this new implementation so they can be filtered by activators. This does _not_ affect the implementation of `ComponentBinding`, only its _internal_ usages.

Fixes #697 

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Refactor (code changes that do not affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
