### PR TITLE
#733 Add support for configuration objects

### DIFF
--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchicalApplicationComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchicalApplicationComponentProvider.java
@@ -29,13 +29,7 @@ import org.dockbox.hartshorn.inject.ContextDrivenProvider;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.inject.MetaProvider;
 import org.dockbox.hartshorn.inject.Provider;
-import org.dockbox.hartshorn.inject.binding.BindingFunction;
-import org.dockbox.hartshorn.inject.binding.BindingHierarchy;
-import org.dockbox.hartshorn.inject.binding.ConcurrentHashSingletonCache;
-import org.dockbox.hartshorn.inject.binding.ContextWrappedHierarchy;
-import org.dockbox.hartshorn.inject.binding.HierarchyBindingFunction;
-import org.dockbox.hartshorn.inject.binding.NativeBindingHierarchy;
-import org.dockbox.hartshorn.inject.binding.SingletonCache;
+import org.dockbox.hartshorn.inject.binding.*;
 import org.dockbox.hartshorn.proxy.Proxy;
 import org.dockbox.hartshorn.proxy.ProxyFactory;
 import org.dockbox.hartshorn.proxy.StateAwareProxyFactory;
@@ -46,10 +40,9 @@ import org.dockbox.hartshorn.util.MultiMap;
 import org.dockbox.hartshorn.util.reflect.FieldContext;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 
+import javax.inject.Inject;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.inject.Inject;
 
 public class HierarchicalApplicationComponentProvider extends DefaultContext implements StandardComponentProvider, ContextCarrier {
 
@@ -212,7 +205,7 @@ public class HierarchicalApplicationComponentProvider extends DefaultContext imp
                         }
 
                         checkForIllegalModification:
-                        if (instance != modified) {
+                        if (!phase.modifiable() && instance != modified) {
                             if (modified instanceof Proxy) {
                                 final Proxy<T> proxy = (Proxy<T>) modified;
                                 final boolean delegateMatches = proxy.manager().delegate().orNull() == instance;

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/ConfigurationObject.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/ConfigurationObject.java
@@ -1,0 +1,16 @@
+package org.dockbox.hartshorn.data.annotations;
+
+import org.dockbox.hartshorn.component.Component;
+import org.dockbox.hartshorn.util.reflect.Extends;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Extends(Component.class)
+public @interface ConfigurationObject {
+    String prefix() default "";
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/ConfigurationObject.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/ConfigurationObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.data.annotations;
 
 import org.dockbox.hartshorn.component.Component;

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/UseConfigurations.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/annotations/UseConfigurations.java
@@ -19,6 +19,7 @@ package org.dockbox.hartshorn.data.annotations;
 import org.dockbox.hartshorn.component.processing.ServiceActivator;
 import org.dockbox.hartshorn.data.ConfigurationComponentPostProcessor;
 import org.dockbox.hartshorn.data.ConfigurationServicePreProcessor;
+import org.dockbox.hartshorn.data.service.ConfigurationObjectPostProcessor;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -33,6 +34,7 @@ import java.lang.annotation.Target;
 @ServiceActivator(processors = {
         ConfigurationComponentPostProcessor.class,
         ConfigurationServicePreProcessor.class,
+        ConfigurationObjectPostProcessor.class,
 })
 @UsePersistence
 public @interface UseConfigurations {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/PropertyHolder.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/PropertyHolder.java
@@ -26,6 +26,14 @@ public interface PropertyHolder {
 
     boolean has(String key);
 
+    default <T> Result<T> update(final T object, final String key) {
+        return this.update(object, key, (Class<T>) null);
+    }
+
+    <T> Result<T> update(T object, String key, Class<T> type);
+
+    <T> Result<T> update(T object, String key, GenericType<T> type);
+
     <T> Result<T> get(String key, Class<T> type);
 
     <T> Result<T> get(String key, GenericType<T> type);

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/StandardPropertyHolder.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/StandardPropertyHolder.java
@@ -22,17 +22,12 @@ import org.dockbox.hartshorn.data.FileFormats;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
 import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.GenericType;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import org.dockbox.hartshorn.util.StringUtilities;
 
 import javax.inject.Inject;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.*;
 
 @Component(singleton = true)
 public class StandardPropertyHolder implements PropertyHolder {
@@ -155,6 +150,9 @@ public class StandardPropertyHolder implements PropertyHolder {
     }
 
     protected Object find(final String key) {
+        if (StringUtilities.empty(key)) {
+            return this.properties;
+        }
         final String[] split = key.split("\\.");
         if (split.length == 1) {
             return this.properties.get(key);

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/StandardPropertyHolder.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/StandardPropertyHolder.java
@@ -16,30 +16,39 @@
 
 package org.dockbox.hartshorn.data.config;
 
-import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.application.ApplicationPropertyHolder;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.data.FileFormats;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
-import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.GenericType;
+import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.StringUtilities;
+import org.dockbox.hartshorn.util.function.CheckedFunction;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.inject.Inject;
 
 @Component(singleton = true)
 public class StandardPropertyHolder implements PropertyHolder {
 
     protected final transient Map<String, Object> properties;
 
-    @Inject
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
     private final ObjectMapper propertyMapper;
 
     @Inject
-    public StandardPropertyHolder(final ApplicationContext applicationContext, final ObjectMapper propertyMapper) {
+    public StandardPropertyHolder(final ApplicationPropertyHolder applicationContext,
+                                  final ObjectMapper objectMapper,
+                                  final ObjectMapper propertyMapper) {
+        this.objectMapper = objectMapper.fileType(FileFormats.JSON);
         this.propertyMapper = propertyMapper.fileType(FileFormats.PROPERTIES);
         this.properties = this.createConfigurationMap();
         applicationContext.properties()
@@ -52,7 +61,11 @@ public class StandardPropertyHolder implements PropertyHolder {
     }
 
     @Override
-    public <T> Result<T> get(final String key, final Class<T> type) {
+    public <T> Result<T> update(final T object, final String key, final Class<T> type) {
+        return this.restore(key, type, serialized -> this.objectMapper.update(object, serialized, type));
+    }
+
+    private <T> Result<T> restore(final String key, final Class<T> type, final CheckedFunction<String, Result<T>> mapper) {
         final Object value = this.find(key);
 
         if (type != null) {
@@ -62,18 +75,30 @@ public class StandardPropertyHolder implements PropertyHolder {
 
             return Result.of(value)
                     .flatMap(object -> this.objectMapper.write(object))
-                    .flatMap(serialized -> this.objectMapper.read(serialized, type));
+                    .flatMap(mapper);
         }
         else {
             return Result.of(value).map(o -> (T) o).map(this::copyOf);
         }
     }
 
+    @Override
+    public <T> Result<T> update(final T object, final String key, final GenericType<T> type) {
+        return Result.of(this.find(key))
+                .flatMap(value -> this.objectMapper.write(value))
+                .flatMap(serialized -> this.objectMapper.read(serialized, type));
+    }
+
+    @Override
+    public <T> Result<T> get(final String key, final Class<T> type) {
+        return this.restore(key, type, serialized -> this.objectMapper.read(serialized, type));
+    }
+
     private <T> T copyOf(final T value) {
-        if (value instanceof Collection collection) {
+        if (value instanceof Collection<?> collection) {
             return (T) new ArrayList<>(collection);
         }
-        else if (value instanceof Map map) {
+        else if (value instanceof Map<?, ?> map) {
             return (T) new LinkedHashMap<>(map);
         }
         else {
@@ -109,7 +134,7 @@ public class StandardPropertyHolder implements PropertyHolder {
             if (i == split.length - 1) {
                 final Object origin = current.get(part);
                 if (origin instanceof Map map && patch instanceof Map) {
-                    this.patchConfigurationMap(map, (Map) patch);
+                    this.patchConfigurationMap(map, (Map<String, Object>) patch);
                     return;
                 }
                 current.put(part, patch); // Overwrite
@@ -137,13 +162,13 @@ public class StandardPropertyHolder implements PropertyHolder {
                 if (originValue instanceof Map && patchValue instanceof Map)
                     this.patchConfigurationMap((Map<String, Object>) originValue, (Map<String, Object>) patchValue);
                 else if (originValue instanceof Collection<?> && patchValue instanceof Collection<?>)
-                    origin.put(key, this.merge((List) originValue, (List) patchValue));
+                    origin.put(key, this.merge((List<Object>) originValue, (List<Object>) patchValue));
                 else origin.put(key, patchValue);
             } else origin.put(key, patchValue);
         }
     }
 
-    protected Collection<?> merge(final Collection first, final Collection second) {
+    protected <T> Collection<T> merge(final Collection<T> first, final Collection<T> second) {
         second.removeAll(first);
         first.addAll(second);
         return first;

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
@@ -110,6 +110,24 @@ public class JacksonObjectMapper extends DefaultObjectMapper {
     }
 
     @Override
+    public <T> Result<T> update(final T object, final String content, final Class<T> type) {
+        this.context.log().debug("Updating object " + object + " with content from string value to type " + type.getName());
+        return Result.of(() -> this.configureMapper().readerForUpdating(object).readValue(content, type));
+    }
+
+    @Override
+    public <T> Result<T> update(final T object, final Path path, final Class<T> type) {
+        this.context.log().debug("Updating object " + object + " with content from path " + path + " to type " + type.getName());
+        return Result.of(() -> this.configureMapper().readerForUpdating(object).readValue(path.toFile(), type));
+    }
+
+    @Override
+    public <T> Result<T> update(final T object, final URL url, final Class<T> type) {
+        this.context.log().debug("Updating object " + object + " with content from url " + url + " to type " + type.getName());
+        return Result.of(() -> this.configureMapper().readerForUpdating(object).readValue(url, type));
+    }
+
+    @Override
     public <T> Result<Boolean> write(final Path path, final T content) {
         this.context.log().debug("Writing content of type " + TypeContext.of(content).name() + " to path " + path);
         if (content instanceof String string) return this.writePlain(path, string);

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/mapping/ObjectMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/mapping/ObjectMapper.java
@@ -65,6 +65,16 @@ public interface ObjectMapper {
         return Result.of(() -> this.read(uri.toURL(), type).orNull());
     }
 
+    <T> Result<T> update(T object, String content, Class<T> type);
+
+    <T> Result<T> update(T object, Path path, Class<T> type);
+
+    <T> Result<T> update(T object, URL url, Class<T> type);
+
+    default <T> Result<T> update(final T object, final URI uri, final Class<T> type) {
+        return Result.of(() -> this.update(object, uri.toURL(), type).orNull());
+    }
+
     Map<String, Object> flat(String content);
 
     Map<String, Object> flat(Path path);

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/ConfigurationObjectPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/ConfigurationObjectPostProcessor.java
@@ -2,32 +2,28 @@ package org.dockbox.hartshorn.data.service;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
-import org.dockbox.hartshorn.component.processing.*;
+import org.dockbox.hartshorn.component.processing.ComponentPostProcessor;
+import org.dockbox.hartshorn.component.processing.ComponentProcessingContext;
+import org.dockbox.hartshorn.component.processing.ProcessingOrder;
 import org.dockbox.hartshorn.data.annotations.ConfigurationObject;
 import org.dockbox.hartshorn.data.annotations.UseConfigurations;
 import org.dockbox.hartshorn.data.config.PropertyHolder;
 import org.dockbox.hartshorn.inject.Key;
-import org.dockbox.hartshorn.util.Exceptional;
+import org.dockbox.hartshorn.util.Result;
 
-@AutomaticActivation
 public class ConfigurationObjectPostProcessor implements ComponentPostProcessor<UseConfigurations> {
 
     @Override
-    public Class<UseConfigurations> activator() {
-        return UseConfigurations.class;
-    }
-
-    @Override
-    public <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance, ComponentProcessingContext<T> processingContext) {
+    public <T> boolean modifies(final ApplicationContext context, final Key<T> key, @Nullable final T instance, final ComponentProcessingContext<T> processingContext) {
         return key.type().annotation(ConfigurationObject.class).present();
     }
 
     @Override
-    public <T> T process(ApplicationContext context, Key<T> key, @Nullable T instance) {
-        ConfigurationObject configurationObject = key.type().annotation(ConfigurationObject.class).get();
-        PropertyHolder propertyHolder = context.get(PropertyHolder.class);
+    public <T> T process(final ApplicationContext context, final Key<T> key, @Nullable final T instance) {
+        final ConfigurationObject configurationObject = key.type().annotation(ConfigurationObject.class).get();
+        final PropertyHolder propertyHolder = context.get(PropertyHolder.class);
 
-        Exceptional<T> configuration = propertyHolder.get(configurationObject.prefix(), key.type().type());
+        final Result<T> configuration = propertyHolder.get(configurationObject.prefix(), key.type().type());
         return configuration.or(instance);
     }
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/ConfigurationObjectPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/ConfigurationObjectPostProcessor.java
@@ -1,0 +1,38 @@
+package org.dockbox.hartshorn.data.service;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.dockbox.hartshorn.application.context.ApplicationContext;
+import org.dockbox.hartshorn.component.processing.*;
+import org.dockbox.hartshorn.data.annotations.ConfigurationObject;
+import org.dockbox.hartshorn.data.annotations.UseConfigurations;
+import org.dockbox.hartshorn.data.config.PropertyHolder;
+import org.dockbox.hartshorn.inject.Key;
+import org.dockbox.hartshorn.util.Exceptional;
+
+@AutomaticActivation
+public class ConfigurationObjectPostProcessor implements ComponentPostProcessor<UseConfigurations> {
+
+    @Override
+    public Class<UseConfigurations> activator() {
+        return UseConfigurations.class;
+    }
+
+    @Override
+    public <T> boolean modifies(ApplicationContext context, Key<T> key, @Nullable T instance, ComponentProcessingContext<T> processingContext) {
+        return key.type().annotation(ConfigurationObject.class).present();
+    }
+
+    @Override
+    public <T> T process(ApplicationContext context, Key<T> key, @Nullable T instance) {
+        ConfigurationObject configurationObject = key.type().annotation(ConfigurationObject.class).get();
+        PropertyHolder propertyHolder = context.get(PropertyHolder.class);
+
+        Exceptional<T> configuration = propertyHolder.get(configurationObject.prefix(), key.type().type());
+        return configuration.or(instance);
+    }
+
+    @Override
+    public Integer order() {
+        return ProcessingOrder.EARLY;
+    }
+}

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/ConfigurationObjectPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/ConfigurationObjectPostProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.data.service;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -23,12 +39,18 @@ public class ConfigurationObjectPostProcessor implements ComponentPostProcessor<
         final ConfigurationObject configurationObject = key.type().annotation(ConfigurationObject.class).get();
         final PropertyHolder propertyHolder = context.get(PropertyHolder.class);
 
-        final Result<T> configuration = propertyHolder.get(configurationObject.prefix(), key.type().type());
+        final Result<T> configuration;
+        if (instance == null) {
+            configuration = propertyHolder.get(configurationObject.prefix(), key.type().type());
+        }
+        else {
+            configuration = propertyHolder.update(instance, configurationObject.prefix(), key.type().type());
+        }
         return configuration.or(instance);
     }
 
     @Override
     public Integer order() {
-        return ProcessingOrder.EARLY;
+        return ProcessingOrder.FIRST;
     }
 }

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/ConfigurationManagerTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/ConfigurationManagerTests.java
@@ -25,9 +25,10 @@ import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
 import java.nio.file.Path;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.inject.Inject;
 
 @HartshornTest
 @UseConfigurations
@@ -131,11 +132,11 @@ public class ConfigurationManagerTests {
 
     @Test
     void testConfigurationObjects() {
-        PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
+        final PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
         propertyHolder.set("user.name", "Hartshorn");
         propertyHolder.set("user.age", 21);
 
-        SampleConfigurationObject configurationObject = this.applicationContext.get(SampleConfigurationObject.class);
+        final SampleConfigurationObject configurationObject = this.applicationContext.get(SampleConfigurationObject.class);
         Assertions.assertNotNull(configurationObject);
         Assertions.assertEquals("Hartshorn", configurationObject.name());
         Assertions.assertEquals(21, configurationObject.age());
@@ -143,11 +144,11 @@ public class ConfigurationManagerTests {
 
     @Test
     void testSetterConfigurationObjects() {
-        PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
+        final PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
         propertyHolder.set("user.name", "Hartshorn");
         propertyHolder.set("user.age", 21);
 
-        SampleSetterConfigurationObject configurationObject = this.applicationContext.get(SampleSetterConfigurationObject.class);
+        final SampleSetterConfigurationObject configurationObject = this.applicationContext.get(SampleSetterConfigurationObject.class);
         Assertions.assertNotNull(configurationObject);
         Assertions.assertEquals("Hartshorn!", configurationObject.name(), "Bean-style setter (public)");
         Assertions.assertEquals(31, configurationObject.age(), "Fluent-style setter (private)");

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/ConfigurationManagerTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/ConfigurationManagerTests.java
@@ -16,19 +16,18 @@
 
 package org.dockbox.hartshorn.data;
 
-import org.dockbox.hartshorn.data.config.PropertyHolder;
-import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.data.annotations.UseConfigurations;
+import org.dockbox.hartshorn.data.config.PropertyHolder;
 import org.dockbox.hartshorn.data.mapping.ObjectMapper;
+import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import java.nio.file.Path;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.inject.Inject;
 
 @HartshornTest
 @UseConfigurations
@@ -128,5 +127,29 @@ public class ConfigurationManagerTests {
         Assertions.assertNotNull(typed);
         Assertions.assertNotNull(typed.nestedString());
         Assertions.assertEquals("Hartshorn", typed.nestedString());
+    }
+
+    @Test
+    void testConfigurationObjects() {
+        PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
+        propertyHolder.set("user.name", "Hartshorn");
+        propertyHolder.set("user.age", 21);
+
+        SampleConfigurationObject configurationObject = this.applicationContext.get(SampleConfigurationObject.class);
+        Assertions.assertNotNull(configurationObject);
+        Assertions.assertEquals("Hartshorn", configurationObject.name());
+        Assertions.assertEquals(21, configurationObject.age());
+    }
+
+    @Test
+    void testSetterConfigurationObjects() {
+        PropertyHolder propertyHolder = this.applicationContext.get(PropertyHolder.class);
+        propertyHolder.set("user.name", "Hartshorn");
+        propertyHolder.set("user.age", 21);
+
+        SampleSetterConfigurationObject configurationObject = this.applicationContext.get(SampleSetterConfigurationObject.class);
+        Assertions.assertNotNull(configurationObject);
+        Assertions.assertEquals("Hartshorn!", configurationObject.name(), "Bean-style setter (public)");
+        Assertions.assertEquals(31, configurationObject.age(), "Fluent-style setter (private)");
     }
 }

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleConfigurationObject.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleConfigurationObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.data;
 
 import org.dockbox.hartshorn.data.annotations.ConfigurationObject;

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleConfigurationObject.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleConfigurationObject.java
@@ -1,0 +1,18 @@
+package org.dockbox.hartshorn.data;
+
+import org.dockbox.hartshorn.data.annotations.ConfigurationObject;
+
+@ConfigurationObject(prefix = "user")
+public class SampleConfigurationObject {
+
+    private String name;
+    private int age;
+
+    public String name() {
+        return name;
+    }
+
+    public int age() {
+        return age;
+    }
+}

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleSetterConfigurationObject.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleSetterConfigurationObject.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dockbox.hartshorn.data;
 
 import org.dockbox.hartshorn.data.annotations.ConfigurationObject;

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleSetterConfigurationObject.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SampleSetterConfigurationObject.java
@@ -1,0 +1,29 @@
+package org.dockbox.hartshorn.data;
+
+import org.dockbox.hartshorn.data.annotations.ConfigurationObject;
+
+@ConfigurationObject(prefix = "user")
+public class SampleSetterConfigurationObject {
+
+    private String name;
+    private int age;
+
+    public String name() {
+        return name;
+    }
+
+    // Classic bean-style setter
+    public void setName(String name) {
+        this.name = name + "!";
+    }
+
+    public int age() {
+        return age;
+    }
+
+    // Fluent-style setter, private
+    private SampleSetterConfigurationObject setAge(int age) {
+        this.age = age + 10;
+        return this;
+    }
+}


### PR DESCRIPTION
# Description
Currently `@Value` is the only way to easily inject configuration values. While this previously made sense as this would only support basic types (`String`s, `Collection`s, and primitives), #731 introduced support for complex configuration types.

This PR adds a new explicit configuration stereotype for `@Component`, to allow the instance to be created based on configuration values through the `PropertyHolder`. If the instance already exists when the component processor is entered, the existing instance will be updated, instead of being replaced with a new instance (even if the processing phase technically permits it).

Fixes #733

## Type of change
- [x] New feature (non-breaking change that does affect the code)

# How Has This Been Tested?
- [x] Unit testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
