### PR TITLE
#700 Cleanup and deprecation notices for `HartshornUtils` and usages

### DIFF
--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/modifiers/CacheServicePostProcessor.java
@@ -28,7 +28,7 @@ import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.proxy.ProxyFunction;
-import org.dockbox.hartshorn.core.services.ComponentContainer;
+import org.dockbox.hartshorn.core.services.ComponentUtilities;
 import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 
 import java.lang.annotation.Annotation;
@@ -52,7 +52,7 @@ public abstract class CacheServicePostProcessor<A extends Annotation> extends Se
                 name = annotation.get().value();
             }
             else {
-                name = ComponentContainer.id(context, methodContext.type());
+                name = ComponentUtilities.id(context, methodContext.type());
             }
         }
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
@@ -27,7 +27,7 @@ import org.dockbox.hartshorn.commands.definition.CommandPartial;
 import org.dockbox.hartshorn.commands.definition.GroupCommandElement;
 import org.dockbox.hartshorn.commands.exceptions.ParsingException;
 import org.dockbox.hartshorn.commands.service.CommandParameter;
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.i18n.Message;
@@ -119,7 +119,7 @@ public class CommandParserImpl implements CommandParser {
         while (matcher.find()) {
             final String flag = matcher.group().trim();
             final String nameUntrimmed = flag.split(" ")[0];
-            final String name = HartshornUtils.trimWith('-', nameUntrimmed);
+            final String name = StringUtilities.trimWith('-', nameUntrimmed);
             final Exceptional<CommandFlag> commandFlag = context.flag(name);
             if (commandFlag.absent()) throw new ParsingException(this.resources.unknownFlag(name));
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/DefaultArgumentConverters.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.commands.arguments;
 
 import org.dockbox.hartshorn.commands.annotations.UseCommands;
 import org.dockbox.hartshorn.commands.definition.ArgumentConverter;
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.adapter.BuiltInStringTypeAdapters;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.domain.Exceptional;
@@ -86,7 +86,7 @@ public final class DefaultArgumentConverters {
             .build();
 
     public static final ArgumentConverter<Duration> DURATION = ArgumentConverterImpl.builder(Duration.class, "duration")
-            .withConverter(HartshornUtils::durationOf)
+            .withConverter(StringUtilities::durationOf)
             .build();
 
     public static final ArgumentConverter<Message> MESSAGE = ArgumentConverterImpl.builder(Message.class, "resource", "i18n", "translation")

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandContextImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/CommandContextImpl.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.commands.context;
 
 import org.dockbox.hartshorn.commands.CommandSource;
 import org.dockbox.hartshorn.commands.service.CommandParameter;
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.CollectionUtilities;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.DefaultContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
@@ -50,7 +50,7 @@ public class CommandContextImpl extends DefaultContext implements CommandContext
 
     @Override
     public <T> T get(final String key) {
-        return HartshornUtils.merge(this.args, this.flags)
+        return CollectionUtilities.merge(this.args, this.flags)
                 .stream()
                 .map(CommandParameter.class::cast)
                 .filter(arg -> arg.trimmedKey().equals(key))
@@ -66,7 +66,7 @@ public class CommandContextImpl extends DefaultContext implements CommandContext
 
     @Override
     public boolean has(final String key) {
-        return HartshornUtils.merge(this.args, this.flags)
+        return CollectionUtilities.merge(this.args, this.flags)
                 .stream()
                 .map(CommandParameter.class::cast)
                 .anyMatch(arg -> arg.trimmedKey().equals(key));

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/definition/CommandFlagElement.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/definition/CommandFlagElement.java
@@ -16,9 +16,9 @@
 
 package org.dockbox.hartshorn.commands.definition;
 
-import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.commands.CommandSource;
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
+import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.Collection;
 
@@ -57,7 +57,7 @@ public class CommandFlagElement<T> implements CommandFlag, CommandElement<T> {
 
     @Override
     public String name() {
-        return HartshornUtils.trimWith('-', this.element.name());
+        return StringUtilities.trimWith('-', this.element.name());
     }
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/definition/CommandFlagImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/definition/CommandFlagImpl.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.commands.definition;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 
 import lombok.AllArgsConstructor;
 
@@ -30,7 +30,7 @@ public class CommandFlagImpl implements CommandFlag {
 
     @Override
     public String name() {
-        return HartshornUtils.trimWith('-', this.name);
+        return StringUtilities.trimWith('-', this.name);
     }
 
     @Override

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameter.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/service/CommandParameter.java
@@ -17,7 +17,7 @@
 package org.dockbox.hartshorn.commands.service;
 
 import org.dockbox.hartshorn.commands.context.CommandContext;
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -36,7 +36,7 @@ public class CommandParameter<T> {
     private final String key;
 
     public String trimmedKey() {
-        return HartshornUtils.trimWith('-', this.key());
+        return StringUtilities.trimWith('-', this.key());
     }
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/CollectionUtilities.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/CollectionUtilities.java
@@ -1,0 +1,59 @@
+package org.dockbox.hartshorn.core;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+public final class CollectionUtilities {
+
+    /**
+     * Constructs a new unique map from a given set of {@link Entry entries}. If no entries are
+     * provided an empty {@link Map} is returned. The constructed map is not concurrent.
+     * Entries can easily be created using {@link org.dockbox.hartshorn.core.domain.tuple.Tuple#of(Object, Object)}
+     *
+     * @param <K> The (super)type of all keys in the entry set
+     * @param <V> The (super)type of all values in the entry set
+     * @param entries The entries to use while constructing a new map
+     *
+     * @return The new non-concurrent map
+     * @throws NullPointerException If an entry is null
+     * @see org.dockbox.hartshorn.core.domain.tuple.Tuple#of(Object, Object)
+     */
+    @SafeVarargs
+    public static <K, V> Map<K, V> ofEntries(final Entry<? extends K, ? extends V>... entries) {
+        if (0 == entries.length) { // implicit null check of entries array
+            return new HashMap<>();
+        }
+        else {
+            final Map<K, V> map = new HashMap<>();
+            for (final Entry<? extends K, ? extends V> entry : entries) {
+                map.put(entry.getKey(), entry.getValue());
+            }
+            return map;
+        }
+    }
+
+    @SafeVarargs
+    public static <T> Collection<T> merge(final Collection<T>... collections) {
+        final Collection<T> merged = new HashSet<>();
+        for (final Collection<T> collection : collections) {
+            merged.addAll(collection);
+        }
+        return merged;
+    }
+
+    public static <T> Set<T> difference(final Collection<T> collectionOne, final Collection<T> collectionTwo) {
+        final BiFunction<Collection<T>, Collection<T>, List<T>> filter = (c1, c2) -> c1.stream()
+                .filter(element -> !c2.contains(element))
+                .toList();
+        final List<T> differenceInOne = filter.apply(collectionOne, collectionTwo);
+        final List<T> differenceInTwo = filter.apply(collectionTwo, collectionOne);
+        return Set.copyOf(CollectionUtilities.merge(differenceInOne, differenceInTwo));
+    }
+
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/HartshornUtils.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/HartshornUtils.java
@@ -17,7 +17,6 @@
 package org.dockbox.hartshorn.core;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.tuple.Vector3N;
 import org.dockbox.hartshorn.core.function.CheckedRunnable;
@@ -35,15 +34,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.regex.Matcher;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -52,23 +48,6 @@ import java.util.stream.StreamSupport;
  * accessed at once and indexed more easily.
  */
 public final class HartshornUtils {
-
-    private static final Random random = new Random();
-    private static final char[] _hex = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
-    };
-    private static final java.util.regex.Pattern minorTimeString = java.util.regex.Pattern.compile("^\\d+$");
-    private static final java.util.regex.Pattern timeString = java.util.regex.Pattern.compile("^((\\d+)w)?((\\d+)d)?((\\d+)h)?((\\d+)m)?((\\d+)s)?$");
-    private static final int secondsInMinute = 60;
-    private static final int secondsInHour = 60 * HartshornUtils.secondsInMinute;
-    private static final int secondsInDay = 24 * HartshornUtils.secondsInHour;
-    private static final int secondsInWeek = 7 * HartshornUtils.secondsInDay;
-    /**
-     * The globally 'empty' unique ID which can be used for empty implementations of {@link
-     * org.dockbox.hartshorn.core.domain.Identifiable}.
-     */
-    public static UUID EMPTY_UUID = UUID.fromString("00000000-1111-2222-3333-000000000000");
 
     private HartshornUtils() {}
 
@@ -84,7 +63,9 @@ public final class HartshornUtils {
      * @return The new non-concurrent map
      * @throws NullPointerException If an entry is null
      * @see org.dockbox.hartshorn.core.domain.tuple.Tuple#of(Object, Object)
+     * @deprecated Use {@link CollectionUtilities#ofEntries(Entry[])} instead.
      */
+    @Deprecated(since = "22.2", forRemoval = true)
     @SafeVarargs
     public static <K, V> Map<K, V> ofEntries(final Entry<? extends K, ? extends V>... entries) {
         if (0 == entries.length) { // implicit null check of entries array
@@ -99,31 +80,49 @@ public final class HartshornUtils {
         }
     }
 
+    /**
+     * @deprecated Use {@link ConcurrentHashMap#newKeySet()} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> Set<T> emptyConcurrentSet() {
         return ConcurrentHashMap.newKeySet();
     }
 
+    /**
+     * @deprecated Use {@link List#of()} instead.
+     */
     @NonNull
     @SafeVarargs
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> List<T> asList(final T... objects) {
         return new ArrayList<>(Arrays.asList(objects));
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#capitalize(String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static String capitalize(final String value) {
         return HartshornUtils.empty(value)
                 ? value
                 : (value.substring(0, 1).toUpperCase() + value.substring(1));
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#empty(String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean empty(final String value) {
         return null == value || value.isEmpty();
     }
 
     // Both start and end are inclusive
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> T[] arraySubset(final T[] array, final int start, final int end) {
         return Arrays.copyOfRange(array, start, end + 1);
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static String contentOrEmpty(@NonNull final Path file) {
         try {
             return Files.readString(file);
@@ -141,6 +140,7 @@ public final class HartshornUtils {
      *
      * @return the t [ ]
      */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> T[] merge(final T[] arrayOne, final T[] arrayTwo) {
         final Set<T> merged = new HashSet<>();
         merged.addAll(Set.of(arrayOne));
@@ -148,10 +148,18 @@ public final class HartshornUtils {
         return merged.toArray(arrayOne);
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#notEmpty(String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean notEmpty(final String value) {
         return null != value && !value.isEmpty();
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#strip(String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static String strip(final String s) {
         return s.replaceAll("[\n\r ]+", "").trim();
     }
@@ -165,6 +173,7 @@ public final class HartshornUtils {
      * @return true if the function does not throw an exception
      * @see HartshornUtils#throwsException(CheckedRunnable)
      */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean doesNotThrow(final CheckedRunnable runnable) {
         return !HartshornUtils.throwsException(runnable);
     }
@@ -176,6 +185,7 @@ public final class HartshornUtils {
      *
      * @return true if the function throws an exception
      */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean throwsException(final CheckedRunnable runnable) {
         try {
             runnable.run();
@@ -197,6 +207,7 @@ public final class HartshornUtils {
      * @return true if the function does not throw an exception
      * @see HartshornUtils#throwsException(CheckedRunnable, Class)
      */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean doesNotThrow(final CheckedRunnable runnable, final Class<? extends Throwable> exception) {
         return !HartshornUtils.throwsException(runnable, exception);
     }
@@ -210,6 +221,7 @@ public final class HartshornUtils {
      *
      * @return true if the function throws the expected exception
      */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean throwsException(final CheckedRunnable runnable, final Class<? extends Throwable> exception) {
         try {
             runnable.run();
@@ -220,36 +232,18 @@ public final class HartshornUtils {
         }
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#durationOf(String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static Exceptional<Duration> durationOf(final String in) {
-        // First, if just digits, return the number in seconds.
-
-        if (HartshornUtils.minorTimeString.matcher(in).matches()) {
-            return Exceptional.of(Duration.ofSeconds(Long.parseUnsignedLong(in)));
-        }
-
-        final Matcher m = HartshornUtils.timeString.matcher(in);
-        if (m.matches()) {
-            long time = HartshornUtils.durationAmount(m.group(2), HartshornUtils.secondsInWeek);
-            time += HartshornUtils.durationAmount(m.group(4), HartshornUtils.secondsInDay);
-            time += HartshornUtils.durationAmount(m.group(6), HartshornUtils.secondsInHour);
-            time += HartshornUtils.durationAmount(m.group(8), HartshornUtils.secondsInMinute);
-            time += HartshornUtils.durationAmount(m.group(10), 1);
-
-            if (0 < time) {
-                return Exceptional.of(Duration.ofSeconds(time));
-            }
-        }
         return Exceptional.empty();
     }
 
-    private static long durationAmount(@Nullable final String g, final int multiplier) {
-        if (null != g && !g.isEmpty()) {
-            return multiplier * Long.parseUnsignedLong(g);
-        }
-
-        return 0;
-    }
-
+    /**
+     * @deprecated Use {@link CollectionUtilities#merge(Collection[])} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     @SafeVarargs
     public static <T> Collection<T> merge(final Collection<T>... collections) {
         final Collection<T> merged = new HashSet<>();
@@ -260,6 +254,7 @@ public final class HartshornUtils {
     }
 
     @SafeVarargs
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T, R> Object[] all(final Function<T, R> function, final T... input) {
         final Collection<R> out = new ArrayList<>();
         for (final T t : input) {
@@ -268,14 +263,17 @@ public final class HartshornUtils {
         return out.toArray();
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> Stream<T> stream(final Iterable<T> iterable) {
         return stream(iterable.iterator());
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> Stream<T> stream(final Iterator<T> tIterator) {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(tIterator, Spliterator.ORDERED), false);
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static String asTable(final List<List<String>> rows) {
         final int[] maxLengths = new int[rows.get(0).size()];
         for (final List<String> row : rows) {
@@ -297,10 +295,18 @@ public final class HartshornUtils {
         return result.toString();
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#capitalize(String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static String[] splitCapitals(final String s) {
         return s.split("(?=\\p{Lu})");
     }
 
+    /**
+     * @deprecated Use {@link StringUtilities#trimWith(char, String)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static String trimWith(final char c, final String s) {
         int len = s.length();
         int st = 0;
@@ -316,26 +322,33 @@ public final class HartshornUtils {
         return ((st > 0) || (len < s.length())) ? s.substring(st, len) : s;
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> List<T> list(final int size) {
         final List<T> list = new ArrayList<>();
         for (int i = 0; i < size; i++) list.add(null);
         return list;
     }
 
+    /**
+     * @deprecated Use {@link CollectionUtilities#difference(Collection, Collection)} instead.
+     */
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> Set<T> difference(final Collection<T> collectionOne, final Collection<T> collectionTwo) {
         final BiFunction<Collection<T>, Collection<T>, List<T>> filter = (c1, c2) -> c1.stream()
                 .filter(element -> !c2.contains(element))
                 .toList();
         final List<T> differenceInOne = filter.apply(collectionOne, collectionTwo);
         final List<T> differenceInTwo = filter.apply(collectionTwo, collectionOne);
-        return asSet(merge(differenceInOne, differenceInTwo));
+        return Set.copyOf(CollectionUtilities.merge(differenceInOne, differenceInTwo));
     }
 
     @NonNull
+    @Deprecated(since = "22.2", forRemoval = true)
     public static <T> Set<T> asSet(final Collection<T> collection) {
         return new HashSet<>(collection);
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static Vector3N cuboidSize(final Vector3N min, final Vector3N max) {
         final double x = max.xD() - min.xD();
         final double y = max.yD() - min.yD();
@@ -343,6 +356,7 @@ public final class HartshornUtils {
         return Vector3N.of(x, y, z);
     }
 
+    @Deprecated(since = "22.2", forRemoval = true)
     public static boolean isCI() {
         for (final StackTraceElement element : Thread.currentThread().getStackTrace()) {
             if (element.getClassName().startsWith("org.junit.")) return true;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/InjectorMetaProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/InjectorMetaProvider.java
@@ -24,6 +24,7 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.TypedOwner;
 import org.dockbox.hartshorn.core.domain.TypedOwnerImpl;
 import org.dockbox.hartshorn.core.services.ComponentContainer;
+import org.dockbox.hartshorn.core.services.ComponentUtilities;
 
 import javax.inject.Singleton;
 import javax.persistence.Entity;
@@ -51,7 +52,7 @@ public class InjectorMetaProvider implements MetaProvider {
                 }
             }
         }
-        return TypedOwnerImpl.of(ComponentContainer.id(this.context, type));
+        return TypedOwnerImpl.of(ComponentUtilities.id(this.context, type));
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/Key.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/Key.java
@@ -41,7 +41,7 @@ public class Key<C> {
     }
 
     public static <C> Key<C> of(final TypeContext<C> type, final Named name) {
-        if (name != null && !HartshornUtils.empty(name.value())) {
+        if (name != null && !StringUtilities.empty(name.value())) {
             return new Key<>(type, name);
         }
         return new Key<>(type, null);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/StringUtilities.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/StringUtilities.java
@@ -1,0 +1,85 @@
+package org.dockbox.hartshorn.core;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class StringUtilities {
+
+    private static final Pattern minorTimeString = Pattern.compile("^\\d+$");
+    private static final Pattern timeString = Pattern.compile("^((\\d+)w)?((\\d+)d)?((\\d+)h)?((\\d+)m)?((\\d+)s)?$");
+    private static final int secondsInMinute = 60;
+    private static final int secondsInHour = 60 * StringUtilities.secondsInMinute;
+    private static final int secondsInDay = 24 * StringUtilities.secondsInHour;
+    private static final int secondsInWeek = 7 * StringUtilities.secondsInDay;
+
+    public static String capitalize(final String value) {
+        return StringUtilities.empty(value)
+                ? value
+                : (value.substring(0, 1).toUpperCase() + value.substring(1));
+    }
+
+    public static boolean empty(final String value) {
+        return null == value || value.isEmpty();
+    }
+
+    public static boolean notEmpty(final String value) {
+        return null != value && !value.isEmpty();
+    }
+
+    public static String strip(final String s) {
+        return s.replaceAll("[\n\r ]+", "").trim();
+    }
+
+    public static Exceptional<Duration> durationOf(final String in) {
+        // First, if just digits, return the number in seconds.
+
+        if (StringUtilities.minorTimeString.matcher(in).matches()) {
+            return Exceptional.of(Duration.ofSeconds(Long.parseUnsignedLong(in)));
+        }
+
+        final Matcher m = StringUtilities.timeString.matcher(in);
+        if (m.matches()) {
+            long time = StringUtilities.durationAmount(m.group(2), StringUtilities.secondsInWeek);
+            time += StringUtilities.durationAmount(m.group(4), StringUtilities.secondsInDay);
+            time += StringUtilities.durationAmount(m.group(6), StringUtilities.secondsInHour);
+            time += StringUtilities.durationAmount(m.group(8), StringUtilities.secondsInMinute);
+            time += StringUtilities.durationAmount(m.group(10), 1);
+
+            if (0 < time) {
+                return Exceptional.of(Duration.ofSeconds(time));
+            }
+        }
+        return Exceptional.empty();
+    }
+
+    private static long durationAmount(@Nullable final String g, final int multiplier) {
+        if (null != g && !g.isEmpty()) {
+            return multiplier * Long.parseUnsignedLong(g);
+        }
+
+        return 0;
+    }
+
+    public static String[] splitCapitals(final String s) {
+        return s.split("(?=\\p{Lu})");
+    }
+
+    public static String trimWith(final char c, final String s) {
+        int len = s.length();
+        int st = 0;
+        final char[] val = s.toCharArray();
+
+        while ((st < len) && (val[st] <= c)) {
+            st++;
+        }
+        while ((st < len) && (val[len - 1] <= c)) {
+            len--;
+        }
+        // skipcq: JAVA-W0243
+        return ((st > 0) || (len < s.length())) ? s.substring(st, len) : s;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * <ul>
  *     <li>{@link #id()} - The unique identifier of the component. This is used to identify the component in the framework.
  *         If not specified, the type of the component is used to generate a valid ID through
- *         {@link org.dockbox.hartshorn.core.services.ComponentContainer#id(ApplicationContext, TypeContext)}</li>
+ *         {@link org.dockbox.hartshorn.core.services.ComponentUtilities#id(ApplicationContext, TypeContext)}</li>
  *     <li>{@link #name()} - The name of the component. This is used to identify the component in the framework. If not
  *         specified, the name of the class is used.</li>
  *     <li>{@link #owner()} - The owner of the component. This is typically ignored internally, but can be used by services
@@ -71,7 +71,7 @@ public @interface Component {
     /**
      * The unique identifier of the component. This is used to identify the component in the framework.
      * If not specified, the type of the component is used to generate a valid ID through
-     * {@link org.dockbox.hartshorn.core.services.ComponentContainer#id(ApplicationContext, TypeContext)}
+     * {@link org.dockbox.hartshorn.core.services.ComponentUtilities#id(ApplicationContext, TypeContext)}
      *
      * @return The unique identifier of the component
      * @see ComponentContainer#id()

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractActivatingApplicationFactory.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.core.boot;
 
+import org.dockbox.hartshorn.core.CollectionUtilities;
 import org.dockbox.hartshorn.core.ComponentType;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.InjectConfiguration;
 import org.dockbox.hartshorn.core.annotations.activate.Activator;
 import org.dockbox.hartshorn.core.annotations.inject.InjectConfig;
@@ -96,7 +96,7 @@ public abstract class AbstractActivatingApplicationFactory<
 
         final Activator activator = this.activatorAnnotation();
         final Set<String> scanPackages = Set.of(activator.scanPackages());
-        final Collection<String> scanPrefixes = HartshornUtils.merge(this.prefixes, scanPackages);
+        final Collection<String> scanPrefixes = CollectionUtilities.merge(this.prefixes, scanPackages);
 
         if (activator.includeBasePackage())
             scanPrefixes.add(this.activator.type().getPackageName());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractApplicationFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/AbstractApplicationFactory.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.core.boot;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.InjectConfiguration;
 import org.dockbox.hartshorn.core.MetaProvider;
 import org.dockbox.hartshorn.core.Modifiers;
@@ -34,6 +33,7 @@ import org.dockbox.hartshorn.core.services.ComponentPreProcessor;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -58,13 +58,13 @@ public abstract class AbstractApplicationFactory<Self extends ApplicationFactory
 
     protected TypeContext<?> activator;
 
-    protected final Set<InjectConfiguration> injectConfigurations = HartshornUtils.emptyConcurrentSet();
-    protected final Set<Annotation> serviceActivators = HartshornUtils.emptyConcurrentSet();
-    protected final Set<Modifiers> modifiers = HartshornUtils.emptyConcurrentSet();
-    protected final Set<String> arguments = HartshornUtils.emptyConcurrentSet();
-    protected final Set<String> prefixes = HartshornUtils.emptyConcurrentSet();
-    protected final Set<ComponentPostProcessor<?>> componentPostProcessors = HartshornUtils.emptyConcurrentSet();
-    protected final Set<ComponentPreProcessor<?>> componentPreProcessors = HartshornUtils.emptyConcurrentSet();
+    protected final Set<InjectConfiguration> injectConfigurations = ConcurrentHashMap.newKeySet();
+    protected final Set<Annotation> serviceActivators = ConcurrentHashMap.newKeySet();
+    protected final Set<Modifiers> modifiers = ConcurrentHashMap.newKeySet();
+    protected final Set<String> arguments = ConcurrentHashMap.newKeySet();
+    protected final Set<String> prefixes = ConcurrentHashMap.newKeySet();
+    protected final Set<ComponentPostProcessor<?>> componentPostProcessors = ConcurrentHashMap.newKeySet();
+    protected final Set<ComponentPreProcessor<?>> componentPreProcessors = ConcurrentHashMap.newKeySet();
 
     @Override
     public Self modifiers(final Modifiers... modifiers) {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationManager.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ApplicationManager.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.core.boot;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.ContextCarrier;
 
 /**
@@ -41,7 +40,7 @@ public interface ApplicationManager extends ContextCarrier, ApplicationLogger, A
      * Indicates whether the application is active in a CI environment or not. This can be determined by the presence of
      * environment variables, or other means.
      * @return {@literal true} if the application is active in a CI environment, {@literal false} otherwise.
-     * @see HartshornUtils#isCI()
+     * @see org.dockbox.hartshorn.core.context.ApplicationEnvironment#isCI()
      */
     boolean isCI();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Hartshorn.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Hartshorn.java
@@ -39,7 +39,7 @@ public final class Hartshorn {
     /**
      * The semantic version of the current/latest release of Hartshorn
      */
-    public static final String VERSION = "22.1";
+    public static final String VERSION = "22.2";
 
     private Hartshorn() {}
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/JavassistApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/JavassistApplicationProxier.java
@@ -17,14 +17,13 @@
 package org.dockbox.hartshorn.core.boot;
 
 import org.dockbox.hartshorn.core.AnnotationHelper.AnnotationInvocationHandler;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.BackingImplementationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
-import org.dockbox.hartshorn.core.proxy.javassist.JavassistInterfaceHandler;
 import org.dockbox.hartshorn.core.proxy.NativeProxyLookup;
 import org.dockbox.hartshorn.core.proxy.ProxyHandler;
 import org.dockbox.hartshorn.core.proxy.ProxyLookup;
+import org.dockbox.hartshorn.core.proxy.javassist.JavassistInterfaceHandler;
 import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyHandler;
 import org.dockbox.hartshorn.core.proxy.javassist.JavassistProxyLookup;
 
@@ -32,6 +31,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.ProxyFactory;
@@ -52,7 +52,7 @@ public class JavassistApplicationProxier implements ApplicationProxier, Applicat
 
     @Getter
     private ApplicationManager applicationManager;
-    private final Set<ProxyLookup> proxyLookups = HartshornUtils.emptyConcurrentSet();
+    private final Set<ProxyLookup> proxyLookups = ConcurrentHashMap.newKeySet();
 
     public JavassistApplicationProxier() {
         this.proxyLookups.add(new NativeProxyLookup());

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ContextualApplicationEnvironment.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/ContextualApplicationEnvironment.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.core.context;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.boot.ApplicationManager;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 
@@ -30,14 +29,18 @@ import lombok.Getter;
 public class ContextualApplicationEnvironment implements ApplicationEnvironment {
 
     @Getter private final PrefixContext prefixContext;
-    @Getter private final boolean isCI;
     @Getter private final ApplicationManager manager;
 
     public ContextualApplicationEnvironment(final PrefixContext prefixContext, final ApplicationManager manager) {
         this.manager = manager;
-        this.isCI = HartshornUtils.isCI();
         this.prefixContext = prefixContext;
         this.manager().log().debug("Created new application environment (isCI: %s, prefixCount: %d)".formatted(this.isCI(), this.prefixContext().prefixes().size()));
+    }
+
+
+    @Override
+    public boolean isCI() {
+        return this.manager.isCI();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/DefaultContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/DefaultContext.java
@@ -17,16 +17,17 @@
 package org.dockbox.hartshorn.core.context;
 
 import org.dockbox.hartshorn.core.CustomMultiMap;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.HashSetMultiMap;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MultiMap;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.annotations.context.AutoCreating;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The default implementation of {@link Context}. This implementation uses a {@link HashSetMultiMap} to store the
@@ -34,8 +35,8 @@ import java.util.Set;
  */
 public abstract class DefaultContext implements Context {
 
-    protected final transient Set<Context> contexts = HartshornUtils.emptyConcurrentSet();
-    protected final transient MultiMap<String, Context> namedContexts = new CustomMultiMap<>(HartshornUtils::emptyConcurrentSet);
+    protected final transient Set<Context> contexts = ConcurrentHashMap.newKeySet();
+    protected final transient MultiMap<String, Context> namedContexts = new CustomMultiMap<>(ConcurrentHashMap::newKeySet);
 
     @Override
     public <C extends Context> void add(final C context) {
@@ -44,13 +45,13 @@ public abstract class DefaultContext implements Context {
 
     @Override
     public <N extends NamedContext> void add(final N context) {
-        if (context != null && HartshornUtils.notEmpty(context.name()))
+        if (context != null && StringUtilities.notEmpty(context.name()))
             this.namedContexts.put(context.name(), context);
     }
 
     @Override
     public <C extends Context> void add(final String name, final C context) {
-        if (context != null && HartshornUtils.notEmpty(name))
+        if (context != null && StringUtilities.notEmpty(name))
             this.namedContexts.put(name, context);
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HierarchicalApplicationComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/HierarchicalApplicationComponentProvider.java
@@ -18,7 +18,6 @@ package org.dockbox.hartshorn.core.context;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.core.CustomMultiTreeMap;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MetaProvider;
 import org.dockbox.hartshorn.core.MultiMap;
@@ -48,7 +47,7 @@ public class HierarchicalApplicationComponentProvider extends DefaultContext imp
     private final transient Map<Key<?>, Object> singletons = new ConcurrentHashMap<>();
     private final transient Map<Key<?>, BindingHierarchy<?>> hierarchies = new ConcurrentHashMap<>();
 
-    protected final transient MultiMap<Integer, ComponentPostProcessor<?>> postProcessors = new CustomMultiTreeMap<>(HartshornUtils::emptyConcurrentSet);
+    protected final transient MultiMap<Integer, ComponentPostProcessor<?>> postProcessors = new CustomMultiTreeMap<>(ConcurrentHashMap::newKeySet);
 
     public HierarchicalApplicationComponentProvider(final ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/StandardDelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/StandardDelegatingApplicationContext.java
@@ -18,7 +18,6 @@ package org.dockbox.hartshorn.core.context;
 
 import org.dockbox.hartshorn.core.CustomMultiTreeMap;
 import org.dockbox.hartshorn.core.Enableable;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.InjectConfiguration;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MetaProvider;
@@ -62,6 +61,7 @@ import java.util.PriorityQueue;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -77,14 +77,14 @@ public class StandardDelegatingApplicationContext extends DefaultContext impleme
 
     private static final Pattern ARGUMENTS = Pattern.compile("--([a-zA-Z0-9\\.]+)=(.+)");
 
-    protected final transient MultiMap<Integer, ComponentPreProcessor<?>> preProcessors = new CustomMultiTreeMap<>(HartshornUtils::emptyConcurrentSet);
+    protected final transient MultiMap<Integer, ComponentPreProcessor<?>> preProcessors = new CustomMultiTreeMap<>(ConcurrentHashMap::newKeySet);
     protected final transient Queue<String> prefixQueue = new PriorityQueue<>(PREFIX_PRIORITY_COMPARATOR);
     protected final transient Properties environmentValues = new Properties();
 
     private final transient StandardComponentProvider componentProvider;
 
     private final Set<Modifiers> modifiers;
-    private final Set<Annotation> activators = HartshornUtils.emptyConcurrentSet();
+    private final Set<Annotation> activators = ConcurrentHashMap.newKeySet();
 
     private final ApplicationEnvironment environment;
     private final ClasspathResourceLocator resourceLocator;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/FieldContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/FieldContext.java
@@ -21,9 +21,9 @@ import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.exceptions.ApplicationException;
-import org.dockbox.hartshorn.core.HartshornUtils;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
@@ -70,7 +70,7 @@ public final class FieldContext<T> extends AnnotatedMemberContext<Field> impleme
             final Exceptional<Property> property = this.annotation(Property.class);
             if (property.present() && !"".equals(property.get().setter())) {
                 final String setter = property.get().setter();
-                final Exceptional<? extends MethodContext<?, ?>> method = this.declaredBy().method(setter, HartshornUtils.asList(this.type()));
+                final Exceptional<? extends MethodContext<?, ?>> method = this.declaredBy().method(setter, List.of(this.type()));
                 final MethodContext<?, Object> methodContext = (MethodContext<?, Object>) method.orThrowUnchecked(() -> new ApplicationException("Setter for field '" + this.name() + "' (" + setter + ") does not exist!"));
                 this.setter = (o, v) -> methodContext.invoke(instance, v);
             } else {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/element/TypeContext.java
@@ -18,8 +18,8 @@ package org.dockbox.hartshorn.core.context.element;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.core.ArrayListMultiMap;
+import org.dockbox.hartshorn.core.CollectionUtilities;
 import org.dockbox.hartshorn.core.GenericType;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.MultiMap;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
@@ -72,7 +72,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             */
             "__$lineHits$__"
     );
-    private static final Map<Class<?>, Class<?>> PRIMITIVE_WRAPPERS = HartshornUtils.ofEntries(
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_WRAPPERS = CollectionUtilities.ofEntries(
             Tuple.of(boolean.class, Boolean.class),
             Tuple.of(byte.class, Byte.class),
             Tuple.of(char.class, Character.class),
@@ -82,7 +82,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             Tuple.of(long.class, Long.class),
             Tuple.of(short.class, Short.class)
     );
-    private static final Map<?, Function<String, ?>> PRIMITIVE_FROM_STRING = HartshornUtils.ofEntries(
+    private static final Map<?, Function<String, ?>> PRIMITIVE_FROM_STRING = CollectionUtilities.ofEntries(
             Tuple.of(boolean.class, Boolean::valueOf),
             Tuple.of(byte.class, Byte::valueOf),
             Tuple.of(char.class, s -> s.charAt(0)),
@@ -92,13 +92,13 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             Tuple.of(long.class, Long::valueOf),
             Tuple.of(short.class, Short::valueOf)
     );
-    private static final List<Class<?>> NATIVE_SUPPORTED = HartshornUtils.asList(
+    private static final List<Class<?>> NATIVE_SUPPORTED = List.of(
             boolean.class, byte.class, short.class,
             int.class, long.class, float.class, double.class,
             byte[].class, int[].class, long[].class,
             String.class, List.class, Map.class
     );
-    private static final Map<Class<?>, Object> PRIMITIVE_DEFAULTS = HartshornUtils.ofEntries(
+    private static final Map<Class<?>, Object> PRIMITIVE_DEFAULTS = CollectionUtilities.ofEntries(
             Tuple.of(boolean.class, false),
             Tuple.of(byte.class, 0),
             Tuple.of(char.class, '\u0000'),
@@ -108,7 +108,7 @@ public class TypeContext<T> extends AnnotatedElementContext<Class<T>> {
             Tuple.of(long.class, 0L),
             Tuple.of(short.class, 0)
     );
-    private static final Map<Class<?>, Class<?>> WRAPPERS_TO_PRIMITIVE = HartshornUtils.ofEntries(
+    private static final Map<Class<?>, Class<?>> WRAPPERS_TO_PRIMITIVE = CollectionUtilities.ofEntries(
             Tuple.of(Boolean.class, boolean.class),
             Tuple.of(Byte.class, byte.class),
             Tuple.of(Character.class, char.class),

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
@@ -17,14 +17,10 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.ComponentType;
-import org.dockbox.hartshorn.core.HartshornUtils;
-import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
-import java.util.Locale;
 
 public interface ComponentContainer {
 
@@ -47,38 +43,4 @@ public interface ComponentContainer {
     boolean permitsProxying();
 
     boolean permitsProcessing();
-
-    static String id(final ApplicationContext context, final TypeContext<?> type) {
-        return id(context, type, false);
-    }
-
-    static String id(final ApplicationContext context, final TypeContext<?> type, final boolean ignoreExisting) {
-        final Exceptional<ComponentContainer> container = context.locator().container(type);
-        if (!ignoreExisting && container.present()) {
-            final String id = container.get().id();
-            if (!"".equals(id)) return id;
-        }
-
-        String raw = type.name();
-        if (raw.endsWith("Service")) {
-            raw = raw.substring(0, raw.length() - 7);
-        }
-        final String[] parts = HartshornUtils.splitCapitals(raw);
-        return String.join("-", parts).toLowerCase(Locale.ROOT);
-    }
-
-    static String name(final ApplicationContext context, final TypeContext<?> type, final boolean ignoreExisting) {
-        final Exceptional<ComponentContainer> container = context.locator().container(type);
-        if (!ignoreExisting && container.present()) {
-            final String name = container.get().name();
-            if (!"".equals(name)) return name;
-        }
-
-        String raw = type.name();
-        if (raw.endsWith("Service")) {
-            raw = raw.substring(0, raw.length() - 7);
-        }
-        final String[] parts = HartshornUtils.splitCapitals(raw);
-        return HartshornUtils.capitalize(String.join(" ", parts));
-    }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
@@ -17,7 +17,6 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.ComponentType;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.stereotype.Component;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -50,21 +49,21 @@ public class ComponentContainerImpl implements ComponentContainer {
 
         final Exceptional<Service> service = component.annotation(Service.class);
         if (service.present()) {
-            this.activators.addAll(HartshornUtils.asList(service.get().activators()));
+            this.activators.addAll(List.of(service.get().activators()));
         }
     }
 
     @Override
     public String id() {
-        final String id = this.annotation.id();
-        if ("".equals(id)) return ComponentContainer.id(this.context, this.component, true);
+        final String id = this.annotation().id();
+        if ("".equals(id)) return ComponentUtilities.id(this.context, this.component, true);
         return id;
     }
 
     @Override
     public String name() {
-        final String name = this.annotation.name();
-        if ("".equals(name)) return ComponentContainer.name(this.context, this.component, true);
+        final String name = this.annotation().name();
+        if ("".equals(name)) return ComponentUtilities.name(this.context, this.component, true);
         return name;
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContextInjectionPreProcessor.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.core.services;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.CollectionUtilities;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.annotations.inject.Context;
@@ -48,9 +48,15 @@ public class ComponentContextInjectionPreProcessor extends ComponentPreValidator
         for (final FieldContext<?> field : type.fields(Context.class))
             this.validate(field, key);
 
-        final List<ExecutableElementContext<?, ?>> constructors = type.injectConstructors().stream().map(c -> (ExecutableElementContext<?, ?>) c).collect(Collectors.toList());
-        final List<ExecutableElementContext<?, ?>> methods = type.methods().stream().map(m -> (ExecutableElementContext<?, ?>) m).collect(Collectors.toList());
-        final Collection<ExecutableElementContext<?, ?>> executables = HartshornUtils.merge(constructors, methods);
+        final List<ExecutableElementContext<?, ?>> constructors = type.injectConstructors().stream()
+                .map(c -> (ExecutableElementContext<?, ?>) c)
+                .collect(Collectors.toList());
+
+        final List<ExecutableElementContext<?, ?>> methods = type.methods().stream()
+                .map(m -> (ExecutableElementContext<?, ?>) m)
+                .collect(Collectors.toList());
+
+        final Collection<ExecutableElementContext<?, ?>> executables = CollectionUtilities.merge(constructors, methods);
 
         for (final ExecutableElementContext<?, ?> executable : executables)
             for (final ParameterContext<?> parameter : executable.parameters(Context.class))

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentUtilities.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentUtilities.java
@@ -1,0 +1,39 @@
+package org.dockbox.hartshorn.core.services;
+
+import org.dockbox.hartshorn.core.StringUtilities;
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+import org.dockbox.hartshorn.core.domain.Exceptional;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+public class ComponentUtilities {
+
+    public static String id(final ApplicationContext context, final TypeContext<?> type) {
+        return id(context, type, false);
+    }
+
+    public static String id(final ApplicationContext context, final TypeContext<?> type, final boolean ignoreExisting) {
+        return format(context, type, ignoreExisting, '-', ComponentContainer::id).toLowerCase(Locale.ROOT);
+    }
+
+    public static String name(final ApplicationContext context, final TypeContext<?> type, final boolean ignoreExisting) {
+        return format(context, type, ignoreExisting, ' ', ComponentContainer::name);
+    }
+
+    protected static String format(final ApplicationContext context, final TypeContext<?> type, final boolean ignoreExisting, final char delimiter, final Function<ComponentContainer, String> attribute) {
+        final Exceptional<ComponentContainer> container = context.locator().container(type);
+        if (!ignoreExisting && container.present()) {
+            final String name = attribute.apply(container.get());
+            if (!"".equals(name)) return name;
+        }
+
+        String raw = type.name();
+        if (raw.endsWith("Service")) {
+            raw = raw.substring(0, raw.length() - 7);
+        }
+        final String[] parts = StringUtilities.splitCapitals(raw);
+        return StringUtilities.capitalize(String.join(delimiter + "", parts));
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/parameter/RuleBasedParameterLoader.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.core.services.parameter;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.core.context.element.ParameterContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
@@ -26,6 +25,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,7 +33,7 @@ import lombok.Getter;
 public class RuleBasedParameterLoader<C extends ParameterLoaderContext> extends ParameterLoader<C>{
 
     @Getter(AccessLevel.PROTECTED)
-    private final Set<ParameterLoaderRule<C>> rules = HartshornUtils.emptyConcurrentSet();
+    private final Set<ParameterLoaderRule<C>> rules = ConcurrentHashMap.newKeySet();
 
     public RuleBasedParameterLoader add(final ParameterLoaderRule<? super C> rule) {
         this.rules.add((ParameterLoaderRule<C>) rule);

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/HartshornUtilTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/HartshornUtilTests.java
@@ -18,7 +18,6 @@ package org.dockbox.hartshorn.core;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.tuple.Tuple;
-import org.dockbox.hartshorn.core.exceptions.ApplicationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,7 +25,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -40,15 +38,6 @@ public class HartshornUtilTests {
     private static final int hour = 60 * minute;
     private static final int day = 24 * hour;
     private static final int week = 7 * day;
-
-    private static Stream<Arguments> modifiableCollections() {
-        return Stream.of(
-                Arguments.of(HartshornUtils.asList("value", "other")),
-                Arguments.of(HartshornUtils.emptyConcurrentSet()),
-                Arguments.of(HartshornUtils.asSet(Arrays.asList("value", "other")))
-
-        );
-    }
 
     private static Stream<Arguments> capitalizeValues() {
         return Stream.of(
@@ -86,14 +75,14 @@ public class HartshornUtilTests {
 
     public static Stream<Arguments> differences() {
         return Stream.of(
-                Arguments.of(HartshornUtils.asList("a", "b"), HartshornUtils.asList("a"), HartshornUtils.asList("b")),
-                Arguments.of(HartshornUtils.asList("a"), HartshornUtils.asList("a", "b"), HartshornUtils.asList("b"))
+                Arguments.of(List.of("a", "b"), List.of("a"), List.of("b")),
+                Arguments.of(List.of("a"), List.of("a", "b"), List.of("b"))
         );
     }
 
     @Test
     void testOfEntriesAddsAllEntries() {
-        final Map<Integer, String> map = HartshornUtils.ofEntries(
+        final Map<Integer, String> map = CollectionUtilities.ofEntries(
                 Tuple.of(1, "two"),
                 Tuple.of(2, "three")
         );
@@ -105,22 +94,15 @@ public class HartshornUtilTests {
 
     @Test
     void testOfEntriesIsEmptyWithNoEntries() {
-        final Map<Object, Object> map = HartshornUtils.ofEntries();
+        final Map<Object, Object> map = CollectionUtilities.ofEntries();
         Assertions.assertNotNull(map);
         Assertions.assertTrue(map.isEmpty());
     }
 
     @ParameterizedTest
-    @MethodSource("modifiableCollections")
-    void testCollectionCanBeModified(final Collection<String> collection) {
-        Assertions.assertNotNull(collection);
-        Assertions.assertDoesNotThrow(() -> collection.add("another"));
-    }
-
-    @ParameterizedTest
     @MethodSource("capitalizeValues")
     void testCapitalizeChangesOnlyFirstCharacter(final String input, final String expected) {
-        final String value = HartshornUtils.capitalize(input);
+        final String value = StringUtilities.capitalize(input);
         Assertions.assertNotNull(value);
         Assertions.assertEquals(expected, value);
     }
@@ -141,88 +123,27 @@ public class HartshornUtilTests {
     }
 
     @Test
-    void testArrayMerge() {
-        final Object[] arr1 = { 1, 2, 3 };
-        final Object[] arr2 = { 4, 5, 6 };
-        final Object[] merged = HartshornUtils.merge(arr1, arr2);
-        for (int i = 0; i < 6; i++) {
-            Assertions.assertEquals(i + 1, (int) merged[i]);
-        }
-    }
-
-    @Test
     void testCollectionMerge() {
         final Collection<Integer> col1 = Arrays.asList(1, 2, 3);
         final Collection<Integer> col2 = Arrays.asList(4, 5, 6);
-        final Collection<Integer> merged = HartshornUtils.merge(col1, col2);
+        final Collection<Integer> merged = CollectionUtilities.merge(col1, col2);
 
         Assertions.assertEquals(6, merged.size());
         Assertions.assertTrue(merged.containsAll(Arrays.asList(1, 2, 3, 4, 5, 6)));
     }
 
-    @Test
-    void testDoesNotThrow() {
-        Assertions.assertTrue(HartshornUtils.doesNotThrow(() -> {
-            final int i = 1 + 1;
-        }));
-        Assertions.assertFalse(HartshornUtils.doesNotThrow(() -> {
-            throw new ApplicationException("error");
-        }));
-    }
-
-    @Test
-    void testDoesNotThrowSpecific() {
-        Assertions.assertTrue(HartshornUtils.doesNotThrow(() -> {
-            final int i = 1 + 1;
-        }, Exception.class));
-        Assertions.assertFalse(HartshornUtils.doesNotThrow(() -> {
-            throw new UnsupportedOperationException("error");
-        }, UnsupportedOperationException.class));
-        Assertions.assertTrue(HartshornUtils.doesNotThrow(() -> {
-            throw new IllegalArgumentException("error");
-        }, UnsupportedOperationException.class));
-    }
-
-    @Test
-    void testThrowsSpecific() {
-        Assertions.assertFalse(HartshornUtils.throwsException(() -> {
-            final int i = 1 + 1;
-        }, Exception.class));
-        Assertions.assertTrue(HartshornUtils.throwsException(() -> {
-            throw new UnsupportedOperationException("error");
-        }, UnsupportedOperationException.class));
-        Assertions.assertFalse(HartshornUtils.throwsException(() -> {
-            throw new IllegalArgumentException("error");
-        }, UnsupportedOperationException.class));
-    }
-
     @ParameterizedTest
     @MethodSource("durations")
     void testDurationOf(final String in, final long expected) {
-        final Exceptional<Duration> duration = HartshornUtils.durationOf(in);
+        final Exceptional<Duration> duration = StringUtilities.durationOf(in);
         Assertions.assertTrue(duration.present());
         Assertions.assertEquals(expected, duration.get().getSeconds());
-    }
-
-    @Test
-    void testToTableString() {
-        final List<List<String>> rows = new ArrayList<>();
-        rows.add(List.of("h1", "h2", "h3"));
-        rows.add(List.of("v1", "v2", "v3"));
-        final String table = HartshornUtils.asTable(rows);
-
-        Assertions.assertNotNull(table);
-        Assertions.assertEquals("""
-                        h1  h2  h3 \s
-                        v1  v2  v3 \s
-                        """,
-                table);
     }
 
     @ParameterizedTest
     @MethodSource("differences")
     void testDifferenceInCollections(final Collection<String> a, final Collection<String> b, final Collection<String> expected) {
-        final Set<String> difference = HartshornUtils.difference(a, b);
+        final Set<String> difference = CollectionUtilities.difference(a, b);
         Assertions.assertEquals(difference.size(), expected.size());
         Assertions.assertTrue(difference.containsAll(expected));
         Assertions.assertTrue(expected.containsAll(difference));

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ReflectTests.java
@@ -147,7 +147,7 @@ public class ReflectTests {
     void testRunMethodReturnsValue(final String method) {
         final ReflectTestType instance = new ReflectTestType();
         final TypeContext<ReflectTestType> type = TypeContext.of(instance);
-        final Exceptional<?> value = type.method(method, HartshornUtils.asList(TypeContext.of(String.class))).get().invoke(instance, "value");
+        final Exceptional<?> value = type.method(method, List.of(TypeContext.of(String.class))).get().invoke(instance, "value");
         Assertions.assertTrue(value.present());
         Assertions.assertEquals("VALUE", value.get());
     }
@@ -266,7 +266,7 @@ public class ReflectTests {
 
     @Test
     void testHasMethodIsTrueIfMethodExists() {
-        Assertions.assertTrue(TypeContext.of(ReflectTestType.class).method("publicMethod", HartshornUtils.asList(TypeContext.of(String.class))).present());
+        Assertions.assertTrue(TypeContext.of(ReflectTestType.class).method("publicMethod", List.of(TypeContext.of(String.class))).present());
     }
 
     @Test
@@ -276,7 +276,7 @@ public class ReflectTests {
 
     @Test
     void testInstanceHasMethodIsTrueIfMethodExists() {
-        Assertions.assertTrue(TypeContext.of(new ReflectTestType()).method("publicMethod", HartshornUtils.asList(TypeContext.of(String.class))).present());
+        Assertions.assertTrue(TypeContext.of(new ReflectTestType()).method("publicMethod", List.of(TypeContext.of(String.class))).present());
     }
 
     @Test

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -17,7 +17,7 @@
 package org.dockbox.hartshorn.data.hibernate;
 
 import org.dockbox.hartshorn.core.Enableable;
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.annotations.inject.Bound;
 import org.dockbox.hartshorn.core.boot.ExceptionHandler;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -124,7 +124,7 @@ public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enab
 
         this.registerDefaultDialects();
 
-        if (HartshornUtils.notEmpty(this.connection.username()) || HartshornUtils.notEmpty(this.connection.password())) {
+        if (StringUtilities.notEmpty(this.connection.username()) || StringUtilities.notEmpty(this.connection.password())) {
             this.applicationContext().log().debug("Username or password were configured in the active connection, adding to Hibernate configuration");
             this.configuration.setProperty("hibernate.connection.username", this.connection.username());
             this.configuration.setProperty("hibernate.connection.password", this.connection.password());

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/PersistenceModifiersTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/PersistenceModifiersTests.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.data.mapping;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
@@ -41,11 +41,11 @@ public class PersistenceModifiersTests {
     @Test
     void testSkipEmptyKeepsNonEmpty() {
         final ObjectMapper mapper = this.applicationContext().get(ObjectMapper.class).skipBehavior(JsonInclusionRule.SKIP_EMPTY);
-        final ModifierElement element = new ModifierElement(HartshornUtils.asList("sample", "other"));
+        final ModifierElement element = new ModifierElement(List.of("sample", "other"));
         final Exceptional<String> out = mapper.write(element);
 
         Assertions.assertTrue(out.present());
-        Assertions.assertEquals("{\"names\":[\"sample\",\"other\"]}", HartshornUtils.strip(out.get()));
+        Assertions.assertEquals("{\"names\":[\"sample\",\"other\"]}", StringUtilities.strip(out.get()));
     }
 
     @Test
@@ -55,6 +55,6 @@ public class PersistenceModifiersTests {
         final Exceptional<String> out = mapper.write(element);
 
         Assertions.assertTrue(out.present());
-        Assertions.assertEquals("{}", HartshornUtils.strip(out.get()));
+        Assertions.assertEquals("{}", StringUtilities.strip(out.get()));
     }
 }

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/service/SerialisationTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/service/SerialisationTests.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.data.service;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.data.PersistentElement;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
@@ -45,7 +45,7 @@ public class SerialisationTests {
         final String json = service.writeToString(element);
 
         Assertions.assertNotNull(json);
-        Assertions.assertEquals("{\"name\":\"sample\"}", HartshornUtils.strip(json));
+        Assertions.assertEquals("{\"name\":\"sample\"}", StringUtilities.strip(json));
     }
 
     @Test

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -17,7 +17,6 @@
 package org.dockbox.hartshorn.events;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
@@ -44,7 +43,7 @@ import javax.inject.Singleton;
 @Singleton
 public class EventBusImpl implements EventBus {
 
-    protected final Set<Function<MethodContext<?, ?>, Exceptional<Boolean>>> validators = HartshornUtils.emptyConcurrentSet();
+    protected final Set<Function<MethodContext<?, ?>, Exceptional<Boolean>>> validators = ConcurrentHashMap.newKeySet();
 
     /** A map of all listening objects with their associated {@link EventWrapper}s. */
     protected final Map<Key<?>, Set<EventWrapper>> listenerToInvokers = new ConcurrentHashMap<>();

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventValidator.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.events;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.CollectionUtilities;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.boot.ApplicationState.Started;
 import org.dockbox.hartshorn.core.boot.LifecycleObserver;
@@ -56,7 +56,7 @@ public class EventValidator implements LifecycleObserver {
             postedEvents.addAll(Arrays.stream(posting.value()).map(TypeContext::of).toList());
         }
 
-        final Set<TypeContext<? extends Event>> difference = HartshornUtils.difference(allEvents, postedEvents);
+        final Set<TypeContext<? extends Event>> difference = CollectionUtilities.difference(allEvents, postedEvents);
 
         if (!difference.isEmpty()) {
             final StringBuilder message = new StringBuilder(difference.size() + " events are not handled by any event bridge!");

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/handle/EventHandler.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.events.handle;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -28,12 +27,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class EventHandler {
 
     private final TypeContext<? extends Event> eventType;
-    private final Set<EventHandler> superTypeHandlers = HartshornUtils.emptyConcurrentSet();
+    private final Set<EventHandler> superTypeHandlers = ConcurrentHashMap.newKeySet();
     private final SortedSet<EventWrapperImpl<?>> invokers = new TreeSet<>(EventWrapperImpl.COMPARATOR);
     private transient EventWrapperImpl<?>[] computedInvokerCache;
 

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/services/TranslationInjectPostProcessor.java
@@ -16,21 +16,21 @@
 
 package org.dockbox.hartshorn.i18n.services;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.MetaProvider;
+import org.dockbox.hartshorn.core.StringUtilities;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.MethodProxyContext;
 import org.dockbox.hartshorn.core.context.element.MethodContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.core.domain.TypedOwner;
+import org.dockbox.hartshorn.core.proxy.ProxyFunction;
+import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 import org.dockbox.hartshorn.i18n.Message;
 import org.dockbox.hartshorn.i18n.TranslationService;
 import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.i18n.annotations.UseTranslations;
-import org.dockbox.hartshorn.core.proxy.ProxyFunction;
-import org.dockbox.hartshorn.core.context.MethodProxyContext;
-import org.dockbox.hartshorn.core.services.ServiceAnnotatedMethodInterceptorPostProcessor;
 
 @AutomaticActivation
 public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodInterceptorPostProcessor<InjectTranslation, UseTranslations> {
@@ -84,7 +84,7 @@ public class TranslationInjectPostProcessor extends ServiceAnnotatedMethodInterc
         }
         String keyJoined = method.name();
         if (keyJoined.startsWith("get")) keyJoined = keyJoined.substring(3);
-        final String[] r = HartshornUtils.splitCapitals(keyJoined);
+        final String[] r = StringUtilities.splitCapitals(keyJoined);
         return prefix + String.join(".", r).toLowerCase();
     }
 }

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.i18n;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
+import org.dockbox.hartshorn.core.CollectionUtilities;
 import org.dockbox.hartshorn.core.annotations.activate.AutomaticActivation;
 import org.dockbox.hartshorn.core.boot.HartshornApplicationFactory;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,7 +53,7 @@ import java.util.Properties;
  */
 public final class TranslationBatchGenerator {
 
-    private static final List<String> BLACKLIST = HartshornUtils.asList(
+    private static final List<String> BLACKLIST = List.of(
             // Test resources
             "class-resources.abstract.entry",
             "class-resources.concrete.entry",
@@ -60,7 +61,7 @@ public final class TranslationBatchGenerator {
             "resource.test.entry",
             "test-resources.test.entry"
     );
-    private static final List<String> HEADER = HartshornUtils.asList("#",
+    private static final List<String> HEADER = List.of("#",
             "# Copyright (C) 2020 Guus Lieben",
             "#",
             "# This framework is free software; you can redistribute it and/or modify",
@@ -117,7 +118,7 @@ public final class TranslationBatchGenerator {
                 final String[] property = string.split("=");
                 final String key = property[0];
                 if (key.startsWith("$")) continue;
-                final String value = String.join("=", HartshornUtils.arraySubset(property, 1, property.length - 1));
+                final String value = String.join("=", Arrays.copyOfRange(property, 1, property.length));
                 if (properties.containsKey(key)) {
                     // Override any existing, drop retired translations
                     cache.setProperty(key, value);
@@ -131,7 +132,7 @@ public final class TranslationBatchGenerator {
             });
 
             Collections.sort(content);
-            final Collection<String> output = HartshornUtils.merge(HEADER, content);
+            final Collection<String> output = CollectionUtilities.merge(HEADER, content);
 
             final String fileOut = String.join("\n", output);
             files.put(file.getName(), fileOut);
@@ -166,7 +167,7 @@ public final class TranslationBatchGenerator {
     private static List<File> existingFiles() {
         final File batch = TranslationBatchGenerator.existingBatch();
         if (batch.exists() && batch.isDirectory()) {
-            return HartshornUtils.asList(batch.listFiles()).stream()
+            return List.of(batch.listFiles()).stream()
                     .filter(f -> !f.isDirectory())
                     .toList();
         }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ControllerContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ControllerContext.java
@@ -18,9 +18,9 @@ package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.core.annotations.context.AutoCreating;
 import org.dockbox.hartshorn.core.context.DefaultContext;
-import org.dockbox.hartshorn.core.HartshornUtils;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.Getter;
 
@@ -28,7 +28,7 @@ import lombok.Getter;
 public class ControllerContext extends DefaultContext {
 
     @Getter
-    private final Set<RequestHandlerContext> requestHandlerContexts = HartshornUtils.emptyConcurrentSet();
+    private final Set<RequestHandlerContext> requestHandlerContexts = ConcurrentHashMap.newKeySet();
 
     public void add(final RequestHandlerContext context) {
         this.requestHandlerContexts.add(context);

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/MvcControllerContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/MvcControllerContext.java
@@ -16,11 +16,11 @@
 
 package org.dockbox.hartshorn.web;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.annotations.context.AutoCreating;
 import org.dockbox.hartshorn.core.context.DefaultContext;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.Getter;
 
@@ -28,7 +28,7 @@ import lombok.Getter;
 public class MvcControllerContext extends DefaultContext {
 
     @Getter
-    private final Set<RequestHandlerContext> requestHandlerContexts = HartshornUtils.emptyConcurrentSet();
+    private final Set<RequestHandlerContext> requestHandlerContexts = ConcurrentHashMap.newKeySet();
 
     public void add(final RequestHandlerContext context) {
         this.requestHandlerContexts.add(context);

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
@@ -16,7 +16,6 @@
 
 package org.dockbox.hartshorn.web.mvc.freemarker;
 
-import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.boot.Hartshorn;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
 import org.dockbox.hartshorn.core.context.element.TypeContext;
@@ -32,6 +31,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 
 import javax.inject.Singleton;
@@ -82,7 +83,7 @@ public class FreeMarkerMVCInitializer implements MVCInitializer {
                 return new Template(name, stringView.template(), this.configuration);
             }
             else if (template instanceof FileViewTemplate fileView) {
-                final String content = HartshornUtils.contentOrEmpty(fileView.path());
+                final String content = this.contentOrEmpty(fileView.path());
                 return new Template(name, content, this.configuration);
             }
             else if (template instanceof ClassPathViewTemplate classPathView) {
@@ -93,6 +94,15 @@ public class FreeMarkerMVCInitializer implements MVCInitializer {
             }
         } catch (final IOException e) {
             throw new ApplicationException(e);
+        }
+    }
+
+    private String contentOrEmpty(final Path path) {
+        try {
+            return Files.readString(path);
+        }
+        catch (final IOException ignored) {
+            return "";
         }
     }
 


### PR DESCRIPTION
# Description
Last year I introduced the first deprecations of `HartshornUtils` which were later marked in release 22.1, and are pending removal in release 22.2. At that time, the focus was to remove the heavily unused utilities, to later clean active usages of other utilities.

This PR marks all remaining methods for deprecation and removal, and refactors them into dedicated utility classes. Three different utility categories exist in HartshornUtils:
- String manipulation, moved to `StringUtilities`
- Collection utilities, moved to `CollectionUtilities`
- Component utilities, moved to `ComponentUtilities`

The static utilities in `ComponentContainer` were also moved to the component utilities class.

Fixes #700

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    - [x] Breaking due to upcoming deprecations

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
