### PR TITLE
#707 Add missing implementation for `StandardDelegatingApplicationContext` `#singleton(Key, S)`

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/StandardDelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/context/StandardDelegatingApplicationContext.java
@@ -481,7 +481,6 @@ public class StandardDelegatingApplicationContext extends DefaultContext impleme
         this.componentProvider.bind(key, instance);
     }
 
-
     public ClasspathResourceLocator resourceLocator() {
         return this.resourceLocator;
     }
@@ -501,7 +500,7 @@ public class StandardDelegatingApplicationContext extends DefaultContext impleme
 
     @Override
     public <T, C extends T> void singleton(final Key<T> key, final C instance) {
-
+        this.componentProvider.singleton(key, instance);
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/services/ComponentContainerImpl.java
@@ -100,7 +100,7 @@ public class ComponentContainerImpl implements ComponentContainer {
 
     @Override
     public boolean permitsProxying() {
-        return this.annotation().permitProxying();
+        return this.permitsProcessing() && this.annotation().permitProxying();
     }
 
     @Override


### PR DESCRIPTION
# Description
Adds a previously missing implementation for `#singleton(Key, S)` in `StandardDelegatingApplicationContext`. This delegates the method to the `StandardComponentProvider` in the context.  

Additionally, the rule to permit proxying on components will now also filter whether processing is permitted in the first place.

Fixes #707

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
