### PR TITLE
#724 Support per class lifecycle in test suite

### DIFF
--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
@@ -16,14 +16,14 @@
 
 package org.dockbox.hartshorn.core.boot;
 
-import org.dockbox.hartshorn.application.HartshornApplicationFactory;
-import org.dockbox.hartshorn.inject.processing.UseServiceProvision;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
-import org.dockbox.hartshorn.testsuite.HartshornExtension;
+import org.dockbox.hartshorn.inject.processing.UseServiceProvision;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
+import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,17 +34,19 @@ import javax.inject.Inject;
 
 @HartshornTest
 @UseServiceProvision
+@TestInstance(Lifecycle.PER_CLASS)
 public class ComponentProvisionTests {
 
     @Inject
     private ApplicationContext applicationContext;
 
-    public static Stream<Arguments> components() {
-        return HartshornExtension.createContext(new HartshornApplicationFactory().loadDefaults(), ComponentProvisionTests.class)
-                .rethrowUnchecked().get()
+    public Stream<Arguments> components() {
+        return this.applicationContext()
                 .locator()
                 .containers().stream()
                 .map(ComponentContainer::type)
+                // org.dockbox.hartshorn.core.types is test-specific and includes a few test-specific types
+                // that are not part of the core types, and thus should not be tested here.
                 .filter(type -> !type.isDeclaredIn("org.dockbox.hartshorn.core.types"))
                 .filter(type -> type.boundConstructors().size() != type.constructors().size())
                 .map(Arguments::of);

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.processing.AutomaticActivation;
 import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.i18n.services.TranslationInjectPostProcessor;
-import org.dockbox.hartshorn.testsuite.HartshornExtension;
+import org.dockbox.hartshorn.testsuite.HartshornLifecycleExtension;
 import org.dockbox.hartshorn.util.CollectionUtilities;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
@@ -82,7 +82,7 @@ public final class TranslationBatchGenerator {
     private TranslationBatchGenerator() {}
 
     public static void main(final String[] args) throws Exception {
-        final ApplicationContext context = HartshornExtension
+        final ApplicationContext context = HartshornLifecycleExtension
                 .createTestContext(new HartshornApplicationFactory().loadDefaults(), TranslationBatchGenerator.class)
                 .orNull();
         final Map<String, String> batches = migrateBatches(context);

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationBatchGenerator.java
@@ -16,16 +16,16 @@
 
 package org.dockbox.hartshorn.i18n;
 
-import org.dockbox.hartshorn.util.CollectionUtilities;
-import org.dockbox.hartshorn.component.processing.AutomaticActivation;
 import org.dockbox.hartshorn.application.HartshornApplicationFactory;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.reflect.MethodContext;
-import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.dockbox.hartshorn.component.ComponentContainer;
+import org.dockbox.hartshorn.component.processing.AutomaticActivation;
 import org.dockbox.hartshorn.i18n.annotations.InjectTranslation;
 import org.dockbox.hartshorn.i18n.services.TranslationInjectPostProcessor;
 import org.dockbox.hartshorn.testsuite.HartshornExtension;
+import org.dockbox.hartshorn.util.CollectionUtilities;
+import org.dockbox.hartshorn.util.reflect.MethodContext;
+import org.dockbox.hartshorn.util.reflect.TypeContext;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -82,7 +82,9 @@ public final class TranslationBatchGenerator {
     private TranslationBatchGenerator() {}
 
     public static void main(final String[] args) throws Exception {
-        final ApplicationContext context = HartshornExtension.createContext(new HartshornApplicationFactory().loadDefaults(), TranslationBatchGenerator.class).orNull();
+        final ApplicationContext context = HartshornExtension
+                .createTestContext(new HartshornApplicationFactory().loadDefaults(), TranslationBatchGenerator.class)
+                .orNull();
         final Map<String, String> batches = migrateBatches(context);
         final String date = SDF.format(LocalDateTime.now());
         final Path outputPath = existingBatch().toPath().resolve("batches/" + date);

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.testsuite;
 
 import org.dockbox.hartshorn.application.Activator;
@@ -37,7 +53,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 @Activator
-public class HartshornExtension implements
+public class HartshornLifecycleExtension implements
         ParameterResolver,
         BeforeAllCallback, AfterAllCallback,
         BeforeEachCallback, AfterEachCallback {
@@ -84,12 +100,12 @@ public class HartshornExtension implements
         }
 
         final ApplicationFactory applicationFactory = this.prepareFactory(testClass, testComponentSources);
-        final ApplicationContext applicationContext = HartshornExtension.createTestContext(applicationFactory, testClass).orNull();
+        final ApplicationContext applicationContext = HartshornLifecycleExtension.createTestContext(applicationFactory, testClass).orNull();
         if (applicationContext == null) {
             if (applicationContext == null) throw new IllegalStateException("Could not create application context");
         }
 
-        applicationContext.bind(HartshornExtension.class).singleton(this);
+        applicationContext.bind(HartshornLifecycleExtension.class).singleton(this);
 
         if (testInstance != null) {
             this.populateTestInstance(testInstance, applicationContext);
@@ -130,7 +146,7 @@ public class HartshornExtension implements
         TypeContext<?> applicationActivator = TypeContext.of(activator);
 
         if (applicationActivator.annotation(Activator.class).absent()) {
-            applicationActivator = TypeContext.of(HartshornExtension.class);
+            applicationActivator = TypeContext.of(HartshornLifecycleExtension.class);
             final Set<Annotation> serviceActivators = TypeContext.of(activator).annotations().stream()
                     .filter(annotation -> TypeContext.of(annotation.annotationType()).annotation(ServiceActivator.class).present())
                     .collect(Collectors.toSet());

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
@@ -31,19 +31,19 @@ import javax.inject.Inject;
 
 /**
  * Annotation for test classes that should be run with the Hartshorn test suite. This will automatically
- * provide the test class with a {@link HartshornExtension} that will provide an active
+ * provide the test class with a {@link HartshornLifecycleExtension} that will provide an active
  * {@link ApplicationContext} for the test class. The provided {@link ApplicationContext} is refreshed
  * according to the lifecycle of the test class.
  *
- * <p>Additionally, the {@link HartshornExtension} will inject fields annotated with {@link Inject}
+ * <p>Additionally, the {@link HartshornLifecycleExtension} will inject fields annotated with {@link Inject}
  * within the test class. Like the active {@link ApplicationContext}, this will be refreshed according to
  * the lifecycle of the test class.
  *
- * @see HartshornExtension
+ * @see HartshornLifecycleExtension
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(HartshornExtension.class)
+@ExtendWith(HartshornLifecycleExtension.class)
 @Extends(Populate.class)
 @Populate(executables = false)
 public @interface HartshornTest {

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
@@ -31,12 +31,13 @@ import javax.inject.Inject;
 
 /**
  * Annotation for test classes that should be run with the Hartshorn test suite. This will automatically
- * provide the test class with a {@link HartshornExtension} that will provide an active {@link ApplicationContext}
- * for the test class. The provided {@link ApplicationContext} is refreshed for every test case, to avoid
- * leaking context data between test cases.
+ * provide the test class with a {@link HartshornExtension} that will provide an active
+ * {@link ApplicationContext} for the test class. The provided {@link ApplicationContext} is refreshed
+ * according to the lifecycle of the test class.
  *
- * <p>Additionally, the {@link HartshornExtension} will inject fields annotated with {@link Inject} within
- * the test class. Like the active {@link ApplicationContext}, this will be refreshed for every test case.
+ * <p>Additionally, the {@link HartshornExtension} will inject fields annotated with {@link Inject}
+ * within the test class. Like the active {@link ApplicationContext}, this will be refreshed according to
+ * the lifecycle of the test class.
  *
  * @see HartshornExtension
  */


### PR DESCRIPTION
# Description
> The `HartshornExtension` in the test suite is designed to support a per-method lifecycle, however this may not always be the case. When a test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)` the lifecycle is no longer maintained per method, making it so `beforeEach` and `afterEach` are no longer called in `HartshornExtension`.

These changes will dynamically support per class and per method lifecycles. This is useful for (for example) parameterized tests which depend on the application context, like the `ComponentProvisionTests` which tests for all default components.

Fixes #724

## Type of change
- [x] New feature (non-breaking change that does affect the code)
- [x] Refactor (code changes that do not affect the behavior of the code)
- [x] Test (changes to tests)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
