### PR TITLE
#726 Fix lambda proxying in different classloader

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentInstanceFactory.java
@@ -21,5 +21,5 @@ import org.dockbox.hartshorn.util.Exceptional;
 
 @FunctionalInterface
 public interface ComponentInstanceFactory {
-    <T>Exceptional<T> instantiate(Key<T> key);
+    <T> Exceptional<T> instantiate(Key<T> key);
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -16,25 +16,26 @@
 
 package org.dockbox.hartshorn.core.proxy;
 
-import org.dockbox.hartshorn.util.StringUtilities;
-import org.dockbox.hartshorn.proxy.UseProxying;
-import org.dockbox.hartshorn.inject.processing.UseServiceProvision;
-import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.util.reflect.MethodContext;
-import org.dockbox.hartshorn.util.Exceptional;
-import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.core.proxy.types.ConcreteProxyTarget;
 import org.dockbox.hartshorn.core.proxy.types.FinalProxyTarget;
 import org.dockbox.hartshorn.core.proxy.types.ProviderService;
 import org.dockbox.hartshorn.core.proxy.types.SampleType;
+import org.dockbox.hartshorn.inject.processing.UseServiceProvision;
 import org.dockbox.hartshorn.proxy.MethodInterceptor;
 import org.dockbox.hartshorn.proxy.MethodWrapper;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.proxy.ProxyManager;
+import org.dockbox.hartshorn.proxy.StateAwareProxyFactory;
+import org.dockbox.hartshorn.proxy.UseProxying;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.dockbox.hartshorn.testsuite.InjectTest;
+import org.dockbox.hartshorn.util.ApplicationException;
+import org.dockbox.hartshorn.util.Exceptional;
+import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,6 +44,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
@@ -335,13 +337,13 @@ public class ProxyTests {
     }
 
     @Service
-    public static interface DemoServiceA { }
+    public interface DemoServiceA { }
 
     @Service
     public static class DemoServiceB { }
 
     @Service
-    public static abstract class DemoServiceC { }
+    public abstract static class DemoServiceC { }
 
     @Test
     void testConcreteProxySelfEquality() throws ApplicationException {
@@ -372,13 +374,12 @@ public class ProxyTests {
         Assertions.assertTrue(proxyInstance.test(proxyInstance));
     }
 
-//    @Test
-//    void testLambdaCanBeProxied() throws NoSuchMethodException, ApplicationException {
-//        // TODO: This test is not working.
-//        final StateAwareProxyFactory<Supplier, ?> factory = this.applicationContext.environment().manager().factory(Supplier.class);
-//        factory.intercept(Supplier.class.getMethod("get"), context -> "foo");
-//        final Exceptional<Supplier> proxy = factory.proxy();
-//        Assertions.assertTrue(proxy.present());
-//        Assertions.assertEquals("foo", proxy.get().get());
-//    }
+    @Test
+    void testLambdaCanBeProxied() throws NoSuchMethodException, ApplicationException {
+        final StateAwareProxyFactory<Supplier, ?> factory = this.applicationContext.environment().manager().factory(Supplier.class);
+        factory.intercept(Supplier.class.getMethod("get"), context -> "foo");
+        final Exceptional<Supplier> proxy = factory.proxy();
+        Assertions.assertTrue(proxy.present());
+        Assertions.assertEquals("foo", proxy.get().get());
+    }
 }


### PR DESCRIPTION
# Description
Fixes the following test:
https://github.com/GuusLieben/Hartshorn/blob/d29dc1648efec1db60bef1d15dafbae0630386bf/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java#L375-L383

This was caused by the ClassLoader for `org.dockbox.hartshorn.proxy.Proxy` being different from the one responsible for the Lambda. By looking up the default ClassLoader for both, this works correctly. Appropriate fallbacks have been put in place to handle the situation where the default ClassLoader is either unavailable or not accessible.

Fixes #726

## Type of change
- [x] Bug fix (non-breaking change that doesn't affect the behavior of the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
