### PR TITLE
#699 Component activation filtering and type presence checks

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Component.java
@@ -141,4 +141,18 @@ public @interface Component {
      * @return {@code true} if the component should be processed
      */
     boolean permitProcessing() default true;
+
+    /**
+     * Indicates one or more prefixed types which are required to be present on the classpath in order for the component
+     * to be loaded. This is used to prevent components from being loaded when they are not required. If one or more types
+     * are specified, the component will only be loaded if all the types are present on the classpath. If no types
+     * are specified, the component will always be loaded (assuming other conditions are met).
+     *
+     * <p>This requires the fully qualified class name to be specified. For example, if the class is named
+     * {@code com.example.MyComponent}, the type would be {@code com.example.MyComponent}. {@code MyComponent} or
+     * {@code com.example.MyComponent.class} are not valid.
+     *
+     * @return The required types.
+     */
+    String[] requires() default {};
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Service.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/annotations/stereotype/Service.java
@@ -92,4 +92,10 @@ public @interface Service {
      * @return Whether the service is permitted to be proxied.
      */
     boolean permitProxying() default true;
+
+    /**
+     * @see Component#requires()
+     * @return The prefixes required by this service.
+     */
+    String[] requires() default {};
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ActivatorPresenceActivationFilter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ActivatorPresenceActivationFilter.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.core.services;
+
+import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+
+public class ActivatorPresenceActivationFilter implements ComponentActivationFilter {
+
+    private final ApplicationContext applicationContext;
+
+    public ActivatorPresenceActivationFilter(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public <T> boolean doActivate(final TypeContext<T> component, final ComponentContainer container) {
+        return container.activators().stream().allMatch(this.applicationContext::hasActivator);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentActivationFilter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentActivationFilter.java
@@ -1,0 +1,7 @@
+package org.dockbox.hartshorn.core.services;
+
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+
+public interface ComponentActivationFilter {
+    <T> boolean doActivate(TypeContext<T> component, ComponentContainer container);
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainer.java
@@ -21,6 +21,7 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Set;
 
 public interface ComponentContainer {
 
@@ -43,4 +44,6 @@ public interface ComponentContainer {
     boolean permitsProxying();
 
     boolean permitsProcessing();
+
+    Set<String> requiredTypes();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import lombok.Getter;
@@ -74,7 +75,7 @@ public class ComponentContainerImpl implements ComponentContainer {
 
     @Override
     public TypeContext<?> owner() {
-        return TypeContext.of(this.annotation.owner());
+        return TypeContext.of(this.annotation().owner());
     }
 
     @Override
@@ -84,27 +85,32 @@ public class ComponentContainerImpl implements ComponentContainer {
 
     @Override
     public boolean singleton() {
-        return this.annotation.singleton();
+        return this.annotation().singleton();
     }
 
     @Override
     public boolean lazy() {
-        return this.annotation.lazy();
+        return this.annotation().lazy();
     }
 
     @Override
     public ComponentType componentType() {
-        return this.annotation.type();
+        return this.annotation().type();
     }
 
     @Override
     public boolean permitsProxying() {
-        return this.annotation.permitProxying();
+        return this.annotation().permitProxying();
     }
 
     @Override
     public boolean permitsProcessing() {
-        return this.annotation.permitProcessing();
+        return this.annotation().permitProcessing();
+    }
+
+    @Override
+    public Set<String> requiredTypes() {
+        return Set.of(this.annotation().requires());
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentLocatorImpl.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.core.services;
 
 import org.dockbox.hartshorn.core.ComponentType;
+import org.dockbox.hartshorn.core.HartshornUtils;
 import org.dockbox.hartshorn.core.HashSetMultiMap;
 import org.dockbox.hartshorn.core.Key;
 import org.dockbox.hartshorn.core.MultiMap;
@@ -27,6 +28,7 @@ import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import lombok.Getter;
 
@@ -35,9 +37,21 @@ public class ComponentLocatorImpl implements ComponentLocator {
     private final MultiMap<String, ComponentContainer> cache = new HashSetMultiMap<>();
     @Getter
     private final ApplicationContext applicationContext;
+    private final Set<ComponentActivationFilter> activationFilters = HartshornUtils.emptyConcurrentSet();
 
     public ComponentLocatorImpl(final ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+        this.registerDefaultActivationFilters();
+    }
+
+    protected void registerDefaultActivationFilters() {
+        this.registerActivationFilter(new ActivatorPresenceActivationFilter(this.applicationContext()));
+        this.registerActivationFilter(new TypePresenceActivationFilter());
+    }
+
+    public void registerActivationFilter(final ComponentActivationFilter activationFilter) {
+        if (activationFilter == null) return;
+        this.activationFilters.add(activationFilter);
     }
 
     @Override
@@ -48,20 +62,25 @@ public class ComponentLocatorImpl implements ComponentLocator {
 
         final long start = System.currentTimeMillis();
 
-        final List<ComponentContainer> containers = this.applicationContext().environment()
+        final List<TypeContext<?>> newComponentTypes = this.applicationContext().environment()
                 .types(prefix, Component.class, false)
                 .stream()
                 .filter(type -> this.cache.allValues().stream().noneMatch(container -> container.type().equals(type)))
+                .toList();
+
+        final List<ComponentContainer> newComponentContainers = newComponentTypes.stream()
                 .map(type -> new ComponentContainerImpl(this.applicationContext(), type))
                 .filter(container -> !container.type().isAnnotation()) // Exclude extended annotations
-                .map(ComponentContainer.class::cast)
-                .filter(container -> container.activators().stream().allMatch(this.applicationContext()::hasActivator))
+                .map(ComponentContainer.class::cast).toList();
+
+        final List<ComponentContainer> filteredComponentContainers = newComponentContainers.stream()
+                .filter(container -> this.activationFilters.stream().allMatch(activationFilter -> activationFilter.doActivate(container.type(), container)))
                 .toList();
 
         final long duration = System.currentTimeMillis() - start;
-        this.applicationContext().log().info("Located %d components with prefix %s in %dms".formatted(containers.size(), prefix, duration));
+        this.applicationContext().log().info("Located %d components with prefix %s in %dms".formatted(filteredComponentContainers.size(), prefix, duration));
 
-        this.cache.putAll(prefix, containers);
+        this.cache.putAll(prefix, filteredComponentContainers);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ServiceImpl.java
@@ -57,6 +57,11 @@ public class ServiceImpl implements Service {
     }
 
     @Override
+    public String[] requires() {
+        return new String[0];
+    }
+
+    @Override
     public Class<? extends Annotation> annotationType() {
         return Service.class;
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/TypePresenceActivationFilter.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/TypePresenceActivationFilter.java
@@ -1,0 +1,14 @@
+package org.dockbox.hartshorn.core.services;
+
+import org.dockbox.hartshorn.core.context.element.TypeContext;
+
+public class TypePresenceActivationFilter implements ComponentActivationFilter {
+
+    @Override
+    public <T> boolean doActivate(final TypeContext<T> component, final ComponentContainer container) {
+        for (final String requiredType : container.requiredTypes()) {
+            if (TypeContext.lookup(requiredType).isVoid()) return false;
+        }
+        return true;
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateProviders.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateProviders.java
@@ -7,7 +7,7 @@ import org.dockbox.hartshorn.data.TransactionManager;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.jpa.JpaRepository;
 
-@Service(activators = UsePersistence.class)
+@Service(activators = UsePersistence.class, requires = "org.hibernate.Hibernate")
 public class HibernateProviders {
 
     @Provider

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonProviders.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonProviders.java
@@ -6,27 +6,48 @@ import org.dockbox.hartshorn.core.context.element.TypeContext;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
 
-@Service(activators = UsePersistence.class)
+// Only require Jackson Core to be present, individual providers validate the presence of
+// required mapper implementations.
+@Service(activators = UsePersistence.class, requires = "com.fasterxml.jackson.databind.ObjectMapper")
 public class JacksonProviders {
 
     @Provider("properties")
-    private final JacksonDataMapper properties = new JavaPropsDataMapper();
+    public JacksonDataMapper properties() {
+        if (TypeContext.lookup("com.fasterxml.jackson.dataformat.javaprop.JavaPropsMapper").isVoid())
+            throw new IllegalStateException("Java properties is not available");
+        return new JavaPropsDataMapper();
+    }
 
     @Provider("json")
-    private final JacksonDataMapper json = new JsonDataMapper();
+    public JacksonDataMapper json() {
+        if (TypeContext.lookup("com.fasterxml.jackson.databind.json.JsonMapper").isVoid())
+            throw new IllegalStateException("Jackson is not available");
+        return new JsonDataMapper();
+    }
 
     @Provider("toml")
-    private final JacksonDataMapper toml = new TomlDataMapper();
+    public JacksonDataMapper toml() {
+        if (TypeContext.lookup("com.fasterxml.jackson.dataformat.toml.TomlMapper").isVoid())
+            throw new IllegalStateException("TOML is not available");
+        return new TomlDataMapper();
+    }
 
     @Provider("xml")
-    private final JacksonDataMapper xml = new XmlDataMapper();
+    public JacksonDataMapper xml() {
+        if (TypeContext.lookup("com.fasterxml.jackson.dataformat.xml.XmlMapper").isVoid())
+            throw new IllegalStateException("XML is not available");
+        return new XmlDataMapper();
+    }
 
     @Provider("yml")
-    private final JacksonDataMapper yml = new YamlDataMapper();
+    public JacksonDataMapper yml() {
+        if (TypeContext.lookup("com.fasterxml.jackson.dataformat.yaml.YAMLMapper").isVoid())
+            throw new IllegalStateException("YAML is not available");
+        return new YamlDataMapper();
+    }
 
     @Provider
     public ObjectMapper objectMapper() {
-        if (TypeContext.lookup("com.fasterxml.jackson.databind.ObjectMapper").isVoid()) throw new IllegalStateException("Jackson is not available");
         return new JacksonObjectMapper();
     }
 }

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyProviders.java
@@ -6,7 +6,7 @@ import org.dockbox.hartshorn.web.HttpWebServer;
 import org.dockbox.hartshorn.web.annotations.UseHttpServer;
 import org.dockbox.hartshorn.web.servlet.DirectoryServlet;
 
-@Service(activators = UseHttpServer.class)
+@Service(activators = UseHttpServer.class, requires = "org.eclipse.jetty.server.Server")
 public class JettyProviders {
 
     @Provider

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
@@ -7,7 +7,7 @@ import org.dockbox.hartshorn.web.mvc.MVCInitializer;
 
 import javax.inject.Singleton;
 
-@Service(activators = UseMvcServer.class)
+@Service(activators = UseMvcServer.class, requires = "freemarker.template.Template")
 public class FreeMarkerProviders {
 
     @Provider


### PR DESCRIPTION
# Description
Currently, components are always activated when the required service activator is present. However, this does not keep in mind that different implementations may exist for the same component bindings. For example, the `ObjectMapper` type defaults to the use of Jackson for object (de)serialization. However, it is likely that another implementation would use Gson instead. With the activator being unaware of the implementation, both would be bound.

This PR introduces a way for components to activate only when specific types are available. This is done through the new `Component#requires` attribute, which allows types to define the fully qualified names of required types. When one or more of these types are absent, the component will not activate by default.  

Filters are applied through the new `ComponentActivationFilter` type. For the type filter, this is done through the `TypePresenceActivationFilter` specifically. These filters are added to- and processed by the `ComponentLocatorImpl`. The default activator filter has been moved to the `ActivatorPresenceActivationFilter`, to follow this new guideline.  

The following internal services have been updated to follow this new utility:
- `HibernateProviders`, requires `@UsePersistence` and `org.hibernate.Hibernate`
- `JacksonProviders`, requires `@UsePersistence` and `com.fasterxml.jackson.databind.ObjectMapper` (dataformat implementations have separate validation in place)
- `JettyProviders`, requires `@UseHttpServer` and `org.eclipse.jetty.server.Server`
- `FreeMarkerProviders`, requires `@UseMvcServer` and `freemarker.template.Template`

Fixes #699 

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
