### PR TITLE
#717 Migrate instance population to post processor

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ApplicationContext.java
@@ -45,10 +45,7 @@ public interface ApplicationContext extends
         ExceptionHandler,
         ApplicationLogger,
         ActivatorHolder,
-        Closeable
-{
-
-    <T> T populate(T type);
+        Closeable {
 
     void add(ComponentProcessor<?> processor);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/StandardDelegatingApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/StandardDelegatingApplicationContext.java
@@ -364,11 +364,6 @@ public class StandardDelegatingApplicationContext extends DefaultContext impleme
     }
 
     @Override
-    public <T> T populate(final T type) {
-        return this.componentPopulator.populate(type);
-    }
-
-    @Override
     public <T> T invoke(final MethodContext<T, ?> method) {
         return this.invoke((MethodContext<? extends T, Object>) method, this.get(method.parent()));
     }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
@@ -1,0 +1,54 @@
+package org.dockbox.hartshorn.component.processing;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.application.ExceptionHandler;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.ComponentContainer;
+import org.dockbox.hartshorn.component.ComponentPopulator;
+import org.dockbox.hartshorn.component.Service;
+import org.dockbox.hartshorn.inject.Key;
+import org.dockbox.hartshorn.proxy.ProxyFactory;
+import org.dockbox.hartshorn.proxy.StateAwareProxyFactory;
+import org.dockbox.hartshorn.util.ApplicationException;
+
+@AutomaticActivation
+public class ComponentFinalizingPostProcessor implements ComponentPostProcessor<Service> {
+
+    @Override
+    public Class<Service> activator() {
+        return Service.class;
+    }
+
+    @Override
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+        T finalizingInstance = instance;
+        if (processingContext.containsKey(Key.of(ProxyFactory.class))) {
+            final ProxyFactory<T, ?> factory = processingContext.get(Key.of(ProxyFactory.class));
+            try {
+                if (((StateAwareProxyFactory) factory).modified() || (instance == null && key.type().isAbstract())) {
+                    finalizingInstance = factory.proxy().or(instance);
+                }
+            }
+            catch (final ApplicationException e) {
+                ExceptionHandler.unchecked(e);
+            }
+        }
+        return context.get(ComponentPopulator.class).populate(finalizingInstance);
+    }
+
+    @Override
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        throw new UnsupportedOperationException("Finalizing without a context is not supported");
+    }
+
+    @Override
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+        return processingContext.get(Key.of(ComponentContainer.class)).permitsProxying();
+    }
+
+    @Override
+    public Integer order() {
+        // Run after all other core post processors, but permit external post processors to run after this one
+        return Integer.MAX_VALUE / 2;
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentFinalizingPostProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.component.processing;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -20,7 +36,7 @@ public class ComponentFinalizingPostProcessor implements ComponentPostProcessor<
     }
 
     @Override
-    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         T finalizingInstance = instance;
         if (processingContext.containsKey(Key.of(ProxyFactory.class))) {
             final ProxyFactory<T, ?> factory = processingContext.get(Key.of(ProxyFactory.class));
@@ -42,7 +58,7 @@ public class ComponentFinalizingPostProcessor implements ComponentPostProcessor<
     }
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return processingContext.get(Key.of(ComponentContainer.class)).permitsProxying();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPreProcessor.java
@@ -48,7 +48,7 @@ import java.lang.annotation.Annotation;
 public interface ComponentPreProcessor<A extends Annotation> extends ComponentProcessor<A> {
 
     @Override
-    default <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    default <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         throw new UnsupportedOperationException("Component pre-processor does not support instance processing, use modifies(ApplicationContext, Key) instead.");
     }
 
@@ -66,7 +66,7 @@ public interface ComponentPreProcessor<A extends Annotation> extends ComponentPr
      * @return <code>true</code> if the component pre-processor modifies the component, <code>false</code>
      * otherwise.
      * @see ComponentProcessor#modifies(ApplicationContext, Key, Object, ComponentProcessingContext)
