### PR TITLE
#650 Automatic configuration filetype detection and #656 configuration fallback sources

### DIFF
--- a/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/UserRepository.java
+++ b/examples/src/persistence/java/org/dockbox/hartshorn/demo/persistence/services/UserRepository.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
 @Service
 /* Indicates this type is responsible for firing the UserCreated event. This serves solely to satisfy the EventValidator, so any unhandled events are noticed on startup */
 @Posting(UserCreatedEvent.class)
-@Configuration(source = "classpath:persistence-demo.yml")
+@Configuration("classpath:persistence-demo.yml")
 public abstract class UserRepository implements JpaRepository<User, Long> {
 
     @Inject

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ClasspathResourceLocator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/ClasspathResourceLocator.java
@@ -18,7 +18,9 @@ package org.dockbox.hartshorn.core.boot;
 
 import org.dockbox.hartshorn.core.domain.Exceptional;
 
+import java.net.URI;
 import java.nio.file.Path;
+import java.util.Set;
 
 /**
  * A classpath resource locator. This class is used to locate resources in the classpath, and make them available to
@@ -40,4 +42,8 @@ public interface ClasspathResourceLocator {
      * @return The resource file wrapped in a {@link Exceptional}, or an appropriate {@link Exceptional} (either none or providing the appropriate exception).
      */
     Exceptional<Path> resource(final String name);
+
+    Set<Path> resources(final String name);
+
+    URI classpathUri();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Resources.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Resources.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.core.boot;
 
 import java.io.File;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Resources.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/core/boot/Resources.java
@@ -1,0 +1,77 @@
+package org.dockbox.hartshorn.core.boot;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class Resources {
+
+    private static ClassLoader defaultClassLoader;
+
+    private Resources() {
+    }
+
+    public static URL getResourceURL(final String resource) throws IOException {
+        return getResourceURL(getClassLoader(), resource);
+    }
+
+    public static URL getResourceURL(final ClassLoader loader, final String resource) throws IOException {
+        URL url = null;
+        if (loader != null) url = loader.getResource(resource);
+        if (url == null) url = ClassLoader.getSystemResource(resource);
+        if (url == null) throw new IOException("Could not find resource " + resource);
+        return url;
+    }
+
+    public static File getResourceAsFile(final String resource) throws IOException {
+        return new File(getResourceURL(resource).getFile());
+    }
+
+    public static File getResourceAsFile(final ClassLoader loader, final String resource) throws IOException {
+        return new File(getResourceURL(loader, resource).getFile());
+    }
+
+    public static Set<URL> getResourceURLs(final String resource) throws IOException {
+        return getResourceURLs(getClassLoader(), resource);
+    }
+
+    public static Set<URL> getResourceURLs(final ClassLoader loader, final String resource) throws IOException {
+        final Set<URL> urls = new HashSet<>();
+        if (loader != null) {
+            final Enumeration<URL> resources = loader.getResources(resource);
+            if (resources != null) {
+                while (resources.hasMoreElements()) urls.add(resources.nextElement());
+            }
+        }
+        final Enumeration<URL> systemResources = ClassLoader.getSystemResources(resource);
+        if (systemResources != null) {
+            while (systemResources.hasMoreElements()) urls.add(systemResources.nextElement());
+        }
+        return Collections.unmodifiableSet(urls);
+    }
+
+    public static Set<File> getResourcesAsFiles(final String resource) throws IOException {
+        return getResourceURLs(resource).stream()
+                .map(url -> new File(url.getFile()))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    public static Set<File> getResourcesAsFiles(final ClassLoader loader, final String resource) throws IOException {
+        return getResourceURLs(loader, resource).stream()
+                .map(url -> new File(url.getFile()))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static ClassLoader getClassLoader() {
+        try {
+            return Thread.currentThread().getContextClassLoader();
+        } catch (final SecurityException e) {
+            return Hartshorn.class.getClassLoader();
+        }
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ClassPathResourceLookupStrategy.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ClassPathResourceLookupStrategy.java
@@ -17,17 +17,17 @@
 package org.dockbox.hartshorn.data;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.domain.Exceptional;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.Getter;
 
 /**
  * Looks up a resource through the classpath. The packaged resource is copied to a temporary file, created and managed
- * by {@link org.dockbox.hartshorn.core.boot.ClasspathResourceLocator#resource(String)}. This requires the strategy name to be
+ * by {@link org.dockbox.hartshorn.core.boot.ClasspathResourceLocator#resources(String)}. This requires the strategy name to be
  * configured to be equal to {@code classpath:{resource_name}}.
  */
 public class ClassPathResourceLookupStrategy implements ResourceLookupStrategy {
@@ -36,7 +36,12 @@ public class ClassPathResourceLookupStrategy implements ResourceLookupStrategy {
     private final String name = "classpath";
 
     @Override
-    public Exceptional<URI> lookup(final ApplicationContext context, final String path, final TypeContext<?> owner, final FileFormats fileFormat) {
-        return context.resourceLocator().resource(path).map(Path::toUri);
+    public Set<URI> lookup(final ApplicationContext context, final String path) {
+        return context.resourceLocator().resources(path).stream().map(Path::toUri).collect(Collectors.toSet());
+    }
+
+    @Override
+    public URI baseUrl(final ApplicationContext context) {
+        return context.resourceLocator().classpathUri();
     }
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ConfigurationProviders.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ConfigurationProviders.java
@@ -19,9 +19,11 @@ package org.dockbox.hartshorn.data;
 import org.dockbox.hartshorn.core.annotations.inject.Provider;
 import org.dockbox.hartshorn.core.annotations.stereotype.Service;
 import org.dockbox.hartshorn.core.context.ApplicationContext;
+import org.dockbox.hartshorn.data.annotations.Configuration;
 import org.dockbox.hartshorn.data.annotations.UseConfigurations;
 
 @Service(activators = UseConfigurations.class)
+@Configuration("application")
 public class ConfigurationProviders {
 
     @Provider

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ResourceLookupStrategy.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ResourceLookupStrategy.java
@@ -17,17 +17,19 @@
 package org.dockbox.hartshorn.data;
 
 import org.dockbox.hartshorn.core.context.ApplicationContext;
-import org.dockbox.hartshorn.core.context.element.TypeContext;
-import org.dockbox.hartshorn.core.domain.Exceptional;
 import org.dockbox.hartshorn.data.annotations.Configuration;
 
 import java.net.URI;
+import java.util.Set;
 
 /**
- * Defines how a {@link Configuration#source() resource} is looked up while processing types annotated with
+ * Defines how a {@link Configuration#value() resource} is looked up while processing types annotated with
  * {@link Configuration}.
  */
 public interface ResourceLookupStrategy {
     String name();
-    Exceptional<URI> lookup(ApplicationContext context, String path, TypeContext<?> owner, FileFormats fileFormat);
+
+    Set<URI> lookup(ApplicationContext context, String path);
+
+    URI baseUrl(ApplicationContext context);
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/Configuration.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/Configuration.java
@@ -17,8 +17,6 @@
 package org.dockbox.hartshorn.data.annotations;
 
 import org.dockbox.hartshorn.data.ConfigurationServicePreProcessor;
-import org.dockbox.hartshorn.core.boot.Hartshorn;
-import org.dockbox.hartshorn.data.FileFormats;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -30,11 +28,13 @@ import java.lang.annotation.Target;
  * {@link org.dockbox.hartshorn.data.ResourceLookupStrategy}. For example a {@link org.dockbox.hartshorn.data.ClassPathResourceLookupStrategy}
  * will accept a source formatted as {@code classpath:filename}.
  *
- * <p>The {@link #source()} should not contain the file extension, the file format is automatically adjusted based on available files.
+ * <p>The {@link #value()} does not have to include the file extension, the file format is automatically adjusted based on available files if
+ * no explicit file extension is provided.
  *
- * <p>The example below will target demo.yml as a classpath resource.
+ * <p>Assuming there is a file called `demo.yml` on the classpath, the following will adapt to {@link org.dockbox.hartshorn.data.FileFormats#YAML}.
  * <pre>{@code
- * @Configuration(source = "classpath:demo")
+ * @Component
+ * @Configuration("classpath:demo")
  * public class SampleClassPathConfiguration {
  *    @Value("sample.value")
  *    private final String value = "default value if key does not exist";
@@ -49,9 +49,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Configuration {
-    String source();
-
-    Class<?> owner() default Hartshorn.class;
-
-    FileFormats filetype() default FileFormats.YAML;
+    String[] value();
+    boolean failOnMissing() default false;
 }

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DemoClasspathConfiguration.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DemoClasspathConfiguration.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 
 @Getter
 @Component
-@Configuration(source = "classpath:junit.yml")
+@Configuration({ "fs:junit", "classpath:junit" })
 public class DemoClasspathConfiguration {
 
     @Value("junit.cp")

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DemoFSConfiguration.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DemoFSConfiguration.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Component
-@Configuration(source = "junit.yml")
+@Configuration("junit.yml")
 public class DemoFSConfiguration {
 
     @Value("junit.fs")

--- a/hartshorn-data/src/test/resources/junit.properties
+++ b/hartshorn-data/src/test/resources/junit.properties
@@ -1,0 +1,1 @@
+junit.number=1

--- a/hartshorn-data/src/test/resources/junit.yml
+++ b/hartshorn-data/src/test/resources/junit.yml
@@ -1,6 +1,5 @@
 junit:
   cp: "This is a value"
-  number: 1
   list:
     - 1
     - 5


### PR DESCRIPTION
# Description
When using a non-default (YAML) file for `@Configuration` types, it is always required to provide the file type. However this leads to strict binding to a given file type.  

With this PR, configurations will automatically scan for all files with the given filename in the configured location. If one or more files exists, each file will be used. If multiple files exist a warning will be given, to indicate potential property duplication. If no files exist the behavior depends on the value of `Configuration#failOnMissing`. If this is `true`, an error will yield. If it is `false` a warning log will be added but the application will proceed, this is the default behavior.

Fixes #650 

Additionally, fallback sources were added. This changes the source definition in `@Configuration` to an array value, which will be iterated until a source was found. If no sources are found `#failOnMissing` will yield the same behavior as mentioned above.

Fixes #656

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
