### PR TITLE
#745 Migrate to Jakarta EE namespace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,11 +123,11 @@ allprojects {
 
         dependencies {
             implementation "org.slf4j:slf4j-api:$slf4jVersion"
-            implementation "javax.persistence:javax.persistence-api:$javaxPersistenceVersion"
+            implementation "jakarta.persistence:jakarta.persistence-api:$jakartaPersistenceVersion"
 
             testImplementation project(":hartshorn-test-suite")
             testImplementation "org.mockito:mockito-inline:$mockitoVersion"
-            testImplementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
+            testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
             testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
             testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
             testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,35 +21,35 @@ projectName=Hartshorn
 projectVersion=22.2
 
 # Core API versions
-slf4jVersion=1.7.32
-logbackVersion=1.2.10
+slf4jVersion=1.7.36
+logbackVersion=1.2.11
 reflectionsVersion=0.10.2
-jakartaInjectVersion=1.0.5
+jakartaInjectVersion=2.0.1
 
 # Testing API versions
 junitVersion=5.8.2
-mockitoVersion=4.2.0
-testContainersVersion=1.16.2
-hamcrestVersion=2.0.0.0
+mockitoVersion=4.5.1
+testContainersVersion=1.17.2
+hamcrestVersion=2.2
 
 # Data API versions
-hibernateVersion=5.6.3.Final
-javaxPersistenceVersion=2.2
-mySqlConnectorVersion=8.0.27
-postgreSqlVersion=42.3.1
-mariaDbClientVersion=2.7.4
-jacksonVersion=2.13.1
+hibernateVersion=6.0.2.Final
+jakartaPersistenceVersion=3.1.0
+mySqlConnectorVersion=8.0.29
+postgreSqlVersion=42.3.6
+mariaDbClientVersion=3.0.5
+jacksonVersion=2.13.3
 woodstoxVersion=4.4.1
 derbyVersion=10.14.2.0
-mssqlDriverVersion=9.4.1.jre11
+mssqlDriverVersion=10.2.1.jre17
 
 # Web API versions
 freeMarkerVersion=2.3.31
 httpClientVersion=4.5.13
-javaxServletVersion=4.0.1
-jettyVersion=9.4.44.v20210927
+jakartaServletVersion=5.0.0
+jettyVersion=11.0.9
 
 # Gradle plugin versions
 licenserVersion=0.6.1
-owaspDependencyCheckVersion=6.5.1
+owaspDependencyCheckVersion=7.1.0.1
 checkerFrameworkVersion=0.6.5

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheImpl.java
@@ -25,7 +25,7 @@ import java.util.Locale;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Default implementation of {@link Cache}.

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheManagerImpl.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheManagerImpl.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Default implementation of {@link CacheManager}.

--- a/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheProviders.java
+++ b/hartshorn-cache/src/main/java/org/dockbox/hartshorn/cache/CacheProviders.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.cache.annotations.UseCaching;
 import org.dockbox.hartshorn.component.processing.Provider;
 import org.dockbox.hartshorn.component.Service;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Service(activators = UseCaching.class)
 public class CacheProviders {

--- a/hartshorn-cache/src/test/java/org/dockbox/hartshorn/cache/CacheTests.java
+++ b/hartshorn-cache/src/test/java/org/dockbox/hartshorn/cache/CacheTests.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @UseCaching
 @HartshornTest

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandGatewayImpl.java
@@ -40,7 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Simple implementation of {@link CommandGateway}.

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListenerImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandListenerImpl.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.util.Scanner;
 import java.util.concurrent.Executors;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class CommandListenerImpl implements CommandListener {
 

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandParserImpl.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Simple implementation of {@link CommandParser}.

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/CommandProviders.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.component.processing.Provider;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Service(activators = UseCommands.class)
 public class CommandProviders {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/SystemSubject.java
@@ -23,8 +23,8 @@ import org.dockbox.hartshorn.util.Identifiable;
 import java.util.Locale;
 import java.util.UUID;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 @Singleton
 public abstract class SystemSubject implements CommandSource, Identifiable {

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/HashtagParameterPattern.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/arguments/HashtagParameterPattern.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.commands.arguments;
 import org.dockbox.hartshorn.commands.CommandParameterResources;
 import org.dockbox.hartshorn.i18n.Message;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Converts Hashtag-patterns into type instances used by command executors. The pattern follows the HashtagPatternParser from WorldEdit.

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/ArgumentConverterContext.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/context/ArgumentConverterContext.java
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.util.Result;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * The utility class which keeps track of all registered {@link ArgumentConverter argument converters}.

--- a/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/extension/CooldownExtension.java
+++ b/hartshorn-commands/src/main/java/org/dockbox/hartshorn/commands/extension/CooldownExtension.java
@@ -29,7 +29,7 @@ import java.time.temporal.TemporalUnit;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Extends a command by providing a cooldown on its execution. If a command is

--- a/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
+++ b/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/CommandDefinitionContextTests.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @UseCommands
 @HartshornTest

--- a/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/HashtagParameterPatternTests.java
+++ b/hartshorn-commands/src/test/java/org/dockbox/hartshorn/commands/HashtagParameterPatternTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Locale;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @UseCommands
 @HartshornTest

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ClasspathApplicationContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/application/context/ClasspathApplicationContext.java
@@ -40,7 +40,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 public class ClasspathApplicationContext extends DelegatingApplicationContext implements
         ProcessableApplicationContext, ObservingApplicationContext {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ComponentProvider.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.inject.Key;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 /**
  * A component provider is a class that is capable of providing components. Components are identified using

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextualComponentPopulator.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/ContextualComponentPopulator.java
@@ -33,8 +33,8 @@ import org.dockbox.hartshorn.util.reflect.FieldContext;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 public class ContextualComponentPopulator implements ComponentPopulator, ContextCarrier {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchicalApplicationComponentProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/HierarchicalApplicationComponentProvider.java
@@ -50,7 +50,7 @@ import org.dockbox.hartshorn.util.reflect.TypeContext;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class HierarchicalApplicationComponentProvider extends DefaultContext implements StandardComponentProvider, ContextCarrier {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/Provider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/component/processing/Provider.java
@@ -34,9 +34,9 @@ import java.lang.annotation.Target;
  * class.
  *
  * <p>Provider methods can have parameters, which will be injected through the active
- * {@link ApplicationContext}. This includes support for {@link javax.inject.Named} parameters.
+ * {@link ApplicationContext}. This includes support for {@link jakarta.inject.Named} parameters.
  *
- * <p>If {@link javax.inject.Singleton} is used on the provider method, the result of the provider
+ * <p>If {@link jakarta.inject.Singleton} is used on the provider method, the result of the provider
  * method will be cached immediately, and the same instance will be returned on subsequent calls.
  *
  * @author Guus Lieben

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ConcreteContextCarrier.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/context/ConcreteContextCarrier.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.context;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * A concrete implementation of {@link ContextCarrier}.

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DefaultProviders.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/DefaultProviders.java
@@ -23,7 +23,7 @@ import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.context.ConcreteContextCarrier;
 import org.dockbox.hartshorn.context.ContextCarrier;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Service(activators = { UseBootstrap.class, UseServiceProvision.class })
 public class DefaultProviders {

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/InjectorMetaProvider.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/InjectorMetaProvider.java
@@ -25,8 +25,8 @@ import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.component.ComponentContainer;
 import org.dockbox.hartshorn.component.ComponentUtilities;
 
-import javax.inject.Singleton;
-import javax.persistence.Entity;
+import jakarta.inject.Singleton;
+import jakarta.persistence.Entity;
 
 public class InjectorMetaProvider implements MetaProvider {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Key.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/Key.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.util.StringUtilities;
 
 import java.util.Objects;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 public class Key<C> {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NamedImpl.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/NamedImpl.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.inject;
 
 import java.lang.annotation.Annotation;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 /**
  * An implementation of the {@link Named} annotation. This is used by {@link Key}s to allow for {@link String}

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/BindingHierarchy.java
@@ -106,7 +106,7 @@ public interface BindingHierarchy<C> extends Iterable<Entry<Integer, Provider<C>
 
     /**
      * Gets the {@link Key} of the current hierarchy, containing a {@link TypeContext}
-     * of type {@code C}, and a potential {@link javax.inject.Named} instance.
+     * of type {@code C}, and a potential {@link jakarta.inject.Named} instance.
      *
      * @return The key of the current hierarchy.
      * @see Key

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentBinding.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/ComponentBinding.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 /**
  * Indicates the annotated type is to be bound to the specified type. This creates a basic entry

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/NativeBindingHierarchy.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/binding/NativeBindingHierarchy.java
@@ -31,7 +31,7 @@ import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 /**
  * The default implementation of the {@link BindingHierarchy} interface. This uses a specified {@link Key} to

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderServicePreProcessor.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/inject/processing/ProviderServicePreProcessor.java
@@ -32,7 +32,7 @@ import org.dockbox.hartshorn.util.reflect.TypedElementContext;
 import java.util.List;
 import java.util.function.Function;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 public final class ProviderServicePreProcessor implements ServicePreProcessor {
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/logging/logback/LogbackApplicationLogger.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/logging/logback/LogbackApplicationLogger.java
@@ -44,8 +44,10 @@ public class LogbackApplicationLogger extends CallerLookupApplicationLogger {
             }
         }
         else {
-            final Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-            rootLogger.setLevel(level);
+            final org.slf4j.Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+            if (logger instanceof Logger) {
+                ((Logger) logger).setLevel(level);
+            }
         }
     }
 }

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/TypeContext.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/TypeContext.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import javassist.util.proxy.ProxyFactory;
 

--- a/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/parameter/ExecutableElementContextParameterLoader.java
+++ b/hartshorn-core/src/main/java/org/dockbox/hartshorn/util/reflect/parameter/ExecutableElementContextParameterLoader.java
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.util.reflect.ParameterContext;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.util.parameter.RuleBasedParameterLoader;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 public class ExecutableElementContextParameterLoader extends RuleBasedParameterLoader<ParameterLoaderContext> {
 

--- a/hartshorn-core/src/test/java/com/example/application/DemoProcessor.java
+++ b/hartshorn-core/src/test/java/com/example/application/DemoProcessor.java
@@ -20,8 +20,8 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ComponentPreProcessor;
 import org.dockbox.hartshorn.inject.Key;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class DemoProcessor implements ComponentPreProcessor {

--- a/hartshorn-core/src/test/java/com/specific/sub/DemoServicePreProcessor.java
+++ b/hartshorn-core/src/test/java/com/specific/sub/DemoServicePreProcessor.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.processing.ServicePreProcessor;
 import org.dockbox.hartshorn.inject.Key;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class DemoServicePreProcessor implements ServicePreProcessor {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ApplicationContextTests.java
@@ -57,7 +57,7 @@ import org.slf4j.Logger;
 
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import test.types.FieldProviderService;
 import test.types.PopulatedType;

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/BindingHierarchyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/BindingHierarchyTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map.Entry;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 public class BindingHierarchyTests {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ContextAwareTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ContextAwareTests.java
@@ -24,7 +24,7 @@ import org.dockbox.hartshorn.testsuite.TestComponents;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import test.types.SampleContextAwareType;
 

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ContextTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/ContextTests.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 public class ContextTests {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/ComponentProvisionTests.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UseServiceProvision

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/MetaProviderTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/boot/MetaProviderTests.java
@@ -26,7 +26,7 @@ import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 public class MetaProviderTests {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/exceptions/ExceptTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/exceptions/ExceptTests.java
@@ -24,7 +24,7 @@ import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 public class ExceptTests {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/proxy/ProxyTests.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @UseServiceProvision
 @UseProxying

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularConstructorA.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularConstructorA.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.core.types;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class CircularConstructorA {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularConstructorB.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularConstructorB.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.core.types;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class CircularConstructorB {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularDependencyA.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularDependencyA.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.core.types;
 
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component(singleton = true)
 public class CircularDependencyA {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularDependencyB.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/CircularDependencyB.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.core.types;
 
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component(singleton = true)
 public class CircularDependencyB {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponent.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponent.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.inject.Context;
 import org.dockbox.hartshorn.inject.Required;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class SetterInjectedComponent {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithAbsentBinding.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithAbsentBinding.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.core.types;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.inject.Required;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class SetterInjectedComponentWithAbsentBinding {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithNonRequiredAbsentBinding.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SetterInjectedComponentWithNonRequiredAbsentBinding.java
@@ -16,7 +16,7 @@
 
 package org.dockbox.hartshorn.core.types;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class SetterInjectedComponentWithNonRequiredAbsentBinding {
 

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SimpleComponent.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SimpleComponent.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.core.types;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class SimpleComponent {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/SingletonEnableable.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.core.types;
 
 import org.dockbox.hartshorn.component.Enableable;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class SingletonEnableable implements Enableable {

--- a/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithEnabledInjectField.java
+++ b/hartshorn-core/src/test/java/org/dockbox/hartshorn/core/types/TypeWithEnabledInjectField.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.core.types;
 import org.dockbox.hartshorn.inject.Enable;
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class TypeWithEnabledInjectField {

--- a/hartshorn-core/src/test/java/test/types/FieldProviderService.java
+++ b/hartshorn-core/src/test/java/test/types/FieldProviderService.java
@@ -19,7 +19,7 @@ package test.types;
 import org.dockbox.hartshorn.component.processing.Provider;
 import org.dockbox.hartshorn.component.Service;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Service
 public class FieldProviderService {

--- a/hartshorn-core/src/test/java/test/types/PopulatedType.java
+++ b/hartshorn-core/src/test/java/test/types/PopulatedType.java
@@ -18,7 +18,7 @@ package test.types;
 
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class PopulatedType {

--- a/hartshorn-core/src/test/java/test/types/SampleBoundPopulatedType.java
+++ b/hartshorn-core/src/test/java/test/types/SampleBoundPopulatedType.java
@@ -18,7 +18,7 @@ package test.types;
 
 import org.dockbox.hartshorn.inject.binding.Bound;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class SampleBoundPopulatedType implements SampleInterface {
 

--- a/hartshorn-core/src/test/java/test/types/SampleContextAwareType.java
+++ b/hartshorn-core/src/test/java/test/types/SampleContextAwareType.java
@@ -19,7 +19,7 @@ package test.types;
 import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class SampleContextAwareType {

--- a/hartshorn-core/src/test/java/test/types/SampleMetaAnnotatedImplementation.java
+++ b/hartshorn-core/src/test/java/test/types/SampleMetaAnnotatedImplementation.java
@@ -19,7 +19,7 @@ package test.types;
 import org.dockbox.hartshorn.inject.binding.ComponentBinding;
 import test.types.SampleInterface;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 @ComponentBinding(value = SampleInterface.class, named = @Named("meta"))
 public class SampleMetaAnnotatedImplementation implements SampleInterface {

--- a/hartshorn-core/src/test/java/test/types/SampleProviderService.java
+++ b/hartshorn-core/src/test/java/test/types/SampleProviderService.java
@@ -19,8 +19,8 @@ package test.types;
 import org.dockbox.hartshorn.component.processing.Provider;
 import org.dockbox.hartshorn.component.Service;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 @Service
 public class SampleProviderService {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ContextPropertyValueLookup.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/ContextPropertyValueLookup.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.data.config.PropertyHolder;
 import org.dockbox.hartshorn.util.Result;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class ContextPropertyValueLookup implements ValueLookup {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/TransactionFactory.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/TransactionFactory.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.component.factory.Factory;
 import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.data.annotations.UsePersistence;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
 @Service(activators = UsePersistence.class)
 public interface TransactionFactory {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/StandardPropertyHolder.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/config/StandardPropertyHolder.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component(singleton = true)
 public class StandardPropertyHolder implements PropertyHolder {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/context/JpaParameterLoaderContext.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/context/JpaParameterLoaderContext.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.application.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 
-import javax.persistence.Query;
+import jakarta.persistence.Query;
 
 public class JpaParameterLoaderContext extends ParameterLoaderContext {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/context/QueryContext.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/context/QueryContext.java
@@ -24,7 +24,7 @@ import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.data.annotations.Query;
 import org.dockbox.hartshorn.data.jpa.JpaRepository;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
 public class QueryContext {
 
@@ -72,14 +72,14 @@ public class QueryContext {
         return this.annotation.automaticFlush();
     }
 
-    public javax.persistence.Query query(final EntityManager entityManager) {
-        final javax.persistence.Query persistenceQuery = this.persistenceQuery(entityManager, this.annotation);
+    public jakarta.persistence.Query query(final EntityManager entityManager) {
+        final jakarta.persistence.Query persistenceQuery = this.persistenceQuery(entityManager, this.annotation);
         final JpaParameterLoaderContext loaderContext = new JpaParameterLoaderContext(this.method, this.entityType, null, this.applicationContext, persistenceQuery);
         this.parameterLoader().loadArguments(loaderContext, this.args);
         return persistenceQuery;
     }
 
-    protected javax.persistence.Query persistenceQuery(final EntityManager entityManager, final Query query) throws IllegalArgumentException {
+    protected jakarta.persistence.Query persistenceQuery(final EntityManager entityManager, final Query query) throws IllegalArgumentException {
         return switch (query.type()) {
             case JPQL -> {
                 if (this.modifiesEntity || this.entityType.isVoid()) yield entityManager.createQuery(query.value());

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateJpaRepository.java
@@ -53,11 +53,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import javax.inject.Inject;
-import javax.persistence.Entity;
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
+import jakarta.inject.Inject;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
 
 public class HibernateJpaRepository<T, ID> implements JpaRepository<T, ID>, Enableable, Closeable {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateQueryFunction.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateQueryFunction.java
@@ -22,7 +22,7 @@ import org.hibernate.Session;
 
 import java.util.function.Function;
 
-import javax.persistence.Query;
+import jakarta.persistence.Query;
 
 public class HibernateQueryFunction implements QueryFunction {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateRemoteImpl.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.hibernate.dialect.Dialect;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 public class HibernateRemoteImpl implements HibernateRemote {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateTransactionManager.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/hibernate/HibernateTransactionManager.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.inject.binding.Bound;
 import org.dockbox.hartshorn.data.TransactionManager;
 import org.hibernate.Session;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
 public class HibernateTransactionManager implements TransactionManager {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jackson/JacksonObjectMapper.java
@@ -53,7 +53,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class JacksonObjectMapper extends DefaultObjectMapper {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jpa/JpaPaginationParameterRule.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jpa/JpaPaginationParameterRule.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.util.Result;
 import org.dockbox.hartshorn.util.parameter.ParameterLoaderRule;
 import org.dockbox.hartshorn.data.context.JpaParameterLoaderContext;
 
-import javax.persistence.Query;
+import jakarta.persistence.Query;
 
 public class JpaPaginationParameterRule implements ParameterLoaderRule<JpaParameterLoaderContext> {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jpa/JpaRepository.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/jpa/JpaRepository.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.data.remote.PersistenceConnection;
 
 import java.util.Set;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
 public interface JpaRepository<T, ID> extends ContextCarrier {
 

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/remote/SqlServerRemote.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/remote/SqlServerRemote.java
@@ -29,6 +29,11 @@ public final class SqlServerRemote extends JdbcRemote {
     }
 
     @Override
+    protected String connectionString(final JdbcRemoteConfiguration server) {
+        return super.connectionString(server) + ";encrypt=true;trustServerCertificate=true;";
+    }
+
+    @Override
     protected String type() {
         return "sqlserver";
     }

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/PersistentTypeService.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/PersistentTypeService.java
@@ -25,7 +25,7 @@ import org.dockbox.hartshorn.data.context.EntityContext;
 
 import java.util.Collection;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
 
 @Service(activators = UsePersistence.class)
 public class PersistentTypeService implements LifecycleObserver {

--- a/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/TransactionalProxyCallbackPostProcessor.java
+++ b/hartshorn-data/src/main/java/org/dockbox/hartshorn/data/service/TransactionalProxyCallbackPostProcessor.java
@@ -30,7 +30,7 @@ import org.dockbox.hartshorn.proxy.ProxyCallback;
 import org.dockbox.hartshorn.proxy.processing.PhasedProxyCallbackPostProcessor;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
 public class TransactionalProxyCallbackPostProcessor extends PhasedProxyCallbackPostProcessor<UsePersistence> {
 

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/Address.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/Address.java
@@ -16,8 +16,8 @@
 
 package org.dockbox.hartshorn.data;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 @Entity
 public class Address {

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/ConfigurationManagerTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/ConfigurationManagerTests.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UseConfigurations

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DataStructuresSerializersTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/DataStructuresSerializersTests.java
@@ -31,7 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UsePersistence

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/QueryRepositoryTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/QueryRepositoryTests.java
@@ -33,8 +33,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.List;
 import java.util.Set;
 
-import javax.inject.Inject;
-import javax.persistence.TransactionRequiredException;
+import jakarta.inject.Inject;
+import jakarta.persistence.TransactionRequiredException;
 
 @Testcontainers(disabledWithoutDocker = true)
 @UsePersistence

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/SqlServiceTest.java
@@ -59,8 +59,8 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 
 @HartshornTest
 @Testcontainers(disabledWithoutDocker = true)

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/User.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/User.java
@@ -16,10 +16,10 @@
 
 package org.dockbox.hartshorn.data;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Transient;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
 
 @Entity(name = "users")
 public class User {

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/ObjectMappingTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/ObjectMappingTests.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UsePersistence

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/PersistenceModifiersTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/mapping/PersistenceModifiersTests.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UsePersistence

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/objects/JpaUser.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/objects/JpaUser.java
@@ -16,9 +16,9 @@
 
 package org.dockbox.hartshorn.data.objects;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 /**
  * A simple JPA compatible user type with an auto-generated {@link #id()}.

--- a/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/service/SerializationTests.java
+++ b/hartshorn-data/src/test/java/org/dockbox/hartshorn/data/service/SerializationTests.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UsePersistence

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventBusImpl.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * A simple default implementation of {@link EventBus}, used for internal event posting and

--- a/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
+++ b/hartshorn-events/src/main/java/org/dockbox/hartshorn/events/EventProviders.java
@@ -22,7 +22,7 @@ import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.events.annotations.UseEvents;
 import org.dockbox.hartshorn.events.handle.EventParameterLoader;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Service(activators = UseEvents.class)
 public class EventProviders {

--- a/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
+++ b/hartshorn-events/src/test/java/org/dockbox/hartshorn/events/EventBusTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UseEvents

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/BundledTranslationService.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/BundledTranslationService.java
@@ -20,7 +20,7 @@ import org.dockbox.hartshorn.application.context.ApplicationContext;
 import org.dockbox.hartshorn.component.Component;
 import org.dockbox.hartshorn.util.Result;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class BundledTranslationService implements TranslationService {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/DefaultTranslationBundle.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Component
 public class DefaultTranslationBundle implements TranslationBundle {

--- a/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationService.java
+++ b/hartshorn-i18n/src/main/java/org/dockbox/hartshorn/i18n/TranslationService.java
@@ -19,7 +19,7 @@ package org.dockbox.hartshorn.i18n;
 import org.dockbox.hartshorn.context.ContextCarrier;
 import org.dockbox.hartshorn.util.Result;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Singleton
 public interface TranslationService extends ContextCarrier {

--- a/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationInjectModifierTests.java
+++ b/hartshorn-i18n/src/test/java/org/dockbox/hartshorn/i18n/TranslationInjectModifierTests.java
@@ -23,7 +23,7 @@ import org.dockbox.hartshorn.testsuite.HartshornTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @HartshornTest
 @UseTranslations

--- a/hartshorn-test-suite/hartshorn-test-suite.gradle
+++ b/hartshorn-test-suite/hartshorn-test-suite.gradle
@@ -3,7 +3,7 @@ dependencies {
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation "org.mockito:mockito-inline:$mockitoVersion"
-    implementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
+    implementation "org.hamcrest:hamcrest:$hamcrestVersion"
     implementation "ch.qos.logback:logback-classic:$logbackVersion"
     implementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     implementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornLifecycleExtension.java
@@ -55,7 +55,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @Activator
 public class HartshornLifecycleExtension implements

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/HartshornTest.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Annotation for test classes that should be run with the Hartshorn test suite. This will automatically

--- a/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/InjectTest.java
+++ b/hartshorn-test-suite/src/main/java/org/dockbox/hartshorn/testsuite/InjectTest.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Acts as a composite between {@link Inject} and {@link Test}. This allows test method parameters to be injected

--- a/hartshorn-web/hartshorn-web.gradle
+++ b/hartshorn-web/hartshorn-web.gradle
@@ -22,7 +22,7 @@ plugins {
 apply from: "$project.rootDir/gradle/publications.gradle"
 
 dependencies {
-    api "javax.servlet:javax.servlet-api:$javaxServletVersion"
+    api "jakarta.servlet:jakarta.servlet-api:$jakartaServletVersion"
 
     implementation 'org.dockbox.hartshorn:hartshorn-core'
     implementation 'org.dockbox.hartshorn:hartshorn-events'

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/DefaultHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/DefaultHttpWebServer.java
@@ -19,8 +19,8 @@ package org.dockbox.hartshorn.web;
 import org.dockbox.hartshorn.util.parameter.ParameterLoader;
 import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 public abstract class DefaultHttpWebServer implements HttpWebServer {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpAction.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpAction.java
@@ -18,8 +18,8 @@ package org.dockbox.hartshorn.web;
 
 import org.dockbox.hartshorn.util.ApplicationException;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @FunctionalInterface
 public interface HttpAction {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpMethod.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpMethod.java
@@ -18,7 +18,7 @@ package org.dockbox.hartshorn.web;
 
 import java.util.Locale;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public enum HttpMethod {
     GET,

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServer.java
@@ -23,8 +23,8 @@ import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
 import java.net.URI;
 
-import javax.inject.Singleton;
-import javax.servlet.Servlet;
+import jakarta.inject.Singleton;
+import jakarta.servlet.Servlet;
 
 @Singleton
 public interface HttpWebServer {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/HttpWebServerInitializer.java
@@ -36,8 +36,8 @@ import org.dockbox.hartshorn.web.servlet.WebServletImpl;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.inject.Inject;
-import javax.servlet.Servlet;
+import jakarta.inject.Inject;
+import jakarta.servlet.Servlet;
 
 @Service(activators = UseHttpServer.class)
 public class HttpWebServerInitializer implements LifecycleObserver {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RequestError.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RequestError.java
@@ -21,8 +21,8 @@ import org.dockbox.hartshorn.util.Result;
 
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface RequestError extends CarrierContext {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RequestErrorImpl.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/RequestErrorImpl.java
@@ -22,8 +22,8 @@ import org.dockbox.hartshorn.util.Result;
 
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class RequestErrorImpl extends DefaultCarrierContext implements RequestError {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/ServletHandler.java
@@ -32,9 +32,9 @@ import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 import java.io.IOException;
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class ServletHandler implements Enableable {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyDirectoryServlet.java
@@ -26,9 +26,9 @@ import org.eclipse.jetty.util.resource.Resource;
 import java.io.IOException;
 import java.net.URI;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class JettyDirectoryServlet implements DirectoryServlet {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyErrorHandler.java
@@ -41,10 +41,10 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class JettyErrorHandler extends ErrorHandler {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyHttpWebServer.java
@@ -39,8 +39,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
-import javax.inject.Inject;
-import javax.servlet.Servlet;
+import jakarta.inject.Inject;
+import jakarta.servlet.Servlet;
 
 @Component
 public class JettyHttpWebServer extends DefaultHttpWebServer {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyResourceService.java
@@ -29,11 +29,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Enumeration;
 
-import javax.inject.Inject;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class JettyResourceService extends ResourceService {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/jetty/JettyServer.java
@@ -27,9 +27,9 @@ import org.eclipse.jetty.server.Server;
 
 import java.io.IOException;
 
-import javax.inject.Inject;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletException;
+import jakarta.inject.Inject;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
 
 public class JettyServer extends Server {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerMVCInitializer.java
@@ -35,7 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/mvc/freemarker/FreeMarkerProviders.java
@@ -21,7 +21,7 @@ import org.dockbox.hartshorn.component.Service;
 import org.dockbox.hartshorn.web.annotations.UseMvcServer;
 import org.dockbox.hartshorn.web.mvc.MVCInitializer;
 
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 @Service(activators = UseMvcServer.class, requires = "freemarker.template.Template")
 public class FreeMarkerProviders {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpRequestParameterLoaderContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/HttpRequestParameterLoaderContext.java
@@ -21,8 +21,8 @@ import org.dockbox.hartshorn.application.context.ParameterLoaderContext;
 import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class HttpRequestParameterLoaderContext extends ParameterLoaderContext {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoaderContext.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/MvcParameterLoaderContext.java
@@ -21,8 +21,8 @@ import org.dockbox.hartshorn.util.reflect.MethodContext;
 import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.dockbox.hartshorn.web.mvc.ViewModel;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class MvcParameterLoaderContext extends HttpRequestParameterLoaderContext{
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/HeaderRequestParameterRule.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/processing/rules/HeaderRequestParameterRule.java
@@ -23,7 +23,7 @@ import org.dockbox.hartshorn.util.reflect.TypeContext;
 import org.dockbox.hartshorn.web.annotations.RequestHeader;
 import org.dockbox.hartshorn.web.processing.HttpRequestParameterLoaderContext;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 public class HeaderRequestParameterRule extends AnnotatedParameterLoaderRule<RequestHeader, HttpRequestParameterLoaderContext> {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/DirectoryServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/DirectoryServlet.java
@@ -19,8 +19,8 @@ package org.dockbox.hartshorn.web.servlet;
 import java.io.IOException;
 import java.net.URI;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @FunctionalInterface
 public interface DirectoryServlet {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletAction.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletAction.java
@@ -19,8 +19,8 @@ package org.dockbox.hartshorn.web.servlet;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.web.HttpAction;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @FunctionalInterface
 public interface HttpServletAction {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletFallback.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpServletFallback.java
@@ -18,9 +18,9 @@ package org.dockbox.hartshorn.web.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @FunctionalInterface
 public interface HttpServletFallback {

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/HttpWebServletAdapter.java
@@ -22,10 +22,10 @@ import org.dockbox.hartshorn.web.HttpAction;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class HttpWebServletAdapter extends HttpServlet {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/MvcServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/MvcServlet.java
@@ -32,10 +32,10 @@ import org.dockbox.hartshorn.web.processing.MvcParameterLoaderContext;
 
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class MvcServlet implements WebServlet {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServlet.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServlet.java
@@ -19,8 +19,8 @@ package org.dockbox.hartshorn.web.servlet;
 import org.dockbox.hartshorn.util.ApplicationException;
 import org.dockbox.hartshorn.web.HttpAction;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface WebServlet {
 

--- a/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletImpl.java
+++ b/hartshorn-web/src/main/java/org/dockbox/hartshorn/web/servlet/WebServletImpl.java
@@ -25,8 +25,8 @@ import org.dockbox.hartshorn.web.RequestHandlerContext;
 import org.dockbox.hartshorn.web.ServletFactory;
 import org.dockbox.hartshorn.web.ServletHandler;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class WebServletImpl implements WebServlet {
 

--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RequestArgumentProcessorTests.java
@@ -42,8 +42,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
 
 @HartshornTest
 @UsePersistence

--- a/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RestIntegrationTest.java
+++ b/hartshorn-web/src/test/java/org/dockbox/hartshorn/web/RestIntegrationTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.AfterEach;
 import java.io.IOException;
 import java.util.function.Function;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 @UseHttpServer
 @HartshornTest


### PR DESCRIPTION
# Description
Hartshorn currently makes use of the Java EE namespace (`javax.*`), which has been replaced with Jakarta EE (since Jakarta EE 9) (`jakarta.*`). See [[jakartaee-platform-dev] Transitioning Jakarta EE to the jakarta namespace](https://www.eclipse.org/lists/jakartaee-platform-dev/msg00029.html).

While late (the change was concluded on June 9th 2019), we intend to stay up to date following this specification now that Hartshorn is officially requiring JDK 17 since #735. This PR changes all usages of the following EE API's from Java EE to Jakarta EE:
- `jakarta.inject-api` - 2.0.1
- `jakarta.persistence-api` - 3.1.0
- `jakarta.servlet-api` - 5.0.0

Additionally, the following dependencies have been updated to support these updates:
- `hibernate-core` - 6.0.2.Final
    - Drivers updated accordingly
- `jetty-server` and `jetty-servlet` - 11.0.9

Additional upgrades:
- `slf4j-api` - 1.7.36
- `logback-classic` - 1.2.11
- `mockito-inline` - 4.5.1
- `testcontainers` - 1.17.2
- `hamcrest` - 2.2
- (OWASP) `dependency-check-gradle` - 7.1.0.1

Fixes #745

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (changes to the build process or auxiliary tools)

# How Has This Been Tested?
- [x] Unit testing
- [x] Integration testing

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove it is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Related issue number is linked in pull request title