-     * @see ComponentProcessor#preconditions(ApplicationContext, Key, Object)
+     * @see ComponentProcessor#preconditions(ApplicationContext, Key, Object, ComponentProcessingContext)
      */
     boolean modifies(ApplicationContext context, Key<?> key);
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentPreProcessor.java
@@ -48,7 +48,7 @@ import java.lang.annotation.Annotation;
 public interface ComponentPreProcessor<A extends Annotation> extends ComponentProcessor<A> {
 
     @Override
-    default <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    default <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         throw new UnsupportedOperationException("Component pre-processor does not support instance processing, use modifies(ApplicationContext, Key) instead.");
     }
 
@@ -65,7 +65,7 @@ public interface ComponentPreProcessor<A extends Annotation> extends ComponentPr
      * @param key The type context of the component.
      * @return <code>true</code> if the component pre-processor modifies the component, <code>false</code>
      * otherwise.
-     * @see ComponentProcessor#modifies(ApplicationContext, Key, Object)
+     * @see ComponentProcessor#modifies(ApplicationContext, Key, Object, ComponentProcessingContext)
      * @see ComponentProcessor#preconditions(ApplicationContext, Key, Object)
      */
     boolean modifies(ApplicationContext context, Key<?> key);

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessingContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessingContext.java
@@ -27,12 +27,22 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-public class ComponentProcessingContext extends DefaultCarrierContext {
+public class ComponentProcessingContext<O> extends DefaultCarrierContext {
 
+    private ProcessingPhase phase;
     private final Map<Key<?>, Object> data = new ConcurrentHashMap<>();
 
     public ComponentProcessingContext(final ApplicationContext applicationContext) {
         super(applicationContext);
+    }
+
+    public ProcessingPhase phase() {
+        return this.phase;
+    }
+
+    public ComponentProcessingContext phase(final ProcessingPhase phase) {
+        this.phase = phase;
+        return this;
     }
 
     public int size() {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessor.java
@@ -73,23 +73,29 @@ public interface ComponentProcessor<A extends Annotation> extends ActivatorFilte
      * @param <T> The type of the component.
      * @return True if the processor should be called, false otherwise.
      */
-    default <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
-        return context.locator().container(key.type()).present() && this.modifies(context, key, instance);
+    default <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+        return processingContext.get(Key.of(ComponentContainer.class)) != null && this.modifies(context, key, instance, processingContext);
     }
 
     /**
      * Determines whether the component processor should be called for the given component. This method
-     * will only be called if the preconditions of {@link #preconditions(ApplicationContext, Key, Object)}
-     * are met, assuming the {@link #preconditions(ApplicationContext, Key, Object)} are not modified
+     * will only be called if the preconditions of {@link #preconditions(ApplicationContext, Key, Object, ComponentProcessingContext)}
+     * are met, assuming the {@link #preconditions(ApplicationContext, Key, Object, ComponentProcessingContext)} are not modified
      * by the implementing class.
      *
-     * @param context The application context.
-     * @param key The key of the component.
-     * @param instance The instance of the component.
-     * @param <T> The type of the component.
+     * @param <T>
+     *         The type of the component.
+     * @param context
+     *         The application context.
+     * @param key
+     *         The key of the component.
+     * @param instance
+     *         The instance of the component.
+     * @param processingContext
+     *
      * @return <code>true</code> if the component processor modifies the component, <code>false</code>
-     * otherwise.
+     *         otherwise.
      */
-    <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance);
+    <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance, final ComponentProcessingContext processingContext);
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ComponentProcessor.java
@@ -58,7 +58,7 @@ public interface ComponentProcessor<A extends Annotation> extends ActivatorFilte
      */
     <T> T process(ApplicationContext context, Key<T> key, @Nullable T instance);
 
-    default <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    default <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return this.process(context, key, instance);
     }
 
@@ -73,7 +73,7 @@ public interface ComponentProcessor<A extends Annotation> extends ActivatorFilte
      * @param <T> The type of the component.
      * @return True if the processor should be called, false otherwise.
      */
-    default <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    default <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return processingContext.get(Key.of(ComponentContainer.class)) != null && this.modifies(context, key, instance, processingContext);
     }
 
@@ -96,6 +96,6 @@ public interface ComponentProcessor<A extends Annotation> extends ActivatorFilte
      * @return <code>true</code> if the component processor modifies the component, <code>false</code>
      *         otherwise.
      */
-    <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance, final ComponentProcessingContext processingContext);
+    <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance, final ComponentProcessingContext<T> processingContext);
 
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/FunctionalComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/FunctionalComponentPostProcessor.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.component.processing;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentType;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.inject.Key;
@@ -26,8 +27,11 @@ import java.lang.annotation.Annotation;
 public abstract class FunctionalComponentPostProcessor<A extends Annotation> implements ComponentPostProcessor<A> {
 
     @Override
-    public <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
-        return ComponentPostProcessor.super.preconditions(context, key, instance)
-                && context.locator().container(key.type()).get().componentType() == ComponentType.FUNCTIONAL;
+    public <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+        final ComponentContainer container = processingContext.get(Key.of(ComponentContainer.class));
+        if (container.componentType() != ComponentType.FUNCTIONAL) {
+            return false;
+        }
+        return ComponentPostProcessor.super.preconditions(context, key, instance, processingContext);
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/FunctionalComponentPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/FunctionalComponentPostProcessor.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Annotation;
 public abstract class FunctionalComponentPostProcessor<A extends Annotation> implements ComponentPostProcessor<A> {
 
     @Override
-    public <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean preconditions(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         final ComponentContainer container = processingContext.get(Key.of(ComponentContainer.class));
         if (container.componentType() != ComponentType.FUNCTIONAL) {
             return false;

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
@@ -16,8 +16,6 @@
 
 package org.dockbox.hartshorn.component.processing;
 
-import java.util.function.Predicate;
-
 public class ProcessingOrder {
 
     public static final int FIRST = -256;
@@ -31,20 +29,13 @@ public class ProcessingOrder {
      * processors are allowed to discard existing instances and return new ones. This can be used to
      * create proxy instances.
      */
-    public static final Predicate<Integer> PHASE_1 = i -> i < 0;
+    public static final ProcessingPhase INITIALIZING = new ProcessingPhase("Initializing", i -> i < 0, true);
 
     /**
      * Indicates which service orders can be performed during phase 2. During this phase, component
      * processors are not allowed to discard existing instances and return new ones. This limits the
      * behavior of these processors to only return the same instance, albeit with different state.
      */
-    public static final Predicate<Integer> PHASE_2 = i -> i >= 0 && i < Integer.MAX_VALUE / 2;
+    public static final ProcessingPhase MODIFYING = new ProcessingPhase("Modifying", i -> i >= 0, false);
 
-    /**
-     * Indicates which service orders can be performed during phase 3. During this phase, component
-     * processors are expected to finalize the state of the instance. This can be used to perform
-     * any finalization tasks. This allows the component processor to return a new instance, but the
-     * new instance is expected to carry the same state as the old instance.
-     */
-    public static final Predicate<Integer> PHASE_3 = i -> i >= Integer.MAX_VALUE / 2;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingOrder.java
@@ -38,5 +38,13 @@ public class ProcessingOrder {
      * processors are not allowed to discard existing instances and return new ones. This limits the
      * behavior of these processors to only return the same instance, albeit with different state.
      */
-    public static final Predicate<Integer> PHASE_2 = i -> i >= 0;
+    public static final Predicate<Integer> PHASE_2 = i -> i >= 0 && i < Integer.MAX_VALUE / 2;
+
+    /**
+     * Indicates which service orders can be performed during phase 3. During this phase, component
+     * processors are expected to finalize the state of the instance. This can be used to perform
+     * any finalization tasks. This allows the component processor to return a new instance, but the
+     * new instance is expected to carry the same state as the old instance.
+     */
+    public static final Predicate<Integer> PHASE_3 = i -> i >= Integer.MAX_VALUE / 2;
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingPhase.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/ProcessingPhase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dockbox.hartshorn.component.processing;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public final class ProcessingPhase implements Predicate<Integer> {
+
+    private final String name;
+    private final Predicate<Integer> predicate;
+    private final boolean isModifiable;
+
+    ProcessingPhase(final String name, final Predicate<Integer> predicate, final boolean isModifiable) {
+        this.name = name;
+        this.predicate = predicate;
+        this.isModifiable = isModifiable;
+    }
+
+    @Override
+    public boolean test(final Integer integer) {
+        return this.predicate.test(integer);
+    }
+
+    public boolean modifiable() {
+        return this.isModifiable;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || this.getClass() != o.getClass()) return false;
+        final ProcessingPhase that = (ProcessingPhase) o;
+        return this.name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name);
+    }
+}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/HartshornApplicationProxier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/HartshornApplicationProxier.java
@@ -59,7 +59,7 @@ public class HartshornApplicationProxier implements ApplicationProxier, Applicat
         if (instance instanceof Proxy proxy) {
             return Exceptional.of(proxy.manager());
         }
-        return null;
+        return Exceptional.empty();
     }
 
     @Override

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/Proxy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/Proxy.java
@@ -24,10 +24,10 @@ package org.dockbox.hartshorn.proxy;
  * @author Guus Lieben
  * @since 22.2
  */
-public interface Proxy {
+public interface Proxy<T> {
     /**
      * Returns the {@link ProxyManager} that is responsible for this proxy.
      * @return the {@link ProxyManager} that is responsible for this proxy
      */
-    ProxyManager manager();
+    ProxyManager<T> manager();
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/PhasedProxyCallbackPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/PhasedProxyCallbackPostProcessor.java
@@ -38,7 +38,7 @@ public abstract class PhasedProxyCallbackPostProcessor<A extends Annotation> ext
     }
 
     @Override
-    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         final Collection<MethodContext<?, T>> methods = this.modifiableMethods(context, key, instance);
 
         final ProxyFactory factory = processingContext.get(Key.of(ProxyFactory.class));

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ProxyDelegationPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ProxyDelegationPostProcessor.java
@@ -31,7 +31,7 @@ public abstract class ProxyDelegationPostProcessor<P, A extends Annotation> exte
     protected abstract Class<P> parentTarget();
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return key.type().childOf(this.parentTarget());
     }
 
@@ -41,7 +41,7 @@ public abstract class ProxyDelegationPostProcessor<P, A extends Annotation> exte
     }
 
     @Override
-    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         final ProxyFactory factory = processingContext.get(Key.of(ProxyFactory.class));
         if (factory == null) return instance;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ProxyDelegationPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ProxyDelegationPostProcessor.java
@@ -31,7 +31,7 @@ public abstract class ProxyDelegationPostProcessor<P, A extends Annotation> exte
     protected abstract Class<P> parentTarget();
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         return key.type().childOf(this.parentTarget());
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodInterceptorPostProcessor.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.proxy.processing;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
@@ -28,7 +29,7 @@ import java.util.Collection;
 public abstract class ServiceAnnotatedMethodInterceptorPostProcessor<M extends Annotation, A extends Annotation> extends ServiceMethodInterceptorPostProcessor<A> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         return !key.type().methods(this.annotation()).isEmpty();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodInterceptorPostProcessor.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 public abstract class ServiceAnnotatedMethodInterceptorPostProcessor<M extends Annotation, A extends Annotation> extends ServiceMethodInterceptorPostProcessor<A> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return !key.type().methods(this.annotation()).isEmpty();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodPostProcessor.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.proxy.processing;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.component.processing.FunctionalComponentPostProcessor;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
@@ -29,7 +30,7 @@ import java.util.Collection;
 public abstract class ServiceAnnotatedMethodPostProcessor<M extends Annotation, A extends Annotation> extends FunctionalComponentPostProcessor<A> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         return !key.type().methods(this.annotation()).isEmpty();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceAnnotatedMethodPostProcessor.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 public abstract class ServiceAnnotatedMethodPostProcessor<M extends Annotation, A extends Annotation> extends FunctionalComponentPostProcessor<A> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return !key.type().methods(this.annotation()).isEmpty();
     }
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceMethodInterceptorPostProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/proxy/processing/ServiceMethodInterceptorPostProcessor.java
@@ -38,7 +38,7 @@ public abstract class ServiceMethodInterceptorPostProcessor<A extends Annotation
     }
 
     @Override
-    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         final TypeContext<T> type = key.type();
         final Collection<MethodContext<?, T>> methods = this.modifiableMethods(type);
 

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
@@ -40,7 +40,7 @@ public class NonProcessableTypeProcessor implements ComponentPostProcessor<Servi
     }
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return instance instanceof NonProcessableType;
     }
 }

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/NonProcessableTypeProcessor.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.core.types;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.component.processing.AutomaticActivation;
 import org.dockbox.hartshorn.component.Service;
@@ -39,7 +40,7 @@ public class NonProcessableTypeProcessor implements ComponentPostProcessor<Servi
     }
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         return instance instanceof NonProcessableType;
     }
 }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ConfigurationComponentPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ConfigurationComponentPostProcessor.java
@@ -40,7 +40,7 @@ import java.util.Collection;
 public class ConfigurationComponentPostProcessor implements ComponentPostProcessor<UseConfigurations> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return !key.type().fields(Value.class).isEmpty();
     }
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ConfigurationComponentPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ConfigurationComponentPostProcessor.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.data;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.data.annotations.UseConfigurations;
 import org.dockbox.hartshorn.data.annotations.Value;
 import org.dockbox.hartshorn.inject.Key;
@@ -39,7 +40,7 @@ import java.util.Collection;
 public class ConfigurationComponentPostProcessor implements ComponentPostProcessor<UseConfigurations> {
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         return !key.type().fields(Value.class).isEmpty();
     }
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/TransactionalProxyCallbackPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/TransactionalProxyCallbackPostProcessor.java
@@ -17,6 +17,7 @@
 package org.dockbox.hartshorn.data.service;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.component.processing.AutomaticActivation;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
@@ -41,7 +42,7 @@ public class TransactionalProxyCallbackPostProcessor extends PhasedProxyCallback
     }
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
         return !key.type().methods(Transactional.class).isEmpty();
     }
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/TransactionalProxyCallbackPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/TransactionalProxyCallbackPostProcessor.java
@@ -42,7 +42,7 @@ public class TransactionalProxyCallbackPostProcessor extends PhasedProxyCallback
     }
 
     @Override
-    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return !key.type().methods(Transactional.class).isEmpty();
     }
 


### PR DESCRIPTION
# Description
Originally, #717 was opened to avoid populating non-components. Since then, this was resolved by #720. However, the concept of moving component population out of the component provider entirely stuck with me.  

The logical way of doing this is to follow the original suggestion I made in #717; move population to a post processor. This is possible in phase 2 of component provision, as it only modifies the state of a component, without potentially discarding the instance (e.g. for proxy instances).  

A next step was to clean up the entire component finalization process. This is made up of two primary steps:
1. Finalize proxy instance
2. Populate outgoing instance

So after step 2 is covered, we are left with step 1 as it is required to be performed before step 2 can be performed. Step 1 is more difficult, as this can potentially swap an outgoing instance with a new proxy instance. This would cause the process to fail, as discarding instances is not permitted in phase 2. 

To resolve this, phase two now permits one type of instance modification; proxying. If the modified instance is a proxy, it is required to have the original instance as its delegate. If this condition is met, the processing will proceed as usual. In all other scenarios the processing will halt and an exception will be thrown. One important thing to note here is the fact that the original instance can be `null`, in which case the delegate of the proxy is also expected to be `null`. Note however, this only targets the primary type delegate, and not any class- or method specific delegates or interceptors.

Fixes #717

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
